### PR TITLE
feat: more docs on protocols, security, etc

### DIFF
--- a/BGP_PROTOCOL.md
+++ b/BGP_PROTOCOL.md
@@ -1,0 +1,172 @@
+# BGP Service Discovery Protocol
+
+This document outlines the adaptation of the Border Gateway Protocol (BGP) for service discovery within the Catalyst Node ecosystem. Instead of routing IP packets between Autonomous Systems (AS) based on CIDR blocks, we propagate service availability and routing information for logical domains.
+
+## Overview
+
+In this system, an **Autonomous System (AS)** represents a logical domain of services (e.g., a company, a datacenter, or a specific cloud environment). We use BGP-style messaging to exchange "routes" which are actually pointers to service endpoints.
+
+- **Standard BGP**: Routes `10.0.0.0/24` -> Next Hop IP.
+- **Catalyst BGP**: Routes `*.mydatacenter.mycompany` -> Envoy Node ID / Service Endpoint.
+
+Traffic is routed via Envoy proxies, not at the IP layer. The "Next Hop" is a catalyst node that can forward the request or terminate it at a local service.
+
+## Architecture
+
+### Internal vs. External Peering
+
+1.  **Internal BGP (iBGP)**: Used within an AS to synchronize service state between nodes. This acts like a route reflector setup where all nodes inside the AS need a consistent view of available services.
+2.  **External BGP (eBGP)**: Used to project available services from one AS to another. This allows `Company A` to publish a specific set of services to `Company B`.
+
+### Route Tables
+
+Nodes maintain two primary routing tables:
+- **Internal Table**: Contains all services known within the local AS.
+- **External Table**: Contains services learned from external peers.
+
+## Protocol Messages
+
+We use a simplified set of BGP messages encoded as JSON (or Protobuf in the future) over a secure channel (e.g., mTLS). The TypeScript implementation uses discriminated unions for these messages.
+
+### 1. OPEN
+
+Sent immediately upon connection establishment to negotiate parameters and capabilities.
+
+- **Version**: Protocol version.
+- **AS Number**: The logical AS ID of the sender.
+- **Hold Time**: Max time (in seconds) between KEEPALIVEs/UPDATEs.
+    - The session Hold Time is negotiated to the lower of the two peers' values.
+    - Default is **180 seconds**.
+    - If negotiated to 0, Keepalives are disabled.
+- **BGP Identifier**: Unique ID of the sending node.
+- **Capabilities**: Supported features (e.g., specific service types).
+- **JWKS** (Optional): JSON Web Key Set (`{ keys: [...] }`) used for verifying signatures if mTLS is not sufficient or for application-layer integrity.
+- **PSK** (Optional): Pre-Shared Key identifier if using PSK-based auth.
+
+### 2. KEEPALIVE
+
+Sent periodically to maintain the session. 
+- Must be sent at a frequency of **Hold Time / 3**.
+- Example: If Hold Time is 180s, Keepalive is sent every 60s.
+- If no message (Keepalive, Update, or Notification) is received within the Hold Time, the peer is considered dead.
+
+### 3. UPDATE
+
+The core message for advertising and withdrawing routes.
+
+- **Withdrawn Routes**: List of service prefixes that are no longer reachable.
+- **Path Attributes**:
+    - `AS_PATH`: List of ASes the route has traversed (loop detection).
+    - `NEXT_HOP`: The Node ID to forward traffic to.
+    - `LOCAL_PREF`: (iBGP only) Preferred exit point.
+    - `COMMUNITIES`: Tags for policy control (e.g., "production", "latency-sensitive").
+- **Network Layer Reachability Information (NLRI)**: The service prefixes being advertised (e.g., `users.dc01.orbis`).
+
+### 4. NOTIFICATION
+
+Sent when an error is detected. The connection is closed immediately after.
+
+- **Error Code**: Category of error (e.g., Message Header Error, OPEN Message Error).
+- **Error Subcode**: Specific error detail.
+- **Data**: Optional debugging data.
+
+## Message Flow Diagrams
+
+### 1. Session Negotiation (OPEN)
+
+Triggered immediately after TCP connection establishment.
+
+```mermaid
+sequenceDiagram
+    participant A as Node A (AS 100)
+    participant B as Node B (AS 200)
+
+    Note over A, B: TCP Connection Established
+
+    A->>B: OPEN (HoldTime=180, ID=A)
+    B->>A: OPEN (HoldTime=60, ID=B)
+
+    Note right of A: Negotiated HoldTime = min(180, 60) = 60s
+    Note left of B: Negotiated HoldTime = min(180, 60) = 60s
+
+    A->>B: KEEPALIVE
+    B->>A: KEEPALIVE
+
+    Note over A, B: Session ESTABLISHED
+```
+
+### 2. Session Maintenance (KEEPALIVE)
+
+Sent periodically to prevent session expiry.
+
+```mermaid
+sequenceDiagram
+    participant A as Node A
+    participant B as Node B
+
+    Note over A, B: Session Idle (Negotiated HoldTime = 60s)
+    
+    loop Every 20s (HoldTime / 3)
+        A->>B: KEEPALIVE
+        B->>A: KEEPALIVE
+    end
+    
+    Note right of A: If no msg received in 60s,<br/>Close Session
+```
+
+### 3. Service Advertisement and Withdrawal (UPDATE)
+
+Used to announce new services or remove existing ones.
+
+```mermaid
+sequenceDiagram
+    participant Svc as Service
+    participant A as Node A
+    participant B as Node B
+
+    Note over Svc, A: New Service Registered
+    Svc->>A: Register "api.hq.corp"
+    
+    Note over A, B: Announcement
+    A->>B: UPDATE (NLRI=["api.hq.corp"], NextHop=A)
+    B->>B: Install Route "api.hq.corp" -> A
+
+    Note over Svc, A: Service Stops
+    Svc->>A: Deregister "api.hq.corp"
+
+    Note over A, B: Withdrawal
+    A->>B: UPDATE (Withdrawn=["api.hq.corp"])
+    B->>B: Remove Route "api.hq.corp"
+```
+
+### 4. Error Handling (NOTIFICATION)
+
+Fatal errors causing session termination.
+
+```mermaid
+sequenceDiagram
+    participant A as Node A
+    participant B as Node B
+
+    A->>B: UPDATE (Malformed Data)
+    
+    Note right of B: Detects Error (Header Error)
+    
+    B->>A: NOTIFICATION (Code=1, Subcode=2)
+    B->>B: Close TCP Connection
+    
+    Note left of A: Receives NOTIFICATION
+    A->>A: Close TCP Connection
+```
+
+## Data Structures
+
+### Service Route
+```typescript
+interface ServiceRoute {
+  prefix: string; // e.g., "users.dc01.orbis"
+  path: number[]; // AS_PATH: [100, 200]
+  nextHop: string; // Node ID of the peer
+  attributes: Record<string, any>;
+}
+```

--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -1,0 +1,89 @@
+# Observability and Logging Strategy
+
+## Overview
+
+We adopt a **hybrid observability architecture**.
+1.  **Expose & Scrape**: The Router (Control Plane & Data Plane) exposes standard Prometheus metrics for the Agent to scrape.
+2.  **Service Push**: The Router acts as a **Metric Sink** for the services it fronts. Services **PUSH** their metrics/logs to the local Router, which aggregates and exposes them.
+
+## Architecture
+
+We utilize a **Push-Aggregation-Scrape** model.
+
+### 1. Services (Push)
+- **Mechanism**: Services **PUSH** metrics to the Catalyst Node (Router) via a sidecar-compatible API (e.g., StatsD or HTTP equivalent).
+- **Requirement**: Services **DO NOT** expose their own scrape endpoints.
+- **Benefit**: Zero-config service discovery; the Router automatically aggregates everything it receives.
+
+### 2. Catalyst Node (Aggregator & Local Endpoint)
+- **Role**: Metric Sink & Aggregator.
+- **Local Endpoint**: The Router exposes a live view of all aggregated metrics at `http://localhost:X/metrics` (Standard Prometheus format).
+- **Usage**:
+    1.  **Debugging**: Operators can `curl` this locally to see exact state.
+    2.  **Collection**: The DataDog Agent (or Prometheus) scrapes this single endpoint to get the status of the Router AND all behind-it services.
+
+#### 2. Data Plane (Envoy Proxy)
+- **Native Support**: Envoy is configured to expose `/stats/prometheus`.
+- **Metrics**: Global request rates, per-upstream latency, connection stats.
+
+#### 3. Services (Fronted Applications)
+- **Pattern**: **PUSH ONLY**.
+- **Behavior**: Services do not run their own exporters. They push metrics (StatsD, OTLP, or HTTP JSON) to the local Catalyst Node (Router).
+- **Benefit**: Services can be ephemeral or behind firewalls; they only need to know "localhost:RouterPort".
+
+## Data Flow Diagram
+
+```mermaid
+graph LR
+    subgraph "Catalyst Node (Router Host)"
+        direction TB
+        
+        subgraph "Services"
+            SvcA[Service A] --Push--> Router
+            SvcB[Service B] --Push--> Router
+        end
+
+        subgraph "Control Plane"
+            Router[Catalyst Node] --Exposes Aggregated--> MetricsEndpoint["/metrics"]
+        end
+        
+        subgraph "Data Plane"
+            Envoy[Envoy Proxy] --Exposes--> EnvoyStats["/stats/prometheus"]
+        end
+        
+        Agent[Local Agent\n(DataDog / OTel / Prom)]
+    end
+
+    Agent --Scrapes--> MetricsEndpoint
+    Agent --Scrapes--> EnvoyStats
+    
+    subgraph "Cloud Backend"
+        Msg[DataDog / Prometheus]
+    end
+
+    Agent --Forwards--> Msg
+```
+
+## Plugin Interface
+
+The Observability Plugin interface now includes methods for **receiving** metrics.
+
+### Interface
+```typescript
+interface ObservabilityPlugin {
+  // Define a metric (Internal)
+  createCounter(name: string, help: string, labels?: string[]): Counter;
+  createGauge(name: string, help: string, labels?: string[]): Gauge;
+  
+  // Ingestion (Service Push)
+  ingestMetric(metricData: any): void;
+  
+  // Lifecycle
+  startServer(port: number): void; // Starts the /metrics endpoint AND Push Receiver
+}
+```
+
+### Advantages of Service Push to Router
+1.  **Simplified Service Discovery**: The monitoring agent only needs to know about the Router, not every dynamic microservice container.
+2.  **Aggregation**: The Router can pre-aggregate metrics (e.g., average latency across 10 service instances) before exposing them, reducing cardinality.
+3.  **Security**: Services don't need to expose open HTTP ports for scraping; they strictly connect outbound to the local Router.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Catalyst Node Peer Security Protocol
+
+## Overview
+
+Peering security uses a Defense-in-Depth approach, layering Transport Security (mTLS) with Application-Layer Authentication (PSK/JWKS) during the **Open Negotiation** phase.
+
+## 1. Transport Security (mTLS)
+
+**Requirement**: Mandatory for all connections.
+- All BGP sessions MUST run over TLS 1.3.
+- Mutual Authentication (mTLS) is required: both client and server must present valid certificates signed by a trusted CA (e.g., the internal PKI of the AS).
+- The Common Name (CN) or SAN in the certificate must match the `BGP Identifier` (Node ID).
+
+## 2. Peering Authentication
+
+Verified during the exchange of the `OPEN` message.
+
+### Pre-Shared Key (PSK)
+- **Field**: `psk` (optional) in `OPEN` message.
+- **Usage**: Contains the Key ID.
+- **Verification**: The receiver looks up the shared secret associated with the Key ID. The message framing (or TLS exporter) is verified using this secret to ensure the peer possesses it.
+
+### JSON Web Key Set (JWKS)
+- **Field**: `jwks` (optional) in `OPEN` message.
+- **Usage**: Contains the public keys (`{ keys: [...] }`) of the sending AS.
+- **Verification**:
+    - Allows the receiver to dynamically learn the peer's public keys.
+    - Subsequent messages (or the OPEN message itself via a detached signature) can be verified against these keys.
+    - Useful for **External Peerings** (eBGP) where a shared PKI might not exist.
+
+## Open Negotiation Flow
+
+1.  **Transport Connection**: TCP -> TLS Handshake (mTLS).
+    - If certs are invalid, connection is dropped immediately.
+
+2.  **Initiator** sends `OPEN`:
+    ```json
+    {
+      "type": "OPEN",
+      "version": 1,
+      "myAsn": 65001,
+      "bgpIdentifier": "node-01.dc01",
+      "holdTime": 180,
+      "psk": "key-id-123",
+      "jwks": { "keys": [...] }
+    }
+    ```
+
+3.  **Receiver** validates:
+    - **mTLS Identity**: Check certificate CN matches `bgpIdentifier`.
+    - **PSK/JWKS**: If provided, validate Key ID or import Keys.
+    - **Policy**: Check if ASN 65001 is a permitted peer.
+
+4.  **Receiver** responds with `OPEN`:
+    - Session enters `ESTABLISHED` state.
+    - `KEEPALIVE` messages begin.

--- a/src/types/bgp/messages.ts
+++ b/src/types/bgp/messages.ts
@@ -1,0 +1,117 @@
+/**
+ * BGP Message Definitions
+ * 
+ * This file contains the TypeScript definitions for the BGP protocol messages
+ * adapted for service discovery in Catalyst Node.
+ * 
+ * @see {@link ../../../BGP_PROTOCOL.md|BGP Protocol Documentation}
+ */
+
+// Discriminated union for all BGP message types
+export type BgpMessage =
+    | OpenMessage
+    | KeepAliveMessage
+    | UpdateMessage
+    | NotificationMessage;
+
+export enum BgpMessageType {
+    OPEN = 'OPEN',
+    KEEPALIVE = 'KEEPALIVE',
+    UPDATE = 'UPDATE',
+    NOTIFICATION = 'NOTIFICATION',
+}
+
+/**
+ * Default Hold Time in seconds.
+ * The suggested default is 180 seconds.
+ */
+export const DEFAULT_HOLD_TIME = 180;
+
+/**
+ * The ratio of Hold Time to Keepalive Interval.
+ * Keepalives should be sent at least every (Hold Time / 3) seconds.
+ */
+export const KEEPALIVE_RATIO = 3;
+
+/**
+ * OPEN Message
+ * Sent immediately upon connection establishment to negotiate capabilities.
+ */
+export interface OpenMessage {
+    type: BgpMessageType.OPEN;
+    version: number;
+    myAsn: number; // Autonomous System Number of the sender
+    holdTime: number; // Max seconds between KEEPALIVEs
+    bgpIdentifier: string; // Unique Node ID of the sender
+    capabilities: BgpCapability[];
+    jwks?: Record<string, unknown>; // JSON Web Key Set
+    psk?: string; // Pre-Shared Key identifier
+}
+
+export interface BgpCapability {
+    code: number;
+    length: number;
+    value: unknown;
+}
+
+/**
+ * KEEPALIVE Message
+ * Sent periodically to maintain the session.
+ */
+export interface KeepAliveMessage {
+    type: BgpMessageType.KEEPALIVE;
+}
+
+/**
+ * UPDATE Message
+ * Used to transfer routing information between peers.
+ */
+export interface UpdateMessage {
+    type: BgpMessageType.UPDATE;
+
+    /**
+     * Routes that are no longer available and should be removed.
+     */
+    withdrawnRoutes: ServicePrefix[];
+
+    /**
+     * Path attributes for the new routes being advertised.
+     */
+    pathAttributes?: PathAttributes;
+
+    /**
+     * Network Layer Reachability Information (NLRI)
+     * The new routes being advertised.
+     */
+    nlri: ServicePrefix[];
+}
+
+export type ServicePrefix = string; // e.g., "users.dc01.orbis"
+
+export interface PathAttributes {
+    asPath: number[]; // Sequence of ASNs
+    nextHop: string; // Node ID of the next hop
+    localPref?: number; // Preference for iBGP
+    communities?: string[]; // Policy tags
+    origin?: 'IGP' | 'EGP' | 'INCOMPLETE';
+}
+
+/**
+ * NOTIFICATION Message
+ * Sent when an error condition is detected. The connection closes after this.
+ */
+export interface NotificationMessage {
+    type: BgpMessageType.NOTIFICATION;
+    errorCode: BgpErrorCode;
+    errorSubcode: number;
+    data?: unknown;
+}
+
+export enum BgpErrorCode {
+    MESSAGE_HEADER_ERROR = 1,
+    OPEN_MESSAGE_ERROR = 2,
+    UPDATE_MESSAGE_ERROR = 3,
+    HOLD_TIMER_EXPIRED = 4,
+    FSM_ERROR = 5,
+    CEASE = 6,
+}

--- a/src/types/bgp/routing.ts
+++ b/src/types/bgp/routing.ts
@@ -1,0 +1,61 @@
+/**
+ * BGP Routing Structure Definitions
+ * 
+ * This file defines the structures for routing tables and individual routes
+ * used in the Catalyst Node service discovery system.
+ */
+
+import { PathAttributes } from './messages';
+
+/**
+ * Represents a simplified route entry in the Routing Information Base (RIB).
+ */
+export interface ServiceRoute {
+    prefix: string; // The service domain, e.g., "users.dc01.orbis"
+
+    // Attributes derived from the UPDATE message
+    attributes: PathAttributes;
+
+    // Metadata for local processing
+    receivedFrom: PeerInfo;
+    receivedAt: Date;
+    isBest: boolean; // Whether this is the currently selected best path
+}
+
+export interface PeerInfo {
+    nodeId: string;
+    asn: number;
+    address: string; // Transport address
+}
+
+/**
+ * Routing Information Base (RIB) types
+ */
+export interface AdjRibIn {
+    // Routes received from peers, before filtering/selection
+    // Map<PeerId, ServiceRoute[]>
+    [peerId: string]: ServiceRoute[];
+}
+
+export interface LocRib {
+    // The selected best routes (Local RIB)
+    // Map<Prefix, ServiceRoute>
+    [prefix: string]: ServiceRoute;
+}
+
+export interface AdjRibOut {
+    // Routes to be advertised to specific peers
+    // Map<PeerId, ServiceRoute[]>
+    [peerId: string]: ServiceRoute[];
+}
+
+/**
+ * The consolidated Route Table structure for a Node
+ */
+export interface RouteTable {
+    // Internal routes (learned via iBGP or locally)
+    internal: LocRib;
+
+    // External routes (learned via eBGP)
+    external: LocRib;
+}

--- a/src/types/peering/connection.ts
+++ b/src/types/peering/connection.ts
@@ -1,1 +1,38 @@
-// comment to check into github
+export interface OpenMessage {
+    type: 'OPEN';
+    version: number;
+    asn: number;
+    bgp_id: string; // The Router ID
+    hold_time: number;
+
+    // Security Fields
+    timestamp: number; // For replay protection
+    jwks_uri?: string; // For External Peering
+    signature?: string; // Signed payload by AS Key
+
+    // Capabilities (Multiprotocol extensions, etc.)
+    capabilities: string[];
+}
+
+export interface OpenConfirmMessage {
+    type: 'OPEN_CONFIRM';
+    timestamp: number;
+    signature?: string;
+}
+
+export interface NotificationMessage {
+    type: 'NOTIFICATION';
+    code: number;
+    subcode: number;
+    data?: any;
+}
+
+export interface KeepAliveMessage {
+    type: 'KEEPALIVE';
+}
+
+export type PeerMessage =
+    | OpenMessage
+    | OpenConfirmMessage
+    | NotificationMessage
+    | KeepAliveMessage;


### PR DESCRIPTION
### TL;DR

Added BGP-based service discovery protocol documentation and TypeScript type definitions for the Catalyst Node ecosystem.

### What changed?

- Added `BGP_PROTOCOL.md` with detailed documentation on adapting BGP for service discovery, including message formats, flow diagrams, and architecture overview
- Added `OBSERVABILITY.md` outlining the hybrid observability architecture with push-aggregation-scrape model
- Added `SECURITY.md` describing the defense-in-depth approach for peer security using mTLS and application-layer authentication
- Created TypeScript type definitions in:
  - `src/types/bgp/messages.ts` - BGP message structures with discriminated unions
  - `src/types/bgp/routing.ts` - Routing table structures and service route interfaces
  - Updated `src/types/peering/connection.ts` with peer message interfaces

### How to test?

Review the documentation for technical accuracy and completeness. The TypeScript interfaces can be validated by importing them in existing code and ensuring they match the protocol specifications described in the documentation.

### Why make this change?

This change establishes the foundation for implementing a BGP-inspired service discovery protocol in the Catalyst Node ecosystem. By adapting BGP concepts to service discovery, we can leverage its proven scalability and fault tolerance while focusing on logical service domains rather than IP routing. The added type definitions provide a clear contract for implementing the protocol in code.