### PR TITLE
feat: add delete handler for service registration

### DIFF
--- a/packages/orchestrator/src/plugins/implementations/proxy-route.ts
+++ b/packages/orchestrator/src/plugins/implementations/proxy-route.ts
@@ -50,6 +50,11 @@ export class DirectProxyRouteTablePlugin extends BasePlugin {
                         };
                     }
                 }
+            } else if (action.action === 'delete') {
+                // Delete works for all route types - removeRoute checks all maps
+                const id = action.data.id;
+                state.removeRoute(id);
+                context.result = { ...context.result, id };
             }
         }
 

--- a/packages/orchestrator/src/plugins/implementations/routing.ts
+++ b/packages/orchestrator/src/plugins/implementations/routing.ts
@@ -50,6 +50,11 @@ export class RouteTablePlugin extends BasePlugin {
                         }
                     };
                 }
+            } else if (action.action === 'delete') {
+                // Delete works for all route types - removeRoute checks all maps
+                const id = action.data.id;
+                state.removeRoute(id);
+                context.result = { ...context.result, id };
             }
         }
 


### PR DESCRIPTION
### TL;DR

Added support for deleting routes in proxy and routing plugins.

### What changed?

- Added a new `delete` action handler in both `DirectProxyRouteTablePlugin` and `RouteTablePlugin` classes
- The implementation removes routes by ID from the state using the `removeRoute` method
- After deletion, the route ID is included in the context result

### How to test?

1. Create a route using either the proxy or routing plugin
2. Send a delete action with the route ID in the data payload
3. Verify that the route is removed from the state
4. Confirm that the response includes the deleted route ID

### Why make this change?

Previously, the plugins only supported adding routes but lacked the ability to remove them. This change completes the CRUD operations by implementing the delete functionality, allowing for better route management and cleanup.