### PR TITLE
docs: update readme for podman dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,11 @@ The "muscle" of the node.
 *   **Decentralized**: No single point of failure or control.
 *   **Plugin-Driven**: Extensible architecture for defining custom behaviors for routing, local services, and propagation.
 *   **Local Services**: Easily spin up and advertise local resources (e.g., VPN clients, GraphQL federations) as network services.
+
+## Development
+
+Run the full stack locally with Podman:
+
+```bash
+podman compose -f docker-compose/example.m0p2.compose.yaml up --build
+```


### PR DESCRIPTION
### TL;DR

Added development instructions to the README for running the full stack locally.

### What changed?

Added a new "Development" section to the README.md file with instructions for running the full stack locally using Podman and the example compose file.

### How to test?

1. Review the updated README.md
2. Try running the command: `podman compose -f docker-compose/example.m0p2.compose.yaml up --build`

### Why make this change?

To provide clear instructions for developers who want to quickly set up and run the full stack locally during development, making it easier for new contributors to get started with the project.