### PR TITLE
feat: add example GraphQL services (orders-api, product-api)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,58 @@
+# Example Services
+
+Example GraphQL services for testing Catalyst Node routing.
+
+## Services
+
+### orders-api
+
+- **Port**: 4001
+- **Description**: Order management service
+- **Queries**: `orders`, `order(id)`, `ordersByStatus(status)`, `serviceInfo`
+- **Mutations**: `createOrder(productId, quantity, total)`, `updateOrderStatus(id, status)`
+
+### product-api
+
+- **Port**: 4002
+- **Description**: Product catalog service
+- **Queries**: `products`, `product(id)`, `productsByCategory(category)`, `serviceInfo`
+- **Mutations**: `createProduct(name, price, category)`, `updateStock(id, inStock)`
+
+## Usage
+
+```bash
+# Install dependencies
+pnpm install
+
+# Run orders-api
+cd examples/orders-api
+pnpm dev
+
+# Run product-api (in another terminal)
+cd examples/product-api
+pnpm dev
+```
+
+## Testing
+
+```bash
+# Health check
+curl http://localhost:4001/health
+curl http://localhost:4002/health
+
+# GraphQL query (orders-api)
+curl -X POST http://localhost:4001/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ orders { id productId status total } }"}'
+
+# GraphQL query (product-api)
+curl -X POST http://localhost:4002/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ products { id name price } }"}'
+```
+
+## Environment Variables
+
+| Variable | Default   | Description      |
+| -------- | --------- | ---------------- |
+| `PORT`   | 4001/4002 | HTTP server port |

--- a/examples/orders-api/package.json
+++ b/examples/orders-api/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@catalyst-examples/orders-api",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.7",
+    "graphql": "^16.9.0",
+    "graphql-yoga": "^5.10.6",
+    "hono": "^4.6.14"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/examples/orders-api/src/index.ts
+++ b/examples/orders-api/src/index.ts
@@ -1,0 +1,155 @@
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
+import { createYoga, createSchema } from 'graphql-yoga'
+
+const PORT = parseInt(process.env.PORT || '4001', 10)
+const SERVICE_NAME = 'orders-api'
+
+// Sample data
+const orders = [
+  {
+    id: '1',
+    productId: '1',
+    quantity: 2,
+    status: 'shipped',
+    total: 1999.98,
+    createdAt: '2024-01-15T10:30:00Z',
+  },
+  {
+    id: '2',
+    productId: '2',
+    quantity: 1,
+    status: 'pending',
+    total: 149.99,
+    createdAt: '2024-01-16T14:20:00Z',
+  },
+  {
+    id: '3',
+    productId: '4',
+    quantity: 5,
+    status: 'delivered',
+    total: 44.95,
+    createdAt: '2024-01-10T09:00:00Z',
+  },
+]
+
+// GraphQL Schema
+const schema = createSchema({
+  typeDefs: /* GraphQL */ `
+    enum OrderStatus {
+      pending
+      processing
+      shipped
+      delivered
+      cancelled
+    }
+
+    type Order {
+      id: ID!
+      productId: ID!
+      quantity: Int!
+      status: OrderStatus!
+      total: Float!
+      createdAt: String!
+    }
+
+    type ServiceInfo {
+      name: String!
+      version: String!
+      uptime: Float!
+    }
+
+    type Query {
+      orders: [Order!]!
+      order(id: ID!): Order
+      ordersByStatus(status: OrderStatus!): [Order!]!
+      serviceInfo: ServiceInfo!
+    }
+
+    type Mutation {
+      createOrder(productId: ID!, quantity: Int!, total: Float!): Order!
+      updateOrderStatus(id: ID!, status: OrderStatus!): Order
+    }
+  `,
+  resolvers: {
+    Query: {
+      orders: () => orders,
+      order: (_, { id }) => orders.find((o) => o.id === id),
+      ordersByStatus: (_, { status }) => orders.filter((o) => o.status === status),
+      serviceInfo: () => ({
+        name: SERVICE_NAME,
+        version: '0.0.1',
+        uptime: process.uptime(),
+      }),
+    },
+    Mutation: {
+      createOrder: (_, { productId, quantity, total }) => {
+        const newOrder = {
+          id: String(orders.length + 1),
+          productId,
+          quantity,
+          status: 'pending' as const,
+          total,
+          createdAt: new Date().toISOString(),
+        }
+        orders.push(newOrder)
+        return newOrder
+      },
+      updateOrderStatus: (_, { id, status }) => {
+        const order = orders.find((o) => o.id === id)
+        if (order) {
+          order.status = status
+        }
+        return order
+      },
+    },
+  },
+})
+
+// Create Yoga instance
+const yoga = createYoga({
+  schema,
+  graphqlEndpoint: '/graphql',
+  landingPage: false,
+})
+
+// Create Hono app
+const app = new Hono()
+
+// Health check endpoint
+app.get('/health', (c) => {
+  return c.json({
+    status: 'healthy',
+    service: SERVICE_NAME,
+    timestamp: new Date().toISOString(),
+  })
+})
+
+// Service info endpoint
+app.get('/', (c) => {
+  return c.json({
+    service: SERVICE_NAME,
+    description: 'Order management service',
+    endpoints: {
+      graphql: '/graphql',
+      health: '/health',
+    },
+  })
+})
+
+// Mount GraphQL Yoga
+app.on(['GET', 'POST'], '/graphql', async (c) => {
+  const response = await yoga.handle(c.req.raw)
+  return response
+})
+
+// Start server
+console.log(`[${SERVICE_NAME}] Starting on port ${PORT}...`)
+
+serve({
+  fetch: app.fetch,
+  port: PORT,
+})
+
+console.log(`[${SERVICE_NAME}] GraphQL endpoint: http://localhost:${PORT}/graphql`)
+console.log(`[${SERVICE_NAME}] Health check: http://localhost:${PORT}/health`)

--- a/examples/orders-api/tsconfig.json
+++ b/examples/orders-api/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/product-api/package.json
+++ b/examples/product-api/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@catalyst-examples/product-api",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.7",
+    "graphql": "^16.9.0",
+    "graphql-yoga": "^5.10.6",
+    "hono": "^4.6.14"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/examples/product-api/src/index.ts
+++ b/examples/product-api/src/index.ts
@@ -1,0 +1,125 @@
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
+import { createYoga, createSchema } from 'graphql-yoga'
+
+const PORT = parseInt(process.env.PORT || '4002', 10)
+const SERVICE_NAME = 'product-api'
+
+// Sample data
+const products = [
+  { id: '1', name: 'Laptop', price: 999.99, category: 'electronics', inStock: true },
+  { id: '2', name: 'Headphones', price: 149.99, category: 'electronics', inStock: true },
+  { id: '3', name: 'Coffee Mug', price: 12.99, category: 'home', inStock: false },
+  { id: '4', name: 'Notebook', price: 8.99, category: 'office', inStock: true },
+]
+
+// GraphQL Schema
+const schema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Product {
+      id: ID!
+      name: String!
+      price: Float!
+      category: String!
+      inStock: Boolean!
+    }
+
+    type ServiceInfo {
+      name: String!
+      version: String!
+      uptime: Float!
+    }
+
+    type Query {
+      products: [Product!]!
+      product(id: ID!): Product
+      productsByCategory(category: String!): [Product!]!
+      serviceInfo: ServiceInfo!
+    }
+
+    type Mutation {
+      createProduct(name: String!, price: Float!, category: String!): Product!
+      updateStock(id: ID!, inStock: Boolean!): Product
+    }
+  `,
+  resolvers: {
+    Query: {
+      products: () => products,
+      product: (_, { id }) => products.find((p) => p.id === id),
+      productsByCategory: (_, { category }) => products.filter((p) => p.category === category),
+      serviceInfo: () => ({
+        name: SERVICE_NAME,
+        version: '0.0.1',
+        uptime: process.uptime(),
+      }),
+    },
+    Mutation: {
+      createProduct: (_, { name, price, category }) => {
+        const newProduct = {
+          id: String(products.length + 1),
+          name,
+          price,
+          category,
+          inStock: true,
+        }
+        products.push(newProduct)
+        return newProduct
+      },
+      updateStock: (_, { id, inStock }) => {
+        const product = products.find((p) => p.id === id)
+        if (product) {
+          product.inStock = inStock
+        }
+        return product
+      },
+    },
+  },
+})
+
+// Create Yoga instance
+const yoga = createYoga({
+  schema,
+  graphqlEndpoint: '/graphql',
+  landingPage: false,
+})
+
+// Create Hono app
+const app = new Hono()
+
+// Health check endpoint
+app.get('/health', (c) => {
+  return c.json({
+    status: 'healthy',
+    service: SERVICE_NAME,
+    timestamp: new Date().toISOString(),
+  })
+})
+
+// Service info endpoint
+app.get('/', (c) => {
+  return c.json({
+    service: SERVICE_NAME,
+    description: 'Product catalog service',
+    endpoints: {
+      graphql: '/graphql',
+      health: '/health',
+    },
+  })
+})
+
+// Mount GraphQL Yoga
+app.on(['GET', 'POST'], '/graphql', async (c) => {
+  const response = await yoga.handle(c.req.raw)
+  return response
+})
+
+// Start server
+console.log(`[${SERVICE_NAME}] Starting on port ${PORT}...`)
+
+serve({
+  fetch: app.fetch,
+  port: PORT,
+})
+
+console.log(`[${SERVICE_NAME}] GraphQL endpoint: http://localhost:${PORT}/graphql`)
+console.log(`[${SERVICE_NAME}] Health check: http://localhost:${PORT}/health`)

--- a/examples/product-api/tsconfig.json
+++ b/examples/product-api/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,56 @@ importers:
 
   .: {}
 
+  examples/orders-api:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.13.7
+        version: 1.19.7(hono@4.11.3)
+      graphql:
+        specifier: ^16.9.0
+        version: 16.12.0
+      graphql-yoga:
+        specifier: ^5.10.6
+        version: 5.18.0(graphql@16.12.0)
+      hono:
+        specifier: ^4.6.14
+        version: 4.11.3
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.3
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
+  examples/product-api:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.13.7
+        version: 1.19.7(hono@4.11.3)
+      graphql:
+        specifier: ^16.9.0
+        version: 16.12.0
+      graphql-yoga:
+        specifier: ^5.10.6
+        version: 5.18.0(graphql@16.12.0)
+      hono:
+        specifier: ^4.6.14
+        version: 4.11.3
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.3
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
   packages/node:
     dependencies:
       '@hono/node-server':
@@ -40,16 +90,16 @@ importers:
         version: 25.0.3
       '@vitest/coverage-v8':
         specifier: ^4.0.16
-        version: 4.0.16(vitest@4.0.16(@types/node@25.0.3))
+        version: 4.0.16(vitest@4.0.16(@types/node@25.0.3)(tsx@4.21.0))
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@25.0.3)
+        version: 4.0.16(@types/node@25.0.3)(tsx@4.21.0)
 
   packages/sdk:
     dependencies:
@@ -65,16 +115,16 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^4.0.16
-        version: 4.0.16(vitest@4.0.16(@types/node@25.0.3))
+        version: 4.0.16(vitest@4.0.16(@types/node@25.0.3)(tsx@4.21.0))
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@25.0.3)
+        version: 4.0.16(@types/node@25.0.3)(tsx@4.21.0)
 
 packages:
 
@@ -860,6 +910,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/node@22.19.3':
+    resolution: {integrity: sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==}
+
   '@types/node@25.0.3':
     resolution: {integrity: sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==}
 
@@ -1033,6 +1086,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-tsconfig@4.13.0:
+    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
+
   graphql-yoga@5.18.0:
     resolution: {integrity: sha512-xFt1DVXS1BZ3AvjnawAGc5OYieSe56WuQuyk3iEpBwJ3QDZJWQGLmU9z/L5NUZ+pUcyprsz/bOwkYIV96fXt/g==}
     engines: {node: '>=18.0.0'}
@@ -1182,6 +1238,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   rollup@4.55.1:
     resolution: {integrity: sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1275,6 +1334,11 @@ packages:
       typescript:
         optional: true
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1282,6 +1346,9 @@ packages:
 
   ufo@1.6.2:
     resolution: {integrity: sha512-heMioaxBcG9+Znsda5Q8sQbWnLJSl98AFDXTO80wELWEzX3hordXsTdxrIfMQoO9IY1MEnoGoPjpoKpMj+Yx0Q==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -2474,11 +2541,15 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node@22.19.3':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@25.0.3':
     dependencies:
       undici-types: 7.16.0
 
-  '@vitest/coverage-v8@4.0.16(vitest@4.0.16(@types/node@25.0.3))':
+  '@vitest/coverage-v8@4.0.16(vitest@4.0.16(@types/node@25.0.3)(tsx@4.21.0))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.16
@@ -2491,7 +2562,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@types/node@25.0.3)
+      vitest: 4.0.16(@types/node@25.0.3)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2504,13 +2575,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.16(vite@7.3.0(@types/node@25.0.3))':
+  '@vitest/mocker@4.0.16(vite@7.3.0(@types/node@25.0.3)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.16
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.0(@types/node@25.0.3)
+      vite: 7.3.0(@types/node@25.0.3)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.0.16':
     dependencies:
@@ -2669,6 +2740,10 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-tsconfig@4.13.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   graphql-yoga@5.18.0(graphql@16.12.0):
     dependencies:
       '@envelop/core': 5.4.0
@@ -2785,11 +2860,12 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss-load-config@6.0.1(postcss@8.5.6):
+  postcss-load-config@6.0.1(postcss@8.5.6)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.6
+      tsx: 4.21.0
 
   postcss@8.5.6:
     dependencies:
@@ -2800,6 +2876,8 @@ snapshots:
   readdirp@4.1.2: {}
 
   resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   rollup@4.55.1:
     dependencies:
@@ -2887,7 +2965,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(postcss@8.5.6)(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
       cac: 6.7.14
@@ -2898,7 +2976,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.6)
+      postcss-load-config: 6.0.1(postcss@8.5.6)(tsx@4.21.0)
       resolve-from: 5.0.0
       rollup: 4.55.1
       source-map: 0.7.6
@@ -2915,15 +2993,24 @@ snapshots:
       - tsx
       - yaml
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.2
+      get-tsconfig: 4.13.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   typescript@5.9.3: {}
 
   ufo@1.6.2: {}
+
+  undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
 
   urlpattern-polyfill@10.1.0: {}
 
-  vite@7.3.0(@types/node@25.0.3):
+  vite@7.3.0(@types/node@25.0.3)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2934,11 +3021,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.0.3
       fsevents: 2.3.3
+      tsx: 4.21.0
 
-  vitest@4.0.16(@types/node@25.0.3):
+  vitest@4.0.16(@types/node@25.0.3)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.16
-      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.0.3))
+      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.0.3)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.16
       '@vitest/runner': 4.0.16
       '@vitest/snapshot': 4.0.16
@@ -2955,7 +3043,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.0(@types/node@25.0.3)
+      vite: 7.3.0(@types/node@25.0.3)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - 'packages/*'
+  - 'examples/*'


### PR DESCRIPTION
### TL;DR

Added example GraphQL services for testing Catalyst Node routing.

### What changed?

- Created two example GraphQL services:
  - `orders-api`: Order management service running on port 4001
  - `product-api`: Product catalog service running on port 4002
- Added a README with documentation on how to use and test the services
- Configured both services with:
  - GraphQL Yoga for the GraphQL server
  - Hono for HTTP routing
  - Health check endpoints
  - Service info endpoints
  - Sample data and schemas

### How to test?

1. Install dependencies:
   ```bash
   pnpm install
   ```

2. Run the services:
   ```bash
   # Run orders-api
   cd examples/orders-api
   pnpm dev

   # Run product-api (in another terminal)
   cd examples/product-api
   pnpm dev
   ```

3. Test the endpoints:
   ```bash
   # Health checks
   curl http://localhost:4001/health
   curl http://localhost:4002/health

   # GraphQL queries
   curl -X POST http://localhost:4001/graphql \
     -H "Content-Type: application/json" \
     -d '{"query": "{ orders { id productId status total } }"}'

   curl -X POST http://localhost:4002/graphql \
     -H "Content-Type: application/json" \
     -d '{"query": "{ products { id name price } }"}'
   ```

### Why make this change?

These example services provide a realistic testing environment for Catalyst Node routing capabilities. Having dedicated test services with well-defined GraphQL schemas allows for more comprehensive testing of routing, federation, and other features in the Catalyst framework.