### PR TITLE
feat: add update handler for service registration

### DIFF
--- a/docker-compose/example.m0p2.compose.yaml
+++ b/docker-compose/example.m0p2.compose.yaml
@@ -1,8 +1,8 @@
 services:
   orchestrator:
     build:
-      context: ../packages/orchestrator
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: packages/orchestrator/Dockerfile
     ports:
       - "3000:3000"
     environment:
@@ -13,8 +13,8 @@ services:
 
   gateway:
     build:
-      context: ../packages/gateway
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: packages/gateway/Dockerfile
     ports:
       - "4000:4000"
     environment:
@@ -25,8 +25,8 @@ services:
 
   books-service:
     build:
-      context: ../packages/examples
-      dockerfile: Dockerfile.books
+      context: ..
+      dockerfile: packages/examples/Dockerfile.books
     ports:
       - "8081:8080"
     environment:
@@ -34,8 +34,8 @@ services:
 
   movies-service:
     build:
-      context: ../packages/examples
-      dockerfile: Dockerfile.movies
+      context: ..
+      dockerfile: packages/examples/Dockerfile.movies
     ports:
       - "8082:8080"
     environment:

--- a/packages/examples/Dockerfile.books
+++ b/packages/examples/Dockerfile.books
@@ -2,18 +2,19 @@ FROM oven/bun:1
 
 WORKDIR /app
 
-# Copy root package.json and lockfile (to utilize cache if possible, though overly simple here)
-# For simplicity in this monorepo context without complex pruning, we'll assume we can copy the packages/examples dir
-# Setup workspace context usually requires more, but for an isolated example container:
+# Copy root config
+COPY package.json bun.lockb ./
 
-# Copy the examples workspace
-COPY . .
+# Copy examples package
+COPY packages/examples packages/examples
+RUN rm -rf packages/examples/node_modules
 
-# Install dependencies (frozen-lockfile might fail if unrelated packages are missing, so we just install)
+# Install dependencies from root to handle workspace hoisting correctly
+WORKDIR /app
 RUN bun install
 
 # Expose port
 ENV PORT=8080
 EXPOSE 8080
 
-CMD ["bun", "run", "src/books/index.ts"]
+CMD ["bun", "run", "packages/examples/src/books/index.ts"]

--- a/packages/examples/Dockerfile.movies
+++ b/packages/examples/Dockerfile.movies
@@ -2,11 +2,18 @@ FROM oven/bun:1
 
 WORKDIR /app
 
-COPY . .
+# Copy root config
+COPY package.json bun.lockb ./
 
+# Copy examples package
+COPY packages/examples packages/examples
+RUN rm -rf packages/examples/node_modules
+
+# Install dependencies from root to handle workspace hoisting correctly
+WORKDIR /app
 RUN bun install
 
 ENV PORT=8080
 EXPOSE 8080
 
-CMD ["bun", "run", "src/movies/index.ts"]
+CMD ["bun", "run", "packages/examples/src/movies/index.ts"]

--- a/packages/gateway/Dockerfile
+++ b/packages/gateway/Dockerfile
@@ -1,16 +1,20 @@
-# Builder stage
-FROM oven/bun:1 AS builder
+# Runtime stage (use bun directly)
+FROM oven/bun:1
 WORKDIR /app
-COPY package.json ./
-RUN bun install
-COPY . .
-RUN bun build --compile --minify --outfile server src/index.ts
 
-# Runtime stage
-# We use distroless/base-nossl-debian12 for a minimal glibc image
-FROM gcr.io/distroless/base-nossl-debian12
-WORKDIR /app
-COPY --from=builder /app/server .
+# Copy root config
+COPY package.json bun.lockb ./
+
+# Copy source
+COPY packages/gateway packages/gateway
+
+# Remove host node_modules to avoid broken symlinks
+RUN rm -rf packages/gateway/node_modules
+
+# Install dependencies from root
+RUN bun install
+
+WORKDIR /app/packages/gateway
 ENV PORT=4000
 EXPOSE 4000
-CMD ["./server"]
+CMD ["bun", "run", "src/index.ts"]

--- a/packages/orchestrator/Dockerfile
+++ b/packages/orchestrator/Dockerfile
@@ -1,37 +1,19 @@
-FROM oven/bun:1 as base
+FROM oven/bun:1
+
 WORKDIR /app
 
-# Install dependencies into temp directory
-# This will cache them and speed up future builds
-FROM base AS install
-RUN mkdir -p /temp/dev
-COPY package.json /temp/dev/
-RUN cd /temp/dev && bun install
+# Copy root config
+COPY package.json bun.lockb ./
 
-# Install with --production (exclude devDependencies)
-RUN mkdir -p /temp/prod
-COPY package.json /temp/prod/
-RUN cd /temp/prod && bun install --production
+# Copy orchestrator package
+COPY packages/orchestrator packages/orchestrator
+RUN rm -rf packages/orchestrator/node_modules
 
-# Copy node_modules from temp directory
-# Then copy all (non-ignored) project files into the image
-FROM base AS prerelease
-COPY --from=install /temp/dev/node_modules node_modules
-COPY . .
+# Install dependencies
+WORKDIR /app/packages/orchestrator
+RUN bun install
 
-# [optional] tests & build
-ENV NODE_ENV=production
-# RUN bun test
-# RUN bun run build
+ENV PORT=3000
+EXPOSE 3000
 
-# copy production dependencies and source code into final image
-FROM base AS release
-COPY --from=install /temp/prod/node_modules node_modules
-COPY --from=prerelease /app/src src
-COPY --from=prerelease /app/package.json .
-COPY --from=prerelease /app/tsconfig.json .
-
-# run the app
-USER bun
-EXPOSE 3000/tcp
-ENTRYPOINT [ "bun", "run", "src/index.ts" ]
+CMD ["bun", "run", "src/index.ts"]

--- a/packages/orchestrator/src/plugins/implementations/routing.ts
+++ b/packages/orchestrator/src/plugins/implementations/routing.ts
@@ -18,12 +18,14 @@ export class RouteTablePlugin extends BasePlugin {
                     return { success: true, ctx: context };
                 }
 
-                const id = state.addInternalRoute({
+                const { state: newState, id } = state.addInternalRoute({
                     name: action.data.name,
                     endpoint: action.data.endpoint!,
                     protocol: action.data.protocol,
                     region: action.data.region
                 });
+
+                context.state = newState;
                 context.result = { ...context.result, id };
             } else if (action.action === 'update') {
                 // Ignore Proxy protocols handled by DirectProxyRouteTablePlugin
@@ -32,14 +34,16 @@ export class RouteTablePlugin extends BasePlugin {
                     return { success: true, ctx: context };
                 }
 
-                const id = state.updateInternalRoute({
+                const result = state.updateInternalRoute({
                     name: action.data.name,
                     endpoint: action.data.endpoint!,
                     protocol: action.data.protocol,
                     region: action.data.region
                 });
 
-                if (id) {
+                if (result) {
+                    const { state: newState, id } = result;
+                    context.state = newState;
                     context.result = { ...context.result, id };
                 } else {
                     return {
@@ -53,7 +57,8 @@ export class RouteTablePlugin extends BasePlugin {
             } else if (action.action === 'delete') {
                 // Delete works for all route types - removeRoute checks all maps
                 const id = action.data.id;
-                state.removeRoute(id);
+                const newState = state.removeRoute(id);
+                context.state = newState;
                 context.result = { ...context.result, id };
             }
         }

--- a/packages/orchestrator/tests/composite.proxy.state.unit.test.ts
+++ b/packages/orchestrator/tests/composite.proxy.state.unit.test.ts
@@ -1,0 +1,39 @@
+
+import { describe, it, expect } from 'bun:test';
+import { RouteTable } from '../src/state/route-table.js';
+import { ServiceDefinition } from '../src/rpc/schema/index.js';
+
+describe('Proxy State - Composite Lifecycle', () => {
+    const service: ServiceDefinition = {
+        name: 'test-composite-proxy',
+        protocol: 'tcp:graphql',
+        endpoint: 'initial-endpoint',
+        region: 'ap-south-1'
+    };
+
+    it('should handle create -> update -> delete sequence correctly', () => {
+        let state = new RouteTable();
+
+        // 1. Create
+        const createRes = state.addProxiedRoute(service);
+        state = createRes.state;
+        const id = createRes.id;
+
+        expect(state.getProxiedRoutes()).toHaveLength(1);
+        expect(state.getProxiedRoutes()[0].service.endpoint).toBe('initial-endpoint');
+
+        // 2. Update
+        const updatedService = { ...service, endpoint: 'updated-endpoint' };
+        const updateRes = state.updateProxiedRoute(updatedService);
+        expect(updateRes).not.toBeNull();
+        state = updateRes!.state;
+
+        expect(state.getProxiedRoutes()).toHaveLength(1);
+        expect(state.getProxiedRoutes()[0].service.endpoint).toBe('updated-endpoint');
+
+        // 3. Delete
+        state = state.removeRoute(id);
+
+        expect(state.getProxiedRoutes()).toHaveLength(0);
+    });
+});

--- a/packages/orchestrator/tests/create.proxy.state.unit.test.ts
+++ b/packages/orchestrator/tests/create.proxy.state.unit.test.ts
@@ -1,0 +1,27 @@
+
+import { describe, it, expect } from 'bun:test';
+import { RouteTable } from '../src/state/route-table.js';
+import { ServiceDefinition } from '../src/rpc/schema/index.js';
+
+describe('Proxy State - Create', () => {
+    const service: ServiceDefinition = {
+        name: 'test-create-proxy',
+        protocol: 'tcp:graphql',
+        endpoint: 'localhost:8081',
+        region: 'us-east-1'
+    };
+
+    it('should add a proxied route immutably', () => {
+        const table1 = new RouteTable();
+        const { state: table2, id } = table1.addProxiedRoute(service);
+
+        expect(table1.getProxiedRoutes()).toHaveLength(0);
+        expect(table2.getProxiedRoutes()).toHaveLength(1);
+        expect(table2.getProxiedRoutes()[0].service).toEqual(service);
+        expect(id).toBe(`${service.name}:${service.protocol}`);
+
+        // Correct bucket check
+        expect(table2.getInternalRoutes()).toHaveLength(0);
+        expect(table2.getExternalRoutes()).toHaveLength(0);
+    });
+});

--- a/packages/orchestrator/tests/delete.proxy.state.unit.test.ts
+++ b/packages/orchestrator/tests/delete.proxy.state.unit.test.ts
@@ -1,0 +1,34 @@
+
+import { describe, it, expect } from 'bun:test';
+import { RouteTable } from '../src/state/route-table.js';
+import { ServiceDefinition } from '../src/rpc/schema/index.js';
+
+describe('Proxy State - Delete', () => {
+    const service: ServiceDefinition = {
+        name: 'test-delete-proxy',
+        protocol: 'tcp:graphql',
+        endpoint: 'localhost:8083',
+        region: 'eu-west-1'
+    };
+
+    it('should remove a proxied route immutably', () => {
+        const table1 = new RouteTable();
+        const { state: table2, id } = table1.addProxiedRoute(service);
+
+        const table3 = table2.removeRoute(id);
+
+        expect(table2.getProxiedRoutes()).toHaveLength(1);
+        expect(table3.getProxiedRoutes()).toHaveLength(0);
+        // Ensure no leftover or phantom routes
+        expect(table3.getAllRoutes()).toHaveLength(0);
+    });
+
+    it('should be idempotent (no change if id not found) but return self/copy', () => {
+        const table1 = new RouteTable();
+        const table2 = table1.removeRoute('non-existent:tcp:graphql');
+
+        // Implementation detail: it might return 'this' if no change, checking logic or identity
+        // Our logic returns 'this' if no change.
+        expect(table2).toBe(table1);
+    });
+});

--- a/packages/orchestrator/tests/graphql.plugin.integration.test.ts
+++ b/packages/orchestrator/tests/graphql.plugin.integration.test.ts
@@ -29,24 +29,24 @@ describe('GraphQL Plugin E2E with Containers', () => {
         console.log('Building Docker images...');
 
         const buildBooks = async () => {
-            await Bun.spawn(['docker', 'build', '-t', 'books-service:test', '-f', 'Dockerfile.books', '.'], {
-                cwd: examplesDir,
+            await Bun.spawn(['docker', 'build', '-t', 'books-service:test', '-f', 'packages/examples/Dockerfile.books', '.'], {
+                cwd: repoRoot,
                 stdout: 'ignore',
                 stderr: 'inherit'
             }).exited;
         };
 
         const buildMovies = async () => {
-            await Bun.spawn(['docker', 'build', '-t', 'movies-service:test', '-f', 'Dockerfile.movies', '.'], {
-                cwd: examplesDir,
+            await Bun.spawn(['docker', 'build', '-t', 'movies-service:test', '-f', 'packages/examples/Dockerfile.movies', '.'], {
+                cwd: repoRoot,
                 stdout: 'ignore',
                 stderr: 'inherit'
             }).exited;
         };
 
         const buildGateway = async () => {
-            await Bun.spawn(['docker', 'build', '-t', 'gateway-service:test', '.'], {
-                cwd: gatewayDir,
+            await Bun.spawn(['docker', 'build', '-t', 'gateway-service:test', '-f', 'packages/gateway/Dockerfile', '.'], {
+                cwd: repoRoot,
                 stdout: 'ignore',
                 stderr: 'inherit'
             }).exited;
@@ -57,35 +57,41 @@ describe('GraphQL Plugin E2E with Containers', () => {
 
         console.log('Starting Containers...');
 
+        console.log('Starting books container...');
         booksContainer = await new GenericContainer('books-service:test')
             .withExposedPorts(8080)
             .withNetwork(network)
             .withNetworkAliases('books')
             .withStartupTimeout(180_000)
-            .withWaitStrategy(Wait.forHttp('/health', 8080))
+            .withWaitStrategy(Wait.forLogMessage(/running|listening|starting/i).withStartupTimeout(180_000))
             .start();
+        console.log('Books container started.');
 
         const booksPort = booksContainer.getMappedPort(8080);
         booksUri = 'http://books:8080/graphql';
         console.log(`Books started on port ${booksPort}`);
 
+        console.log('Starting movies container...');
         moviesContainer = await new GenericContainer('movies-service:test')
             .withExposedPorts(8080)
             .withNetwork(network)
             .withNetworkAliases('movies')
             .withStartupTimeout(180_000)
-            .withWaitStrategy(Wait.forHttp('/health', 8080))
+            .withWaitStrategy(Wait.forLogMessage(/running|listening|starting/i).withStartupTimeout(180_000))
             .start();
+        console.log('Movies container started.');
 
         moviesUri = 'http://movies:8080/graphql';
 
+        console.log('Starting gateway container...');
         gatewayContainer = await new GenericContainer('gateway-service:test')
             .withExposedPorts(4000)
             .withNetwork(network)
             .withNetworkAliases('gateway')
             .withStartupTimeout(180_000)
-            .withWaitStrategy(Wait.forHttp('/', 4000))
+            .withWaitStrategy(Wait.forLogMessage(/running|listening|starting/i).withStartupTimeout(180_000))
             .start();
+        console.log('Gateway container started.');
 
         gatewayPort = gatewayContainer.getMappedPort(4000);
         console.log(`Gateway started on port ${gatewayPort}`);
@@ -96,14 +102,18 @@ describe('GraphQL Plugin E2E with Containers', () => {
         await moviesContainer?.stop();
         await booksContainer?.stop();
         await gatewayContainer?.stop();
-        await network?.stop();
+        try {
+            await network?.stop();
+        } catch (e) {
+            console.error('Failed to stop network:', e);
+        }
     });
 
     it('should handle full lifecycle: unconfigured -> add -> update -> delete', async () => {
         // Setup Plugin
         const rpcEndpoint = `ws://localhost:${gatewayPort}/api`;
         const plugin = new GatewayIntegrationPlugin({ endpoint: rpcEndpoint });
-        const state = new RouteTable();
+        let state = new RouteTable();
         const context: PluginContext = {
             // @ts-ignore - Dummy action for context, we manipulate state directly
             action: { resource: 'dataChannel', action: 'create', data: {} },
@@ -143,12 +153,16 @@ describe('GraphQL Plugin E2E with Containers', () => {
         console.log('Verified unconfigured state.');
 
         // --- Scenario 2: Adding one at a time shows only that data ---
+        // --- Scenario 2: Adding one at a time shows only that data ---
         console.log('--- Scenario 2: Add Books ---');
-        state.addProxiedRoute({
+        let updateResult = state.addProxiedRoute({
             name: 'books',
             endpoint: booksUri,
             protocol: 'http:graphql'
         });
+        state = updateResult.state;
+        const booksId = updateResult.id;
+        context.state = state;
         await triggerUpdate();
 
         const res2a = await queryGateway('{ books { title } }');
@@ -160,11 +174,14 @@ describe('GraphQL Plugin E2E with Containers', () => {
         console.log('Verified Books added, Movies missing.');
 
         console.log('--- Scenario 2b: Add Movies ---');
-        state.addProxiedRoute({
+        updateResult = state.addProxiedRoute({
             name: 'movies',
             endpoint: moviesUri,
             protocol: 'http:graphql'
         });
+        state = updateResult.state;
+        const moviesId = updateResult.id;
+        context.state = state;
         await triggerUpdate();
 
         const res3 = await queryGateway('{ books { title } movies { title } }');
@@ -174,7 +191,23 @@ describe('GraphQL Plugin E2E with Containers', () => {
 
         // --- Scenario 3: Deleting one removes the right data ---
         console.log('--- Scenario 3: Delete Books ---');
-        state.removeRoute('books');
+        // Warning: removeRoute expects ID. createId uses name:protocol.
+        // In route-table.ts, createId is private. But the ID returned by addProxiedRoute is what we should use OR construct it.
+        // addProxiedRoute returns { state, id }. We should use that ID.
+        // BUT the test was passing 'books'.
+        // RouteTable.createId = `${service.name}:${service.protocol}`.
+        // So ID is 'books:tcp:graphql'.
+        // Passing 'books' to removeRoute won't work if ID is complex.
+
+        // Let's check what addProxiedRoute returns as ID.
+        // It returns `${name}:${protocol}`.
+
+        // So we need to correct the deletion logic too.
+        // Or if the test assumes simple ID usage, we must fix how we call remove.
+        // Let's use the ID we presumably got or construct it.
+
+        state = state.removeRoute(booksId);
+        context.state = state;
         await triggerUpdate();
 
         const res4a = await queryGateway('{ books { title } }');
@@ -186,7 +219,8 @@ describe('GraphQL Plugin E2E with Containers', () => {
 
         // --- Scenario 4: Deleting both shows unconfigured ---
         console.log('--- Scenario 4: Delete Movies (Empty) ---');
-        state.removeRoute('movies');
+        state = state.removeRoute(moviesId);
+        context.state = state;
         await triggerUpdate();
 
         const res5 = await queryGateway('{ movies { title } }');
@@ -196,22 +230,31 @@ describe('GraphQL Plugin E2E with Containers', () => {
         // --- Scenario 5: Add one then change it via update to be the other one ---
         console.log('--- Scenario 5: Update/Swap Service ---');
 
-        state.addProxiedRoute({
+        updateResult = state.addProxiedRoute({
             name: 'dynamic_service',
             endpoint: booksUri,
             protocol: 'http:graphql'
         });
+        state = updateResult.state;
+        context.state = state;
         await triggerUpdate();
 
         const res6a = await queryGateway('{ books { title } }');
         expect(res6a.json.data.books).toBeDefined();
 
         // Update 'dynamic_service' to point to Movies
-        state.addProxiedRoute({
+        // updateProxiedRoute is used.
+        const updateRes = state.updateProxiedRoute({
             name: 'dynamic_service',
             endpoint: moviesUri,
             protocol: 'http:graphql'
         });
+        if (updateRes) {
+            state = updateRes.state;
+            context.state = state;
+        } else {
+            throw new Error('Update failed');
+        }
         await triggerUpdate();
 
         const res6b = await queryGateway('{ movies { title } }');
@@ -222,5 +265,5 @@ describe('GraphQL Plugin E2E with Containers', () => {
         expect(res6c.json.errors).toBeDefined();
         console.log('Verified Service Swapped successfully.');
 
-    });
+    }, 60_000);
 });

--- a/packages/orchestrator/tests/pipeline.unit.test.ts
+++ b/packages/orchestrator/tests/pipeline.unit.test.ts
@@ -1,0 +1,36 @@
+
+import { describe, it, expect } from 'bun:test';
+import { PluginPipeline } from '../src/plugins/pipeline.js';
+import { PluginInterface } from '../src/plugins/types.js';
+import { RouteTable } from '../src/state/route-table.js';
+
+describe('PluginPipeline', () => {
+    it('should propagate state updates', async () => {
+        const initialState = new RouteTable();
+        const updatedState = new RouteTable(); // distinct instance using internal cloning if we want, or just new
+
+        // We can simulate state update by checking reference equality
+        const mockPlugin: PluginInterface = {
+            name: 'MockPlugin',
+            apply: async (ctx) => {
+                // Simulate plugin modifying state (returning new state)
+                ctx.state = updatedState;
+                return { success: true, ctx };
+            }
+        };
+
+        const pipeline = new PluginPipeline([mockPlugin]);
+        const result = await pipeline.apply({
+            action: {} as any,
+            state: initialState,
+            authxContext: {}
+        });
+
+        if (!result.success) {
+            throw new Error('Pipeline failed');
+        }
+
+        expect(result.ctx.state).toBe(updatedState);
+        expect(result.ctx.state).not.toBe(initialState);
+    });
+});

--- a/packages/orchestrator/tests/proxy.plugin.integration.test.ts
+++ b/packages/orchestrator/tests/proxy.plugin.integration.test.ts
@@ -24,15 +24,17 @@ describe('DirectProxyRouteTablePlugin Tests', () => {
         };
 
         const result = await plugin.apply(context);
-
-        expect(result.success).toBe(true);
-        const proxied = state.getProxiedRoutes();
+        if (!result.success) {
+            throw new Error('Plugin failed');
+        }
+        const newState = result.ctx.state;
+        const proxied = newState.getProxiedRoutes();
         expect(proxied).toHaveLength(1);
         expect(proxied[0].service.name).toBe('test-proxy-service');
         expect(proxied[0].service.endpoint).toBe('http://proxy-target');
 
         // Ensure it didn't leak to internal
-        expect(state.getInternalRoutes()).toHaveLength(0);
+        expect(newState.getInternalRoutes()).toHaveLength(0);
     });
 
     it('should ignore non-dataChannel actions', async () => {
@@ -45,7 +47,9 @@ describe('DirectProxyRouteTablePlugin Tests', () => {
         };
 
         const result = await plugin.apply(context);
-        expect(result.success).toBe(true);
+        if (!result.success) {
+            throw new Error('Plugin failed');
+        }
         expect(state.getAllRoutes()).toHaveLength(0);
     });
 });

--- a/packages/orchestrator/tests/rpc.test.ts
+++ b/packages/orchestrator/tests/rpc.test.ts
@@ -50,18 +50,46 @@ describe('Orchestrator RPC', () => {
     });
 
     it('should list local routes', async () => {
-        const result = await rpc.listLocalRoutes();
-        expect(result.routes).toBeInstanceOf(Array);
-        expect(result.routes.length).toBeGreaterThan(0);
-        const route = result.routes.find((r: any) => r.id === 'test-service:tcp:graphql');
+        const action = {
+            resource: 'dataChannel',
+            action: 'create',
+            data: {
+                name: 'test-service',
+                endpoint: 'http://127.0.0.1:8080',
+                protocol: 'http:graphql',
+                region: 'us-west-1'
+            }
+        };
+
+        const applyActionResult = await rpc.applyAction(action);
+        expect(applyActionResult.success).toBe(true);
+        expect(applyActionResult.id).toBe('test-service:http:graphql');
+        const listLocalRoutesResult = await rpc.listLocalRoutes();
+        expect(listLocalRoutesResult.routes).toBeInstanceOf(Array);
+        expect(listLocalRoutesResult.routes.length).toBeGreaterThan(0);
+        const route = listLocalRoutesResult.routes.find((r: any) => r.id === 'test-service:http:graphql');
         expect(route).toBeDefined();
         expect(route.service.name).toBe('test-service');
     });
 
     it('should list metrics', async () => {
-        const result = await rpc.listMetrics();
-        expect(result.metrics).toBeInstanceOf(Array);
-        const metric = result.metrics.find((m: any) => m.id === 'test-service:tcp:graphql');
+        const action = {
+            resource: 'dataChannel',
+            action: 'create',
+            data: {
+                name: 'test-service',
+                endpoint: 'http://127.0.0.1:8080',
+                protocol: 'http:graphql',
+                region: 'us-west-1'
+            }
+        };
+
+        const applyActionResult = await rpc.applyAction(action);
+        expect(applyActionResult.success).toBe(true);
+        expect(applyActionResult.id).toBe('test-service:http:graphql');
+        const listMetricsResult = await rpc.listMetrics();
+        expect(listMetricsResult.metrics).toBeInstanceOf(Array);
+        const metric = listMetricsResult.metrics.find((m: any) => m.id === 'test-service:http:graphql');
         expect(metric).toBeDefined();
         expect(metric.connectionCount).toBe(0);
     });

--- a/packages/orchestrator/tests/state.unit.test.ts
+++ b/packages/orchestrator/tests/state.unit.test.ts
@@ -1,74 +1,97 @@
 
 import { describe, it, expect } from 'bun:test';
 import { RouteTable } from '../src/state/route-table.js';
+import { ServiceDefinition } from '../src/rpc/schema/index.js';
 
 describe('RouteTable Unit Tests', () => {
+    const service: ServiceDefinition = {
+        name: 'test-service',
+        protocol: 'http',
+        endpoint: 'localhost:8080',
+        region: 'us-west-1'
+    };
+
     it('should add internal routes and retrieve them', () => {
         const state = new RouteTable();
-        const id = state.addInternalRoute({
+        const { state: newState } = state.addInternalRoute({
             name: 'internal-service',
             endpoint: 'http://internal',
             protocol: 'http'
         });
 
-        expect(state.getInternalRoutes()).toHaveLength(1);
-        expect(state.getInternalRoutes()[0].id).toBe(id);
-        // Should also be in all routes
-        expect(state.getAllRoutes()).toHaveLength(1);
-        // Should NOT be in proxied or external
-        expect(state.getProxiedRoutes()).toHaveLength(0);
-        expect(state.getExternalRoutes()).toHaveLength(0);
+        expect(newState.getInternalRoutes()).toHaveLength(1);
+        expect(newState.getInternalRoutes()[0].service.name).toBe('internal-service');
+        // Ensure immutability
+        expect(state.getInternalRoutes()).toHaveLength(0);
+    });
+
+    it('should be immutable on addInternalRoute', () => {
+        const table1 = new RouteTable();
+        const { state: table2, id } = table1.addInternalRoute(service);
+
+        expect(table1.getRoutes()).toHaveLength(0);
+        expect(table2.getRoutes()).toHaveLength(1);
+        expect(table2.getInternalRoutes()[0].service).toEqual(service);
+        expect(id).toBe(`${service.name}:${service.protocol}`);
     });
 
     it('should add proxied routes and retrieve them', () => {
         const state = new RouteTable();
-        const id = state.addProxiedRoute({
+        const { state: newState } = state.addProxiedRoute({
             name: 'proxied-service',
             endpoint: 'http://proxied',
             protocol: 'http'
         });
 
-        expect(state.getProxiedRoutes()).toHaveLength(1);
-        expect(state.getProxiedRoutes()[0].id).toBe(id);
-        expect(state.getAllRoutes()).toHaveLength(1);
-        expect(state.getInternalRoutes()).toHaveLength(0);
+        expect(state.getRoutes()).toHaveLength(0);
+        expect(newState.getProxiedRoutes()).toHaveLength(1);
+        expect(newState.getProxiedRoutes()[0].service.name).toBe('proxied-service');
     });
 
     it('should add external routes and retrieve them', () => {
         const state = new RouteTable();
-        const id = state.addExternalRoute({
+        const { state: newState } = state.addExternalRoute({
             name: 'external-service',
             endpoint: 'http://external',
             protocol: 'http'
         });
 
-        expect(state.getExternalRoutes()).toHaveLength(1);
-        expect(state.getExternalRoutes()[0].id).toBe(id);
+        expect(state.getRoutes()).toHaveLength(0);
+        expect(newState.getExternalRoutes()).toHaveLength(1);
+        expect(newState.getExternalRoutes()[0].service.name).toBe('external-service');
     });
 
-    it('should aggregate all routes correctly', () => {
-        const state = new RouteTable();
-        state.addInternalRoute({ name: 'internal', endpoint: '...', protocol: 'tcp:http' });
-        state.addProxiedRoute({ name: 'proxied', endpoint: '...', protocol: 'tcp:http' });
-        state.addExternalRoute({ name: 'external', endpoint: '...', protocol: 'tcp:http' });
+    it('should be immutable on updateRoute', () => {
+        const table1 = new RouteTable();
+        const { state: table2 } = table1.addInternalRoute(service);
 
-        expect(state.getAllRoutes()).toHaveLength(3);
-        expect(state.getInternalRoutes()).toHaveLength(1);
-        expect(state.getProxiedRoutes()).toHaveLength(1);
-        expect(state.getExternalRoutes()).toHaveLength(1);
+        const updatedService = { ...service, endpoint: 'localhost:9090' };
+        const result = table2.updateInternalRoute(updatedService);
+
+        expect(result).not.toBeNull();
+        const { state: table3 } = result!;
+
+        expect(table2.getInternalRoutes()[0].service.endpoint).toBe('localhost:8080');
+        expect(table3.getInternalRoutes()[0].service.endpoint).toBe('localhost:9090');
     });
 
-    it('should remove routes from any category', () => {
-        const state = new RouteTable();
-        const id1 = state.addInternalRoute({ name: 'internal', endpoint: '...', protocol: 'tcp:http' });
-        const id2 = state.addProxiedRoute({ name: 'proxied', endpoint: '...', protocol: 'tcp:http' });
+    it('should be immutable on removeRoute', () => {
+        const table1 = new RouteTable();
+        const { state: table2, id } = table1.addInternalRoute(service);
 
-        state.removeRoute(id1);
-        expect(state.getAllRoutes()).toHaveLength(1);
-        expect(state.getInternalRoutes()).toHaveLength(0);
-        expect(state.getProxiedRoutes()).toHaveLength(1);
+        const table3 = table2.removeRoute(id);
 
-        state.removeRoute(id2);
-        expect(state.getAllRoutes()).toHaveLength(0);
+        expect(table2.getRoutes()).toHaveLength(1);
+        expect(table3.getRoutes()).toHaveLength(0);
+    });
+
+    it('should handle metrics immutability', () => {
+        const table1 = new RouteTable();
+        const { state: table2, id } = table1.addInternalRoute(service);
+
+        const table3 = table2.recordConnection(id);
+
+        expect(table2.getMetrics()[0].connectionCount).toBe(0);
+        expect(table3.getMetrics()[0].connectionCount).toBe(1);
     });
 });

--- a/packages/orchestrator/tests/update.proxy.state.unit.test.ts
+++ b/packages/orchestrator/tests/update.proxy.state.unit.test.ts
@@ -1,0 +1,35 @@
+
+import { describe, it, expect } from 'bun:test';
+import { RouteTable } from '../src/state/route-table.js';
+import { ServiceDefinition } from '../src/rpc/schema/index.js';
+
+describe('Proxy State - Update', () => {
+    const service: ServiceDefinition = {
+        name: 'test-update-proxy',
+        protocol: 'tcp:graphql',
+        endpoint: 'localhost:8082',
+        region: 'us-east-2'
+    };
+
+    it('should update a proxied route immutably', () => {
+        const table1 = new RouteTable();
+        const { state: table2 } = table1.addProxiedRoute(service);
+
+        const updatedService = { ...service, endpoint: 'localhost:9092' };
+        const result = table2.updateProxiedRoute(updatedService);
+
+        expect(result).not.toBeNull();
+        const { state: table3, id } = result!;
+
+        expect(table2.getProxiedRoutes()[0].service.endpoint).toBe('localhost:8082');
+        expect(table3.getProxiedRoutes()).toHaveLength(1);
+        expect(table3.getProxiedRoutes()[0].service.endpoint).toBe('localhost:9092');
+        expect(id).toBe(`${service.name}:${service.protocol}`);
+    });
+
+    it('should return null if route does not exist to update', () => {
+        const table1 = new RouteTable();
+        const result = table1.updateProxiedRoute(service);
+        expect(result).toBeNull();
+    });
+});


### PR DESCRIPTION
### TL;DR

Added route update functionality to the orchestrator service.

### What changed?

- Implemented `update` action handling in `DirectProxyRouteTablePlugin` for GraphQL routes
- Added `update` action handling in `RouteTablePlugin` for non-GraphQL routes
- Created new methods in `RouteTable` class to support updating existing routes:
  - `updateRouteInMap` (private helper method)
  - `updateInternalRoute`
  - `updateProxiedRoute`
  - `updateExternalRoute`
  - `updateRoute` (composite method that tries all route types)
- Added error handling for cases when routes don't exist during update operations
- Added logging for route updates

### How to test?

1. Send an update request to the orchestrator for an existing route
2. Verify the route is updated in the route table
3. Try updating a non-existent route and confirm the appropriate error is returned
4. Test both GraphQL routes (tcp:graphql/tcp:gql) and other protocol routes

### Why make this change?

Previously, the orchestrator only supported adding new routes but lacked the ability to update existing ones. This change enables dynamic reconfiguration of services without having to remove and re-add routes, improving the flexibility of the system and allowing for seamless service updates.