### PR TITLE
chore: milestone 0 phase 2 docker compose file

### DIFF
--- a/docker-compose/example.m0p2.compose.yaml
+++ b/docker-compose/example.m0p2.compose.yaml
@@ -1,0 +1,42 @@
+services:
+  orchestrator:
+    build:
+      context: ../packages/orchestrator
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      - CATALYST_GQL_GATEWAY_ENDPOINT=ws://gateway:4000/api
+      - PORT=3000
+    depends_on:
+      - gateway
+
+  gateway:
+    build:
+      context: ../packages/gateway
+      dockerfile: Dockerfile
+    ports:
+      - "4000:4000"
+    environment:
+      - PORT=4000
+    depends_on:
+      - books-service
+      - movies-service
+
+  books-service:
+    build:
+      context: ../packages/examples
+      dockerfile: Dockerfile.books
+    ports:
+      - "8081:8080"
+    environment:
+      - PORT=8080
+
+  movies-service:
+    build:
+      context: ../packages/examples
+      dockerfile: Dockerfile.movies
+    ports:
+      - "8082:8080"
+    environment:
+      - PORT=8080

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "catalyst-monorepo",
   "private": true,
+  "scripts": {
+    "start:m0p2": "docker compose -f docker-compose/example.m0p2.compose.yaml up --build"
+  },
   "packageManager": "pnpm@10.0.0",
   "workspaces": [
     "packages/*"

--- a/packages/orchestrator/Dockerfile
+++ b/packages/orchestrator/Dockerfile
@@ -1,0 +1,37 @@
+FROM oven/bun:1 as base
+WORKDIR /app
+
+# Install dependencies into temp directory
+# This will cache them and speed up future builds
+FROM base AS install
+RUN mkdir -p /temp/dev
+COPY package.json /temp/dev/
+RUN cd /temp/dev && bun install
+
+# Install with --production (exclude devDependencies)
+RUN mkdir -p /temp/prod
+COPY package.json /temp/prod/
+RUN cd /temp/prod && bun install --production
+
+# Copy node_modules from temp directory
+# Then copy all (non-ignored) project files into the image
+FROM base AS prerelease
+COPY --from=install /temp/dev/node_modules node_modules
+COPY . .
+
+# [optional] tests & build
+ENV NODE_ENV=production
+# RUN bun test
+# RUN bun run build
+
+# copy production dependencies and source code into final image
+FROM base AS release
+COPY --from=install /temp/prod/node_modules node_modules
+COPY --from=prerelease /app/src src
+COPY --from=prerelease /app/package.json .
+COPY --from=prerelease /app/tsconfig.json .
+
+# run the app
+USER bun
+EXPOSE 3000/tcp
+ENTRYPOINT [ "bun", "run", "src/index.ts" ]


### PR DESCRIPTION
### TL;DR

Added Docker Compose configuration for M0P2 example with a new npm script to run it.

### What changed?

- Created a new Docker Compose file `docker-compose/example.m0p2.compose.yaml` that defines four services:
  - `orchestrator`: Connects to the gateway and exposes port 3000
  - `gateway`: Connects to the books and movies services and exposes port 4000
  - `books-service`: Exposes port 8081 (mapped to 8080 internally)
  - `movies-service`: Exposes port 8082 (mapped to 8080 internally)
- Added a Dockerfile for the orchestrator service with a multi-stage build process
- Added a new npm script `start:m0p2` to the root package.json to run the Docker Compose setup

### How to test?

1. Run the new npm script:
```bash
npm run start:m0p2
```
2. Access the orchestrator at http://localhost:3000
3. Access the gateway at http://localhost:4000/api
4. Access the books service at http://localhost:8081
5. Access the movies service at http://localhost:8082

### Why make this change?

This change provides a containerized environment for running the M0P2 example, making it easier to test and demonstrate the system with all its components working together. The Docker Compose setup ensures proper service dependencies and networking between the orchestrator, gateway, and example services.