### PR TITLE
build(docker): use monorepo root context so bun can resove catlog

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+**/node_modules
+dist
+**/dist
+*.log
+.git
+.gitignore
+*.md
+.env*
+coverage
+.turbo

--- a/docker-compose/example.m0p2.compose.yaml
+++ b/docker-compose/example.m0p2.compose.yaml
@@ -1,8 +1,8 @@
 services:
   orchestrator:
     build:
-      context: ../packages/orchestrator
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: packages/orchestrator/Dockerfile
     ports:
       - "3000:3000"
     environment:
@@ -13,10 +13,10 @@ services:
 
   gateway:
     build:
-      context: ../packages/gateway
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: packages/gateway/Dockerfile
     ports:
-      - "4000:4000"
+      - "4040:4000"
     environment:
       - PORT=4000
     depends_on:
@@ -25,8 +25,8 @@ services:
 
   books-service:
     build:
-      context: ../packages/examples
-      dockerfile: Dockerfile.books
+      context: ..
+      dockerfile: packages/examples/Dockerfile.books
     ports:
       - "8081:8080"
     environment:
@@ -34,8 +34,8 @@ services:
 
   movies-service:
     build:
-      context: ../packages/examples
-      dockerfile: Dockerfile.movies
+      context: ..
+      dockerfile: packages/examples/Dockerfile.movies
     ports:
       - "8082:8080"
     environment:

--- a/packages/examples/Dockerfile.books
+++ b/packages/examples/Dockerfile.books
@@ -1,18 +1,20 @@
+# Build from monorepo root context to resolve catalog references
 FROM oven/bun:1
 
 WORKDIR /app
 
-# Copy root package.json and lockfile (to utilize cache if possible, though overly simple here)
-# For simplicity in this monorepo context without complex pruning, we'll assume we can copy the packages/examples dir
-# Setup workspace context usually requires more, but for an isolated example container:
+# Copy workspace config files (catalog definitions are in root package.json)
+COPY package.json bun.lockb ./
+COPY packages/examples/package.json ./packages/examples/
 
-# Copy the examples workspace
-COPY . .
+# Install from workspace root - bun resolves catalogs from root package.json
+RUN bun install --omit dev
 
-# Install dependencies (frozen-lockfile might fail if unrelated packages are missing, so we just install)
-RUN bun install
+# Copy source code
+COPY packages/examples/src ./packages/examples/src
 
-# Expose port
+WORKDIR /app/packages/examples
+
 ENV PORT=8080
 EXPOSE 8080
 

--- a/packages/examples/Dockerfile.movies
+++ b/packages/examples/Dockerfile.movies
@@ -1,10 +1,19 @@
+# Build from monorepo root context to resolve catalog references
 FROM oven/bun:1
 
 WORKDIR /app
 
-COPY . .
+# Copy workspace config files (catalog definitions are in root package.json)
+COPY package.json bun.lockb ./
+COPY packages/examples/package.json ./packages/examples/
 
-RUN bun install
+# Install from workspace root - bun resolves catalogs from root package.json
+RUN bun install --omit dev
+
+# Copy source code
+COPY packages/examples/src ./packages/examples/src
+
+WORKDIR /app/packages/examples
 
 ENV PORT=8080
 EXPOSE 8080

--- a/packages/gateway/Dockerfile
+++ b/packages/gateway/Dockerfile
@@ -1,16 +1,29 @@
-# Builder stage
+# Build from monorepo root context to resolve catalog references
 FROM oven/bun:1 AS builder
 WORKDIR /app
-COPY package.json ./
-RUN bun install
-COPY . .
+
+# Copy workspace config files (catalog definitions are in root package.json)
+COPY package.json bun.lockb ./
+COPY packages/gateway/package.json ./packages/gateway/
+
+# Install from workspace root - bun resolves catalogs from root package.json
+RUN bun install --omit dev
+
+# Copy source code
+COPY packages/gateway/src ./packages/gateway/src
+COPY packages/gateway/tsconfig.json ./packages/gateway/
+
+# Build binary
+WORKDIR /app/packages/gateway
 RUN bun build --compile --minify --outfile server src/index.ts
 
 # Runtime stage
 # We use distroless/base-nossl-debian12 for a minimal glibc image
 FROM gcr.io/distroless/base-nossl-debian12
 WORKDIR /app
-COPY --from=builder /app/server .
+
+COPY --from=builder /app/packages/gateway/server .
+
 ENV PORT=4000
 EXPOSE 4000
 CMD ["./server"]

--- a/packages/orchestrator/Dockerfile
+++ b/packages/orchestrator/Dockerfile
@@ -1,37 +1,28 @@
-FROM oven/bun:1 as base
+# Build from monorepo root context to resolve catalog references
+FROM oven/bun:1 AS builder
 WORKDIR /app
 
-# Install dependencies into temp directory
-# This will cache them and speed up future builds
-FROM base AS install
-RUN mkdir -p /temp/dev
-COPY package.json /temp/dev/
-RUN cd /temp/dev && bun install
+# Copy workspace config files (catalog definitions are in root package.json)
+COPY package.json bun.lockb ./
+COPY packages/orchestrator/package.json ./packages/orchestrator/
 
-# Install with --production (exclude devDependencies)
-RUN mkdir -p /temp/prod
-COPY package.json /temp/prod/
-RUN cd /temp/prod && bun install --production
+# Install from workspace root - bun resolves catalogs from root package.json
+RUN bun install --omit dev
 
-# Copy node_modules from temp directory
-# Then copy all (non-ignored) project files into the image
-FROM base AS prerelease
-COPY --from=install /temp/dev/node_modules node_modules
-COPY . .
+# Copy source code
+COPY packages/orchestrator/src ./packages/orchestrator/src
+COPY packages/orchestrator/tsconfig.json ./packages/orchestrator/
 
-# [optional] tests & build
-ENV NODE_ENV=production
-# RUN bun test
-# RUN bun run build
+# Build binary
+WORKDIR /app/packages/orchestrator
+RUN bun build --compile --minify --outfile server src/index.ts
 
-# copy production dependencies and source code into final image
-FROM base AS release
-COPY --from=install /temp/prod/node_modules node_modules
-COPY --from=prerelease /app/src src
-COPY --from=prerelease /app/package.json .
-COPY --from=prerelease /app/tsconfig.json .
+# Runtime stage
+FROM gcr.io/distroless/base-nossl-debian12
+WORKDIR /app
 
-# run the app
-USER bun
-EXPOSE 3000/tcp
-ENTRYPOINT [ "bun", "run", "src/index.ts" ]
+COPY --from=builder /app/packages/orchestrator/server .
+
+ENV PORT=3000
+EXPOSE 3000
+CMD ["./server"]


### PR DESCRIPTION
### TL;DR

Optimized Docker builds for all services by using monorepo root as build context and implementing multi-stage builds.

### What changed?

- Added `.dockerignore` file to exclude unnecessary files from Docker builds
- Updated all Dockerfiles to build from the monorepo root context instead of individual package contexts
- Implemented proper multi-stage builds for the orchestrator and gateway services
- Changed gateway port mapping from 4000 to 4040 in docker-compose
- Improved dependency installation with `--omit dev` flag
- Streamlined file copying to include only necessary files
- Switched orchestrator and gateway to use distroless containers for smaller, more secure images
- Compiled services to binaries for improved startup performance

### How to test?

1. Build and run the services using docker-compose:
   ```
   podman compose -f docker-compose/example.m0p2.compose.yaml up --build
   ```
2. Verify the orchestrator is accessible at http://localhost:3000
3. Verify the gateway is accessible at http://localhost:4040
4. Confirm the books service is accessible at http://localhost:8081
5. Confirm the movies service is accessible at http://localhost:8082

### Why make this change?

These changes improve the Docker build process by:
- Reducing image sizes by excluding unnecessary files and using distroless containers
- Improving build performance through better caching
- Enhancing security by using minimal runtime images
- Ensuring proper dependency resolution across the monorepo
- Creating a more consistent build approach across all services