### PR TITLE
feat(auth): add key management with ES384 ECDSA keypairs

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@catalyst/auth",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "bun run --watch src/index.ts",
+    "build": "tsc",
+    "test": "bun test",
+    "start": "bun run src/index.ts"
+  },
+  "dependencies": {
+    "@hono/capnweb": "catalog:",
+    "capnweb": "catalog:",
+    "hono": "catalog:",
+    "jose": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/bun": "catalog:dev",
+    "@types/node": "catalog:dev",
+    "typescript": "catalog:dev",
+    "vitest": "catalog:testing"
+  }
+}

--- a/packages/auth/src/keys.ts
+++ b/packages/auth/src/keys.ts
@@ -1,0 +1,206 @@
+import * as jose from 'jose';
+import { mkdirSync, readFileSync, writeFileSync, renameSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { z } from 'zod';
+import type { KeyObject } from 'node:crypto';
+
+// jose v6 uses native platform key types
+type CryptoKeyLike = CryptoKey | KeyObject;
+
+export interface KeyPair {
+    privateKey: CryptoKeyLike;
+    publicKey: CryptoKeyLike;
+    kid: string;
+}
+
+export interface SerializedKeyPair {
+    privateKeyJwk: jose.JWK;
+    publicKeyJwk: jose.JWK;
+    kid: string;
+    createdAt: string;
+}
+
+// JWK schema - must have kty, allow any other properties (jose validates the rest)
+const JwkSchema = z.object({ kty: z.string() }).catchall(z.unknown());
+
+// Zod schema for validating loaded keypair files
+const SerializedKeyPairSchema = z.object({
+    privateKeyJwk: JwkSchema,
+    publicKeyJwk: JwkSchema,
+    kid: z.string().min(1),
+    createdAt: z.iso.datetime(),
+});
+
+const DEFAULT_KEYS_DIR = process.env.CATALYST_AUTH_KEYS_DIR || '/data/keys';
+const KEYPAIR_FILE = 'keypair.json';
+const ALGORITHM = 'ES384' as const;
+
+/**
+ * Add standard metadata to a JWK (kid, alg, use)
+ */
+function decorateJwk(jwk: jose.JWK, kid: string): jose.JWK {
+    return {
+        ...jwk,
+        kid,
+        alg: ALGORITHM,
+        use: 'sig',
+    };
+}
+
+/**
+ * Generate a new ECDSA ES384 keypair with a unique key ID
+ * Key ID is derived from the JWK thumbprint (RFC 7638) for deterministic, secure identification
+ */
+export async function generateKeyPair(): Promise<KeyPair> {
+    const { publicKey, privateKey } = await jose.generateKeyPair(ALGORITHM, {
+        extractable: true,
+    });
+
+    // Use JWK thumbprint as key ID (RFC 7638) - deterministic and standard
+    const publicKeyJwk = await jose.exportJWK(publicKey);
+    const kid = await jose.calculateJwkThumbprint(publicKeyJwk, 'sha256');
+
+    return {
+        privateKey,
+        publicKey,
+        kid,
+    };
+}
+
+/**
+ * Export a keypair to JWK format for persistence
+ */
+export async function exportKeyPair(keyPair: KeyPair): Promise<SerializedKeyPair> {
+    const [privateKeyJwk, publicKeyJwk] = await Promise.all([
+        jose.exportJWK(keyPair.privateKey),
+        jose.exportJWK(keyPair.publicKey),
+    ]);
+
+    return {
+        privateKeyJwk: decorateJwk(privateKeyJwk, keyPair.kid),
+        publicKeyJwk: decorateJwk(publicKeyJwk, keyPair.kid),
+        kid: keyPair.kid,
+        createdAt: new Date().toISOString(),
+    };
+}
+
+/**
+ * Import a keypair from JWK format
+ */
+export async function importKeyPair(serialized: SerializedKeyPair): Promise<KeyPair> {
+    const [privateKey, publicKey] = await Promise.all([
+        jose.importJWK(serialized.privateKeyJwk, ALGORITHM),
+        jose.importJWK(serialized.publicKeyJwk, ALGORITHM),
+    ]);
+
+    // jose.importJWK returns CryptoKey for asymmetric keys (Uint8Array only for symmetric 'oct' keys)
+    return {
+        privateKey: privateKey as CryptoKeyLike,
+        publicKey: publicKey as CryptoKeyLike,
+        kid: serialized.kid,
+    };
+}
+
+/**
+ * Save a keypair to disk with secure permissions
+ * Uses atomic write (temp file + rename) to prevent TOCTOU race conditions
+ */
+export async function saveKeyPair(keyPair: KeyPair, keysDir: string = DEFAULT_KEYS_DIR): Promise<void> {
+    const serialized = await exportKeyPair(keyPair);
+    const filePath = join(keysDir, KEYPAIR_FILE);
+    const tempPath = join(keysDir, `.keypair.${process.pid}.tmp`);
+
+    // Ensure directory exists with restricted permissions
+    mkdirSync(keysDir, { recursive: true, mode: 0o700 });
+
+    try {
+        // Write to temp file with secure permissions (owner read/write only)
+        writeFileSync(tempPath, JSON.stringify(serialized, null, 2), {
+            encoding: 'utf-8',
+            mode: 0o600,
+        });
+
+        
+        renameSync(tempPath, filePath);
+    } catch (err) {
+        // Clean up temp file on failure
+        try {
+            unlinkSync(tempPath);
+        } catch {
+            // Ignore cleanup errors
+        }
+        throw err;
+    }
+}
+
+/**
+ * Load a keypair from disk with validation
+ * Handles missing file gracefully, validates structure before use
+ */
+export async function loadKeyPair(keysDir: string = DEFAULT_KEYS_DIR): Promise<KeyPair | null> {
+    const filePath = join(keysDir, KEYPAIR_FILE);
+
+    let data: string;
+    try {
+        data = readFileSync(filePath, 'utf-8');
+    } catch (err) {
+        // File doesn't exist - not an error, just no existing keypair
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+            return null;
+        }
+        throw err;
+    }
+
+    // Parse and validate JSON structure
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(data);
+    } catch {
+        throw new Error(`Invalid JSON in keypair file: ${filePath}`);
+    }
+
+    // Validate against schema
+    const result = SerializedKeyPairSchema.safeParse(parsed);
+    if (!result.success) {
+        throw new Error(
+            `Invalid keypair file structure in ${filePath}: ${result.error.issues.map(i => i.message).join(', ')}`
+        );
+    }
+
+    return importKeyPair(result.data as SerializedKeyPair);
+}
+
+/**
+ * Load existing keypair or generate a new one
+ * Returns { keyPair, generated: boolean } so caller can log if needed
+ */
+export async function loadOrGenerateKeyPair(keysDir: string = DEFAULT_KEYS_DIR): Promise<{ keyPair: KeyPair; generated: boolean }> {
+    const existing = await loadKeyPair(keysDir);
+
+    if (existing) {
+        return { keyPair: existing, generated: false };
+    }
+
+    const keyPair = await generateKeyPair();
+    await saveKeyPair(keyPair, keysDir);
+
+    return { keyPair, generated: true };
+}
+
+/**
+ * Get the public key in JWK format (for JWKS endpoint)
+ */
+export async function getPublicKeyJwk(keyPair: KeyPair): Promise<jose.JWK> {
+    const jwk = await jose.exportJWK(keyPair.publicKey);
+    return decorateJwk(jwk, keyPair.kid);
+}
+
+/**
+ * Get the JWKS (JSON Web Key Set) containing all public keys
+ */
+export async function getJwks(keyPair: KeyPair): Promise<jose.JSONWebKeySet> {
+    const publicKeyJwk = await getPublicKeyJwk(keyPair);
+    return {
+        keys: [publicKeyJwk],
+    };
+}

--- a/packages/auth/tests/keys.integration.test.ts
+++ b/packages/auth/tests/keys.integration.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { existsSync, rmSync, mkdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import * as jose from 'jose';
+import {
+    generateKeyPair,
+    exportKeyPair,
+    importKeyPair,
+    saveKeyPair,
+    loadKeyPair,
+    loadOrGenerateKeyPair,
+    getPublicKeyJwk,
+    getJwks,
+    type KeyPair,
+    type SerializedKeyPair
+} from '../src/keys.js';
+
+describe('Keys Integration Tests - File Persistence', () => {
+    let testKeysDir: string;
+
+    beforeEach(() => {
+        // Create unique temp directory for each test
+        testKeysDir = join(tmpdir(), `catalyst-auth-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+        mkdirSync(testKeysDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        // Clean up temp directory
+        if (existsSync(testKeysDir)) {
+            rmSync(testKeysDir, { recursive: true, force: true });
+        }
+    });
+
+    describe('saveKeyPair', () => {
+        it('should save keypair to specified directory', async () => {
+            const keyPair = await generateKeyPair();
+            await saveKeyPair(keyPair, testKeysDir);
+
+            const filePath = join(testKeysDir, 'keypair.json');
+            expect(existsSync(filePath)).toBe(true);
+        });
+
+        it('should create directory if it does not exist', async () => {
+            const nestedDir = join(testKeysDir, 'nested', 'dir');
+            const keyPair = await generateKeyPair();
+
+            await saveKeyPair(keyPair, nestedDir);
+
+            expect(existsSync(nestedDir)).toBe(true);
+            expect(existsSync(join(nestedDir, 'keypair.json'))).toBe(true);
+        });
+
+        it('should save keypair in valid JSON format', async () => {
+            const keyPair = await generateKeyPair();
+            await saveKeyPair(keyPair, testKeysDir);
+
+            const filePath = join(testKeysDir, 'keypair.json');
+            const data = readFileSync(filePath, 'utf-8');
+            const parsed = JSON.parse(data) as SerializedKeyPair;
+
+            expect(parsed.privateKeyJwk).toBeDefined();
+            expect(parsed.publicKeyJwk).toBeDefined();
+            expect(parsed.kid).toBe(keyPair.kid);
+            expect(parsed.createdAt).toBeDefined();
+        });
+
+        it('should preserve all key properties in saved file', async () => {
+            const keyPair = await generateKeyPair();
+            await saveKeyPair(keyPair, testKeysDir);
+
+            const filePath = join(testKeysDir, 'keypair.json');
+            const data = readFileSync(filePath, 'utf-8');
+            const parsed = JSON.parse(data) as SerializedKeyPair;
+
+            // Verify algorithm and use are preserved
+            expect(parsed.privateKeyJwk.alg).toBe('ES384');
+            expect(parsed.privateKeyJwk.use).toBe('sig');
+            expect(parsed.publicKeyJwk.alg).toBe('ES384');
+            expect(parsed.publicKeyJwk.use).toBe('sig');
+
+            // Verify EC curve parameters
+            expect(parsed.publicKeyJwk.kty).toBe('EC');
+            expect(parsed.publicKeyJwk.crv).toBe('P-384');
+        });
+
+        it('should overwrite existing keypair file', async () => {
+            const keyPair1 = await generateKeyPair();
+            await saveKeyPair(keyPair1, testKeysDir);
+
+            const keyPair2 = await generateKeyPair();
+            await saveKeyPair(keyPair2, testKeysDir);
+
+            const filePath = join(testKeysDir, 'keypair.json');
+            const data = readFileSync(filePath, 'utf-8');
+            const parsed = JSON.parse(data) as SerializedKeyPair;
+
+            expect(parsed.kid).toBe(keyPair2.kid);
+            expect(parsed.kid).not.toBe(keyPair1.kid);
+        });
+    });
+
+    describe('loadKeyPair', () => {
+        it('should load previously saved keypair', async () => {
+            const original = await generateKeyPair();
+            await saveKeyPair(original, testKeysDir);
+
+            const loaded = await loadKeyPair(testKeysDir);
+
+            expect(loaded).not.toBeNull();
+            expect(loaded!.kid).toBe(original.kid);
+        });
+
+        it('should return null if no keypair file exists', async () => {
+            const loaded = await loadKeyPair(testKeysDir);
+
+            expect(loaded).toBeNull();
+        });
+
+        it('should return null for non-existent directory', async () => {
+            const nonExistentDir = join(testKeysDir, 'does-not-exist');
+
+            const loaded = await loadKeyPair(nonExistentDir);
+
+            expect(loaded).toBeNull();
+        });
+
+        it('should load keys that can sign and verify', async () => {
+            const original = await generateKeyPair();
+            await saveKeyPair(original, testKeysDir);
+
+            const loaded = await loadKeyPair(testKeysDir);
+            expect(loaded).not.toBeNull();
+
+            // Sign with loaded private key
+            const jwt = await new jose.SignJWT({ test: 'loaded-key' })
+                .setProtectedHeader({ alg: 'ES384', kid: loaded!.kid })
+                .setIssuedAt()
+                .setExpirationTime('1h')
+                .sign(loaded!.privateKey);
+
+            // Verify with loaded public key
+            const { payload } = await jose.jwtVerify(jwt, loaded!.publicKey);
+            expect(payload.test).toBe('loaded-key');
+        });
+
+        it('should load keys compatible with original keys', async () => {
+            const original = await generateKeyPair();
+
+            // Sign with original key before saving
+            const jwt = await new jose.SignJWT({ test: 'before-save' })
+                .setProtectedHeader({ alg: 'ES384', kid: original.kid })
+                .sign(original.privateKey);
+
+            await saveKeyPair(original, testKeysDir);
+            const loaded = await loadKeyPair(testKeysDir);
+
+            // Verify the JWT signed before save with the loaded key
+            const { payload } = await jose.jwtVerify(jwt, loaded!.publicKey);
+            expect(payload.test).toBe('before-save');
+        });
+    });
+
+    describe('loadOrGenerateKeyPair', () => {
+        it('should generate new keypair when none exists', async () => {
+            const result = await loadOrGenerateKeyPair(testKeysDir);
+
+            expect(result).toBeDefined();
+            expect(result.keyPair.kid).toBeDefined();
+            expect(result.keyPair.privateKey).toBeDefined();
+            expect(result.keyPair.publicKey).toBeDefined();
+            expect(result.generated).toBe(true);
+        });
+
+        it('should save generated keypair to disk', async () => {
+            await loadOrGenerateKeyPair(testKeysDir);
+
+            const filePath = join(testKeysDir, 'keypair.json');
+            expect(existsSync(filePath)).toBe(true);
+        });
+
+        it('should load existing keypair when present', async () => {
+            // Generate and save a keypair first
+            const original = await generateKeyPair();
+            await saveKeyPair(original, testKeysDir);
+
+            // Now call loadOrGenerateKeyPair
+            const result = await loadOrGenerateKeyPair(testKeysDir);
+
+            expect(result.keyPair.kid).toBe(original.kid);
+            expect(result.generated).toBe(false);
+        });
+
+        it('should not overwrite existing keypair', async () => {
+            const original = await generateKeyPair();
+            await saveKeyPair(original, testKeysDir);
+
+            // Call loadOrGenerateKeyPair multiple times
+            const result1 = await loadOrGenerateKeyPair(testKeysDir);
+            const result2 = await loadOrGenerateKeyPair(testKeysDir);
+
+            expect(result1.keyPair.kid).toBe(original.kid);
+            expect(result2.keyPair.kid).toBe(original.kid);
+        });
+
+        it('should create directory if it does not exist', async () => {
+            const nestedDir = join(testKeysDir, 'nested', 'auth', 'keys');
+
+            await loadOrGenerateKeyPair(nestedDir);
+
+            expect(existsSync(nestedDir)).toBe(true);
+            expect(existsSync(join(nestedDir, 'keypair.json'))).toBe(true);
+        });
+    });
+
+    describe('End-to-End Key Lifecycle', () => {
+        it('should support complete key lifecycle: generate -> save -> load -> use', async () => {
+            // 1. Generate a new keypair
+            const keyPair = await generateKeyPair();
+            // JWK thumbprint is base64url-encoded SHA-256 hash (43 chars)
+            expect(keyPair.kid).toMatch(/^[A-Za-z0-9_-]{43}$/);
+
+            // 2. Save to disk
+            await saveKeyPair(keyPair, testKeysDir);
+
+            // 3. Load from disk
+            const loaded = await loadKeyPair(testKeysDir);
+            expect(loaded).not.toBeNull();
+
+            // 4. Use for JWT operations
+            const claims = { sub: 'user123', role: 'admin' };
+            const jwt = await new jose.SignJWT(claims)
+                .setProtectedHeader({ alg: 'ES384', kid: loaded!.kid })
+                .setIssuedAt()
+                .setExpirationTime('1h')
+                .setIssuer('catalyst-auth')
+                .sign(loaded!.privateKey);
+
+            // 5. Verify with JWKS
+            const jwks = await getJwks(loaded!);
+            const keySet = jose.createLocalJWKSet(jwks);
+            const { payload } = await jose.jwtVerify(jwt, keySet);
+
+            expect(payload.sub).toBe('user123');
+            expect(payload.role).toBe('admin');
+            expect(payload.iss).toBe('catalyst-auth');
+        });
+
+        it('should maintain key continuity across save/load cycles', async () => {
+            const keyPair = await generateKeyPair();
+
+            // Sign multiple JWTs
+            const jwt1 = await new jose.SignJWT({ id: 1 })
+                .setProtectedHeader({ alg: 'ES384', kid: keyPair.kid })
+                .sign(keyPair.privateKey);
+
+            const jwt2 = await new jose.SignJWT({ id: 2 })
+                .setProtectedHeader({ alg: 'ES384', kid: keyPair.kid })
+                .sign(keyPair.privateKey);
+
+            // Save and reload
+            await saveKeyPair(keyPair, testKeysDir);
+            const loaded = await loadKeyPair(testKeysDir);
+
+            // Verify both JWTs with reloaded key
+            const { payload: p1 } = await jose.jwtVerify(jwt1, loaded!.publicKey);
+            const { payload: p2 } = await jose.jwtVerify(jwt2, loaded!.publicKey);
+
+            expect(p1.id).toBe(1);
+            expect(p2.id).toBe(2);
+        });
+
+        it('should export JWKS suitable for public distribution', async () => {
+            const result = await loadOrGenerateKeyPair(testKeysDir);
+            const jwks = await getJwks(result.keyPair);
+
+            // JWKS should be safe for public distribution
+            for (const key of jwks.keys) {
+                // Should NOT contain private key material
+                expect(key.d).toBeUndefined();
+
+                // Should contain required public key fields
+                expect(key.kty).toBe('EC');
+                expect(key.crv).toBe('P-384');
+                expect(key.x).toBeDefined();
+                expect(key.y).toBeDefined();
+                expect(key.kid).toBeDefined();
+                expect(key.alg).toBe('ES384');
+                expect(key.use).toBe('sig');
+            }
+        });
+    });
+
+    describe('Error Handling', () => {
+        it('should handle corrupted keypair file gracefully', async () => {
+            const filePath = join(testKeysDir, 'keypair.json');
+            const { writeFileSync } = await import('fs');
+            writeFileSync(filePath, 'not valid json', 'utf-8');
+
+            await expect(loadKeyPair(testKeysDir)).rejects.toThrow();
+        });
+
+        it('should handle invalid JWK data in keypair file', async () => {
+            const filePath = join(testKeysDir, 'keypair.json');
+            const { writeFileSync } = await import('fs');
+
+            const invalidData: SerializedKeyPair = {
+                privateKeyJwk: { kty: 'invalid' as any },
+                publicKeyJwk: { kty: 'invalid' as any },
+                kid: 'test-kid',
+                createdAt: new Date().toISOString()
+            };
+
+            writeFileSync(filePath, JSON.stringify(invalidData), 'utf-8');
+
+            await expect(loadKeyPair(testKeysDir)).rejects.toThrow();
+        });
+    });
+
+    describe('Concurrent Access', () => {
+        it('should handle concurrent loadOrGenerateKeyPair calls', async () => {
+            // Simulate concurrent calls
+            const results = await Promise.all([
+                loadOrGenerateKeyPair(testKeysDir),
+                loadOrGenerateKeyPair(testKeysDir),
+                loadOrGenerateKeyPair(testKeysDir)
+            ]);
+
+            // All should succeed
+            expect(results).toHaveLength(3);
+            results.forEach(result => {
+                expect(result.keyPair.kid).toBeDefined();
+                expect(result.keyPair.privateKey).toBeDefined();
+                expect(result.keyPair.publicKey).toBeDefined();
+            });
+        });
+
+        it('should handle concurrent saveKeyPair calls', async () => {
+            const keyPairs = await Promise.all([
+                generateKeyPair(),
+                generateKeyPair(),
+                generateKeyPair()
+            ]);
+
+            // Save concurrently (last one wins)
+            await Promise.all(
+                keyPairs.map(kp => saveKeyPair(kp, testKeysDir))
+            );
+
+            // File should exist and be valid
+            const loaded = await loadKeyPair(testKeysDir);
+            expect(loaded).not.toBeNull();
+
+            // Should be one of the saved keypairs
+            const kids = keyPairs.map(kp => kp.kid);
+            expect(kids).toContain(loaded!.kid);
+        });
+    });
+});

--- a/packages/auth/tests/keys.unit.test.ts
+++ b/packages/auth/tests/keys.unit.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { existsSync, rmSync, mkdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import * as jose from 'jose';
+import {
+    generateKeyPair,
+    exportKeyPair,
+    importKeyPair,
+    saveKeyPair,
+    loadKeyPair,
+    loadOrGenerateKeyPair,
+    getPublicKeyJwk,
+    getJwks,
+    type KeyPair,
+    type SerializedKeyPair
+} from '../src/keys.js';
+
+describe('Keys Unit Tests', () => {
+    describe('generateKeyPair', () => {
+        it('should generate a valid ES384 keypair', async () => {
+            const keyPair = await generateKeyPair();
+
+            expect(keyPair).toBeDefined();
+            expect(keyPair.privateKey).toBeDefined();
+            expect(keyPair.publicKey).toBeDefined();
+            expect(keyPair.kid).toBeDefined();
+        });
+
+        it('should generate a key ID using JWK thumbprint', async () => {
+            const keyPair = await generateKeyPair();
+
+            // JWK thumbprint is base64url-encoded SHA-256 hash (43 chars)
+            expect(keyPair.kid).toMatch(/^[A-Za-z0-9_-]{43}$/);
+        });
+
+        it('should generate unique key IDs for each keypair', async () => {
+            const keyPair1 = await generateKeyPair();
+            const keyPair2 = await generateKeyPair();
+
+            expect(keyPair1.kid).not.toBe(keyPair2.kid);
+        });
+
+        it('should generate keys that can sign and verify', async () => {
+            const keyPair = await generateKeyPair();
+
+            // Create a JWT
+            const jwt = await new jose.SignJWT({ test: 'data' })
+                .setProtectedHeader({ alg: 'ES384', kid: keyPair.kid })
+                .setIssuedAt()
+                .setExpirationTime('1h')
+                .sign(keyPair.privateKey);
+
+            // Verify the JWT
+            const { payload } = await jose.jwtVerify(jwt, keyPair.publicKey);
+            expect(payload.test).toBe('data');
+        });
+    });
+
+    describe('exportKeyPair', () => {
+        it('should export keypair to JWK format', async () => {
+            const keyPair = await generateKeyPair();
+            const serialized = await exportKeyPair(keyPair);
+
+            expect(serialized.privateKeyJwk).toBeDefined();
+            expect(serialized.publicKeyJwk).toBeDefined();
+            expect(serialized.kid).toBe(keyPair.kid);
+            expect(serialized.createdAt).toBeDefined();
+        });
+
+        it('should include algorithm and use in exported JWKs', async () => {
+            const keyPair = await generateKeyPair();
+            const serialized = await exportKeyPair(keyPair);
+
+            expect(serialized.privateKeyJwk.alg).toBe('ES384');
+            expect(serialized.privateKeyJwk.use).toBe('sig');
+            expect(serialized.publicKeyJwk.alg).toBe('ES384');
+            expect(serialized.publicKeyJwk.use).toBe('sig');
+        });
+
+        it('should include key ID in both JWKs', async () => {
+            const keyPair = await generateKeyPair();
+            const serialized = await exportKeyPair(keyPair);
+
+            expect(serialized.privateKeyJwk.kid).toBe(keyPair.kid);
+            expect(serialized.publicKeyJwk.kid).toBe(keyPair.kid);
+        });
+
+        it('should have valid ISO timestamp for createdAt', async () => {
+            const beforeTime = new Date();
+            const keyPair = await generateKeyPair();
+            const serialized = await exportKeyPair(keyPair);
+            const afterTime = new Date();
+
+            const createdAt = new Date(serialized.createdAt);
+            expect(createdAt.getTime()).toBeGreaterThanOrEqual(beforeTime.getTime());
+            expect(createdAt.getTime()).toBeLessThanOrEqual(afterTime.getTime());
+        });
+
+        it('should export EC curve parameters correctly', async () => {
+            const keyPair = await generateKeyPair();
+            const serialized = await exportKeyPair(keyPair);
+
+            // ES384 uses P-384 curve
+            expect(serialized.publicKeyJwk.kty).toBe('EC');
+            expect(serialized.publicKeyJwk.crv).toBe('P-384');
+            expect(serialized.publicKeyJwk.x).toBeDefined();
+            expect(serialized.publicKeyJwk.y).toBeDefined();
+        });
+
+        it('should include private key component (d) in private JWK', async () => {
+            const keyPair = await generateKeyPair();
+            const serialized = await exportKeyPair(keyPair);
+
+            expect(serialized.privateKeyJwk.d).toBeDefined();
+            // Public key should NOT have d component
+            expect(serialized.publicKeyJwk.d).toBeUndefined();
+        });
+    });
+
+    describe('importKeyPair', () => {
+        it('should import a serialized keypair', async () => {
+            const original = await generateKeyPair();
+            const serialized = await exportKeyPair(original);
+            const imported = await importKeyPair(serialized);
+
+            expect(imported.kid).toBe(original.kid);
+            expect(imported.privateKey).toBeDefined();
+            expect(imported.publicKey).toBeDefined();
+        });
+
+        it('should import keys that can sign and verify', async () => {
+            const original = await generateKeyPair();
+            const serialized = await exportKeyPair(original);
+            const imported = await importKeyPair(serialized);
+
+            // Sign with imported private key
+            const jwt = await new jose.SignJWT({ test: 'roundtrip' })
+                .setProtectedHeader({ alg: 'ES384', kid: imported.kid })
+                .setIssuedAt()
+                .setExpirationTime('1h')
+                .sign(imported.privateKey);
+
+            // Verify with imported public key
+            const { payload } = await jose.jwtVerify(jwt, imported.publicKey);
+            expect(payload.test).toBe('roundtrip');
+        });
+
+        it('should produce keys compatible with original keys', async () => {
+            const original = await generateKeyPair();
+            const serialized = await exportKeyPair(original);
+            const imported = await importKeyPair(serialized);
+
+            // Sign with original private key
+            const jwt = await new jose.SignJWT({ test: 'cross-verify' })
+                .setProtectedHeader({ alg: 'ES384', kid: original.kid })
+                .sign(original.privateKey);
+
+            // Verify with imported public key
+            const { payload } = await jose.jwtVerify(jwt, imported.publicKey);
+            expect(payload.test).toBe('cross-verify');
+        });
+    });
+
+    describe('getPublicKeyJwk', () => {
+        it('should return public key in JWK format', async () => {
+            const keyPair = await generateKeyPair();
+            const jwk = await getPublicKeyJwk(keyPair);
+
+            expect(jwk.kty).toBe('EC');
+            expect(jwk.crv).toBe('P-384');
+            expect(jwk.x).toBeDefined();
+            expect(jwk.y).toBeDefined();
+        });
+
+        it('should include key ID in JWK', async () => {
+            const keyPair = await generateKeyPair();
+            const jwk = await getPublicKeyJwk(keyPair);
+
+            expect(jwk.kid).toBe(keyPair.kid);
+        });
+
+        it('should include algorithm and use', async () => {
+            const keyPair = await generateKeyPair();
+            const jwk = await getPublicKeyJwk(keyPair);
+
+            expect(jwk.alg).toBe('ES384');
+            expect(jwk.use).toBe('sig');
+        });
+
+        it('should NOT include private key component', async () => {
+            const keyPair = await generateKeyPair();
+            const jwk = await getPublicKeyJwk(keyPair);
+
+            expect(jwk.d).toBeUndefined();
+        });
+    });
+
+    describe('getJwks', () => {
+        it('should return JWKS with keys array', async () => {
+            const keyPair = await generateKeyPair();
+            const jwks = await getJwks(keyPair);
+
+            expect(jwks).toBeDefined();
+            expect(jwks.keys).toBeDefined();
+            expect(Array.isArray(jwks.keys)).toBe(true);
+        });
+
+        it('should include exactly one key', async () => {
+            const keyPair = await generateKeyPair();
+            const jwks = await getJwks(keyPair);
+
+            expect(jwks.keys).toHaveLength(1);
+        });
+
+        it('should include the public key with correct properties', async () => {
+            const keyPair = await generateKeyPair();
+            const jwks = await getJwks(keyPair);
+            const key = jwks.keys[0];
+
+            expect(key.kid).toBe(keyPair.kid);
+            expect(key.alg).toBe('ES384');
+            expect(key.use).toBe('sig');
+            expect(key.kty).toBe('EC');
+            expect(key.crv).toBe('P-384');
+        });
+
+        it('should produce valid JWKS for jose verification', async () => {
+            const keyPair = await generateKeyPair();
+            const jwks = await getJwks(keyPair);
+
+            // Create a JWT
+            const jwt = await new jose.SignJWT({ test: 'jwks' })
+                .setProtectedHeader({ alg: 'ES384', kid: keyPair.kid })
+                .sign(keyPair.privateKey);
+
+            // Create a JWKS from the keys
+            const keySetGetKey = jose.createLocalJWKSet(jwks);
+
+            // Verify using the JWKS
+            const { payload } = await jose.jwtVerify(jwt, keySetGetKey);
+            expect(payload.test).toBe('jwks');
+        });
+    });
+});

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "esModuleInterop": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "declaration": true,
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "types": ["bun-types"]
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
# Add cryptographic key management for auth service

This PR adds a new `@catalyst/auth` package with comprehensive cryptographic key management:

- JWK generation with RFC 7638 thumbprint-based key IDs
- Atomic file writes with secure permissions (0o600)
- Zod schema validation for keypair files
- JWKS endpoint support for public key distribution

The implementation includes:
- ES384 keypair generation, persistence, and loading
- Secure key storage with proper file permissions
- Comprehensive unit and integration tests
- Support for JWT signing and verification