### PR TITLE
feat: milestone 0, phase 1 graphlq

### DIFF
--- a/packages/gateway/.dockerignore
+++ b/packages/gateway/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+tests
+.git
+.DS_Store

--- a/packages/gateway/Dockerfile
+++ b/packages/gateway/Dockerfile
@@ -1,0 +1,16 @@
+# Builder stage
+FROM oven/bun:1 AS builder
+WORKDIR /app
+COPY package.json ./
+RUN bun install
+COPY . .
+RUN bun build --compile --minify --outfile server src/index.ts
+
+# Runtime stage
+# We use distroless/base-nossl-debian12 for a minimal glibc image
+FROM gcr.io/distroless/base-nossl-debian12
+WORKDIR /app
+COPY --from=builder /app/server .
+ENV PORT=4000
+EXPOSE 4000
+CMD ["./server"]

--- a/packages/gateway/README.md
+++ b/packages/gateway/README.md
@@ -1,59 +1,129 @@
 # @catalyst/gateway
 
-The GraphQL Federation Gateway for Catalyst Node.
+The **Catalyst Gateway** is a high-performance, dynamic GraphQL Federation server built to orchestrate microservices into a unified graph. It is designed for zero-downtime reconfiguration, allowing the graph to evolve at runtime without restarting the server.
 
-## Features
+## 🚀 Features
 
-- **GraphQL Federation**: Can federate multiple GraphQL services into a single graph.
-- **Dynamic Configuration**: Configuration (service list) is updated via RPC (WebSocket) without restarting the server.
-- **RPC Server**: Uses `capnweb` over WebSocket for high-performance configuration updates.
+- **Universal Federation**: Dynamically stitches multiple remote GraphQL schemas into a single unified API.
+- **Zero-Downtime Reconfiguration**: Updates the schema graph instantly via RPC without dropping connections.
+- **High Performance RPC**: Uses **Cap'n Web** over WebSockets for typed, efficient configuration management.
+- **Production Ready**: Containerized with a minimal footprint (Distroless + Bun compiled binary).
+- **Type-Safe**: Fully typed end-to-end with TypeScript.
 
-## Configuration
+## 🛠️ Tech Stack
 
-The gateway is configured primarily via environment variables for startup parameters, and RPC for runtime logic.
+- **Runtime**: [Bun](https://bun.sh)
+- **Web Framework**: [Hono](https://hono.dev)
+- **GraphQL Engine**: [GraphQL Yoga](https://the-guild.dev/graphql/yoga)
+- **Schema Stitching**: [GraphQL Tools](https://the-guild.dev/graphql/tools)
+- **RPC**: [Cap'n Web](https://github.com/capnproto/capnproto)
+- **Testing**: [Testcontainers](https://testcontainers.com) + [Bun Test](https://bun.sh/docs/cli/test)
 
-### Environment Variables
+## 📐 Architecture & API
 
-| Variable | Description | Default |
-| :--- | :--- | :--- |
-| `PORT` | The HTTP port to listen on. | `4000` |
+### System Overview
 
-## RPC API
+The Gateway listens for configuration updates via a WebSocket RPC channel. When a new configuration is received (list of services), it fetches their schemas, stitches them together, and hot-swaps the internal GraphQL engine.
 
-The gateway exposes a WebSocket RPC endpoint at `/api`.
+```mermaid
+sequenceDiagram
+    participant Orchestrator
+    participant RPC as Gateway (RPC Layer)
+    participant Core as Gateway (GraphQL Core)
+    participant ServiceA as Service A
+    participant ServiceB as Service B
 
-### Methods
+    Note over Orchestrator, ServiceB: Initialization
+    Orchestrator->>RPC: Connect (WebSocket /api)
+    
+    Note over Orchestrator, ServiceB: Configuration Update
+    Orchestrator->>RPC: updateConfig({ services: [A, B] })
+    RPC->>Core: reload(config)
+    
+    par Fetch Schemas
+        Core->>ServiceA: Introspection Query
+        Core->>ServiceB: Introspection Query
+    end
+    
+    ServiceA-->>Core: Schema A
+    ServiceB-->>Core: Schema B
+    
+    Core->>Core: Stitch Schemas
+    Core-->>RPC: { success: true }
+    RPC-->>Orchestrator: { success: true }
+    
+    Note over Orchestrator, ServiceB: Traffic
+    Client->>Core: Query { A, B }
+    Core->>ServiceA: Delegate Query
+    Core->>ServiceB: Delegate Query
+```
 
-#### `updateConfig(config: GatewayConfig)`
+### RPC API
 
-Updates the federation configuration.
+**Endpoint**: `ws://<host>:<port>/api`
 
-**Parameters:**
+**Method**: `updateConfig(config: GatewayConfig): Promise<GatewayUpdateResult>`
 
 ```typescript
 type GatewayConfig = {
   services: {
     name: string;
     url: string;
-    token?: string;
+    token?: string; // Optional Bearer token
   }[];
-}
+};
+
+type GatewayUpdateResult = 
+  | { success: true } 
+  | { success: false; error: string };
 ```
 
-## Development
+## 🧪 Testing Architecture
 
-### Start the server
+We use **Testcontainers** to verify the Gateway in a real Docker environment, ensuring that network communication, architecture compatibility (Linux x64), and federation logic work exactly as they would in production.
+
+```ascii
++-------------------------------------------------------+
+|                   Test Runner (Bun)                   |
+|         packages/gateway/tests/container.test.ts      |
++---------------------------+---------------------------+
+                            |
+                 Controls Lifecycle via
+                    Docker Socket
+                            |
++---------------------------v---------------------------+
+|                    Docker Network                     |
+|                                                       |
+|  +--------------+   +--------------+   +-----------+  |
+|  |              |   |              |   |           |  |
+|  |   Gateway    +<--+    Books     |   |   Movies  |  |
+|  |  (Unknown)   |   |   (Known)    |   |  (Known)  |  |
+|  |              +-->+              |   |           |  |
+|  +------+-------+   +--------------+   +-----------+  |
+|         ^                                             |
++---------|---------------------------------------------+
+          |
+    Tests perform:
+    1. RPC Config Update (Connects Books)
+    2. GraphQL Query Verification
+    3. RPC Re-config (Connects Movies)
+    4. Full Graph Verification
+```
+
+## 📦 Docker Support
+
+The Gateway is built as a standalone executable on top of a Distroless image for maximum security and minimum size.
 
 ```bash
-pnpm dev
-# OR with custom port
-PORT=4001 pnpm dev
+# Build
+docker build -t catalyst-gateway .
+
+# Run
+docker run -p 4000:4000 catalyst-gateway
 ```
 
-### Verification
+### Environment Variables
 
-Run the included test script to verify RPC connectivity and schema reloading:
-
-```bash
-pnpm test:rpc
-```
+| Variable | Description | Default |
+| :--- | :--- | :--- |
+| `PORT` | The HTTP port to listen on. | `4000` |

--- a/packages/gateway/tests/container.gateway.test.ts
+++ b/packages/gateway/tests/container.gateway.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { GenericContainer, Wait, StartedTestContainer, Network, StartedNetwork } from 'testcontainers';
+import path from 'path';
+import { newWebSocketRpcSession } from 'capnweb';
+
+describe('Gateway Container Integration', () => {
+    const TIMEOUT = 180000; // 3 minutes for builds
+    // Containers
+    let booksContainer: StartedTestContainer;
+    let moviesContainer: StartedTestContainer;
+    let gatewayContainer: StartedTestContainer;
+    let network: StartedNetwork;
+
+    // Gateway Access
+    let gatewayPort: number;
+    let rpcClient: any;
+    let ws: WebSocket;
+
+    beforeAll(async () => {
+        network = await new Network().start();
+        const examplesDir = path.resolve(__dirname, '../../examples');
+        const gatewayDir = path.resolve(__dirname, '..');
+
+        // 1. Build & Start Books (Background)
+        const startBooks = async () => {
+            const imageName = 'books-service:test';
+            await Bun.spawn(['docker', 'build', '-t', imageName, '-f', 'Dockerfile.books', '.'], {
+                cwd: examplesDir, stdout: 'ignore', stderr: 'inherit'
+            }).exited;
+
+            booksContainer = await new GenericContainer(imageName)
+                .withNetwork(network)
+                .withNetworkAliases('books')
+                .withExposedPorts(8080)
+                .withWaitStrategy(Wait.forHttp('/health', 8080))
+                .start();
+        };
+
+        // 2. Build & Start Movies (Background)
+        const startMovies = async () => {
+            const imageName = 'movies-service:test';
+            await Bun.spawn(['docker', 'build', '-t', imageName, '-f', 'Dockerfile.movies', '.'], {
+                cwd: examplesDir, stdout: 'ignore', stderr: 'inherit'
+            }).exited;
+
+            moviesContainer = await new GenericContainer(imageName)
+                .withNetwork(network)
+                .withNetworkAliases('movies')
+                .withExposedPorts(8080)
+                .withWaitStrategy(Wait.forHttp('/health', 8080))
+                .start();
+        };
+
+        // 3. Build & Start Gateway (Background)
+        const startGateway = async () => {
+            const imageName = 'gateway-service:test';
+            await Bun.spawn(['docker', 'build', '-t', imageName, '.'], {
+                cwd: gatewayDir, stdout: 'ignore', stderr: 'inherit'
+            }).exited;
+
+            gatewayContainer = await new GenericContainer(imageName)
+                .withNetwork(network)
+                .withExposedPorts(4000)
+                .withWaitStrategy(Wait.forHttp('/', 4000))
+                .start();
+
+            gatewayPort = gatewayContainer.getMappedPort(4000);
+        };
+
+        // Run builds in parallel to save time
+        await Promise.all([startBooks(), startMovies(), startGateway()]);
+
+    }, TIMEOUT);
+
+    afterAll(async () => {
+        if (ws) ws.close();
+        if (booksContainer) await booksContainer.stop();
+        if (moviesContainer) await moviesContainer.stop();
+        if (gatewayContainer) await gatewayContainer.stop();
+        if (network) await network.stop();
+    });
+
+    const getRpcClient = async () => {
+        if (rpcClient) return rpcClient;
+        const url = `ws://localhost:${gatewayPort}/api`;
+        ws = new WebSocket(url);
+        await new Promise<void>((resolve, reject) => {
+            ws.addEventListener('open', () => resolve());
+            ws.addEventListener('error', (e) => reject(e));
+        });
+        rpcClient = newWebSocketRpcSession(ws as any);
+        return rpcClient;
+    };
+
+    const queryGateway = async (query: string) => {
+        const res = await fetch(`http://localhost:${gatewayPort}/graphql`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ query })
+        });
+        return res.json();
+    };
+
+    it('should be in initial state (waiting for config)', async () => {
+        // The current implementation might return 404 or empty schema if no config. 
+        // Based on previous tests, it might just have an empty schema or basic query.
+        // Let's assume the status query or just introspection works but returns nothing useful yet.
+        // Alternatively, the health check passed, so server is up.
+
+        // If we query for something that doesn't exist, it should error.
+        const result = await queryGateway('{ books { title } }');
+        expect(result.errors).toBeDefined();
+    });
+
+    it('should add Books service successfully', async () => {
+        const client = await getRpcClient();
+        const config = {
+            services: [
+                // Use the Docker network alias 'books'
+                { name: 'books', url: 'http://books:8080/graphql' }
+            ]
+        };
+
+        const update = await client.updateConfig(config);
+        expect(update).toEqual({ success: true });
+
+        // Query Books
+        const result = await queryGateway('{ books { title } }');
+        expect(result.data.books).toBeDefined();
+        expect(result.data.books.length).toBeGreaterThan(0);
+
+        // Query Movies (Should Fail)
+        const failResult = await queryGateway('{ movies { title } }');
+        expect(failResult.errors).toBeDefined();
+    });
+
+    it('should add Movies service (incremental)', async () => {
+        const client = await getRpcClient();
+        const config = {
+            services: [
+                { name: 'books', url: 'http://books:8080/graphql' },
+                { name: 'movies', url: 'http://movies:8080/graphql' }
+            ]
+        };
+
+        const update = await client.updateConfig(config);
+        expect(update).toEqual({ success: true });
+
+        // Query Both
+        const result = await queryGateway(`
+            query {
+                books { title }
+                movies { title }
+            }
+        `);
+
+        expect(result.data.books).toBeDefined();
+        expect(result.data.movies).toBeDefined();
+        expect(result.data.books.length).toBeGreaterThan(0);
+        expect(result.data.movies.length).toBeGreaterThan(0);
+    });
+
+    it('should reset to empty config', async () => {
+        const client = await getRpcClient();
+        // Sending empty services list
+        // Note: The schema might complain if 'services' is required to be non-empty or if schema stitching fails with 0 subschemas.
+        // But let's try.
+        const config = { services: [] };
+
+        const update = await client.updateConfig(config);
+
+        // If the implementation allows clearing the schema (no services), it sets default schema or stays as is?
+        // Checking `GatewayGraphqlServer.reload`:
+        // if (services.length === 0) -> It might fail stitching if stitchSchemas expects at least one?
+        // Actually `stitchSchemas({ subschemas: [] })` is valid but creates empty schema.
+
+        expect(update).toEqual({ success: true });
+
+        // Querying books should now fail
+        const result = await queryGateway('{ books { title } }');
+        expect(result.errors).toBeDefined();
+    });
+});


### PR DESCRIPTION
# Add Docker Support for Gateway Service

### TL;DR

Added Docker support for the Gateway service with a multi-stage build process and comprehensive container integration tests.

### What changed?

- Created a `Dockerfile` using a multi-stage build approach:
  - Builder stage uses Bun to compile the application to a binary
  - Runtime stage uses a minimal Distroless base image for security and size
- Added `.dockerignore` to exclude unnecessary files from the build context
- Enhanced the README with detailed documentation about Docker support, architecture, and testing
- Implemented container integration tests using Testcontainers to verify the Gateway works correctly in a containerized environment

### How to test?

1. Build the Docker image:
   ```bash
   docker build -t catalyst-gateway .
   ```

2. Run the container:
   ```bash
   docker run -p 4000:4000 catalyst-gateway
   ```

3. Run the integration tests:
   ```bash
   bun test tests/container.gateway.test.ts
   ```

### Why make this change?

Containerization enables consistent deployment across environments and simplifies the operational aspects of running the Gateway service. The multi-stage build process produces a minimal, secure runtime image while the comprehensive integration tests ensure the Gateway functions correctly in a containerized environment, particularly with respect to network communication and federation capabilities.