### PR TITLE
fix: enums for udp, tcp, http, graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,17 @@ The "muscle" of the node.
 *   **Decentralized**: No single point of failure or control.
 *   **Plugin-Driven**: Extensible architecture for defining custom behaviors for routing, local services, and propagation.
 *   **Local Services**: Easily spin up and advertise local resources (e.g., VPN clients, GraphQL federations) as network services.
+
+## Protocol Support
+
+We support a variety of protocols for service definitions. Currently, **GraphQL** receives first-class support for federation.
+
+| Protocol | Status | Notes |
+| :--- | :--- | :--- |
+| `tcp` | ✅ Stabilized | Generic TCP tunneling |
+| `udp` | ✅ Stabilized | Generic UDP tunneling |
+| `http` | 🚧 Beta | Generic HTTP proxying |
+| `http:graphql` | ✅ Live | Fully federated GraphQL support |
+| `http:gql` | ✅ Live | Alias for `http:graphql` |
+| `http:grpc` | 🗓️ Planned | gRPC transcoding and routing |
+

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -55,7 +55,7 @@ export function serviceCommands() {
         .description('Register a new service')
         .argument('<name>', 'Service name')
         .argument('<endpoint>', 'Service endpoint URL')
-        .option('-p, --protocol <protocol>', 'Service protocol', 'tcp:graphql')
+        .option('-p, --protocol <protocol>', 'Service protocol', 'http:graphql')
         .action(async (name, endpoint, options) => {
             const result = await addService({ name, endpoint, protocol: options.protocol });
 

--- a/packages/cli/tests/service.integration.test.ts
+++ b/packages/cli/tests/service.integration.test.ts
@@ -143,7 +143,7 @@ describe('CLI E2E with Containers', () => {
         const addRes1 = await addService({
             name: 'books',
             endpoint: booksUri,
-            protocol: 'tcp:graphql'
+            protocol: 'http:graphql'
         });
         expect(addRes1.success).toBe(true);
 
@@ -162,7 +162,7 @@ describe('CLI E2E with Containers', () => {
         const addRes2 = await addService({
             name: 'movies',
             endpoint: moviesUri,
-            protocol: 'tcp:graphql'
+            protocol: 'http:graphql'
         });
         expect(addRes2.success).toBe(true);
 

--- a/packages/cli/tests/service.unit.test.ts
+++ b/packages/cli/tests/service.unit.test.ts
@@ -34,7 +34,7 @@ describe('Service Commands', () => {
 
     describe('addService', () => {
         it('should add a service successfully', async () => {
-            const result = await addService({ name: 'test-service', endpoint: 'http://localhost:8080', protocol: 'tcp:graphql' });
+            const result = await addService({ name: 'test-service', endpoint: 'http://localhost:8080', protocol: 'http:graphql' });
             expect(result.success).toBe(true);
             expect(mockApplyAction).toHaveBeenCalled();
             const lastCall = mockApplyAction.mock.calls[0][0];
@@ -44,14 +44,14 @@ describe('Service Commands', () => {
                 data: {
                     name: 'test-service',
                     endpoint: 'http://localhost:8080',
-                    protocol: 'tcp:graphql'
+                    protocol: 'http:graphql'
                 }
             });
         });
 
         it('should handle failure when adding service', async () => {
             mockApplyAction.mockImplementationOnce(() => Promise.resolve({ success: false, error: 'Failed' }));
-            const result = await addService({ name: 'fail', endpoint: 'err', protocol: 'tcp:graphql' });
+            const result = await addService({ name: 'fail', endpoint: 'err', protocol: 'http:graphql' });
             expect(result.success).toBe(false);
             if (!result.success) { // logic check
                 expect(result.error).toBe('Failed');
@@ -60,7 +60,7 @@ describe('Service Commands', () => {
 
         it('should handle connection errors', async () => {
             mockCreateClient.mockRejectedValueOnce(new Error('Connect Error'));
-            const result = await addService({ name: 'fail', endpoint: 'err', protocol: 'tcp:graphql' });
+            const result = await addService({ name: 'fail', endpoint: 'err', protocol: 'http:graphql' });
             expect(result.success).toBe(false);
             if (!result.success) {
                 expect(result.error).toContain('Connect Error');

--- a/packages/orchestrator/README.md
+++ b/packages/orchestrator/README.md
@@ -114,7 +114,7 @@ Use the Catalyst CLI or an RPC client to register your GraphQL service:
   "data": {
     "name": "books",
     "endpoint": "http://books-service:8080/graphql",
-    "protocol": "tcp:graphql"
+    "protocol": "http:graphql" // or 'http:gql'
   }
 }
 ```

--- a/packages/orchestrator/src/plugins/implementations/gateway.ts
+++ b/packages/orchestrator/src/plugins/implementations/gateway.ts
@@ -25,7 +25,7 @@ export class GatewayIntegrationPlugin extends BasePlugin {
         const services = state.getAllRoutes()
             .map(r => r.service) // Extract ServiceDefinition
             // Filter strictly for GraphQL protocols.
-            .filter(s => s.endpoint && (s.protocol === 'tcp:graphql' || s.protocol === 'tcp:gql'))
+            .filter(s => s.endpoint && (s.protocol === 'http:graphql' || s.protocol === 'http:gql'))
             .map(s => ({
                 name: s.name,
                 url: s.endpoint!,

--- a/packages/orchestrator/src/plugins/implementations/proxy-route.ts
+++ b/packages/orchestrator/src/plugins/implementations/proxy-route.ts
@@ -16,7 +16,7 @@ export class DirectProxyRouteTablePlugin extends BasePlugin {
 
                 // Add to Routes as Proxied - Only if protocol matches
                 const protocol = action.data.protocol;
-                if (protocol === 'tcp:graphql' || protocol === 'tcp:gql') {
+                if (protocol === 'http:graphql' || protocol === 'http:gql') {
                     state.addProxiedRoute({
                         name: action.data.name,
                         endpoint: action.data.endpoint!,

--- a/packages/orchestrator/src/plugins/implementations/routing.ts
+++ b/packages/orchestrator/src/plugins/implementations/routing.ts
@@ -14,7 +14,7 @@ export class RouteTablePlugin extends BasePlugin {
                 // Mutate the state (RouteTable) - Internal by default for this plugin
                 // Ignore Proxy protocols handled by DirectProxyRouteTablePlugin
                 const protocol = action.data.protocol;
-                if (protocol === 'tcp:graphql' || protocol === 'tcp:gql') {
+                if (protocol === 'http:graphql' || protocol === 'http:gql') {
                     return { success: true, ctx: context };
                 }
 

--- a/packages/orchestrator/src/rpc/schema/direct.ts
+++ b/packages/orchestrator/src/rpc/schema/direct.ts
@@ -1,7 +1,7 @@
 
 import { z } from 'zod';
 
-export const ServiceProtocolSchema = z.enum(['tcp', 'tcp:http', 'tcp:graphql', 'tcp:gql', 'tcp:grpc', 'udp']);
+export const ServiceProtocolSchema = z.enum(['tcp', 'udp', 'http', 'http:graphql', 'http:gql', 'http:grpc']);
 export type ServiceProtocol = z.infer<typeof ServiceProtocolSchema>;
 
 export const ServiceDefinitionSchema = z.object({

--- a/packages/orchestrator/tests/graphql.plugin.integration.test.ts
+++ b/packages/orchestrator/tests/graphql.plugin.integration.test.ts
@@ -147,7 +147,7 @@ describe('GraphQL Plugin E2E with Containers', () => {
         state.addProxiedRoute({
             name: 'books',
             endpoint: booksUri,
-            protocol: 'tcp:graphql'
+            protocol: 'http:graphql'
         });
         await triggerUpdate();
 
@@ -163,7 +163,7 @@ describe('GraphQL Plugin E2E with Containers', () => {
         state.addProxiedRoute({
             name: 'movies',
             endpoint: moviesUri,
-            protocol: 'tcp:graphql'
+            protocol: 'http:graphql'
         });
         await triggerUpdate();
 
@@ -199,7 +199,7 @@ describe('GraphQL Plugin E2E with Containers', () => {
         state.addProxiedRoute({
             name: 'dynamic_service',
             endpoint: booksUri,
-            protocol: 'tcp:graphql'
+            protocol: 'http:graphql'
         });
         await triggerUpdate();
 
@@ -210,7 +210,7 @@ describe('GraphQL Plugin E2E with Containers', () => {
         state.addProxiedRoute({
             name: 'dynamic_service',
             endpoint: moviesUri,
-            protocol: 'tcp:graphql'
+            protocol: 'http:graphql'
         });
         await triggerUpdate();
 

--- a/packages/orchestrator/tests/proxy.plugin.integration.test.ts
+++ b/packages/orchestrator/tests/proxy.plugin.integration.test.ts
@@ -15,7 +15,7 @@ describe('DirectProxyRouteTablePlugin Tests', () => {
                 data: {
                     name: 'test-proxy-service',
                     endpoint: 'http://proxy-target',
-                    protocol: 'tcp:http',
+                    protocol: 'http:graphql',
                     region: 'us-west'
                 }
             },

--- a/packages/orchestrator/tests/rpc.test.ts
+++ b/packages/orchestrator/tests/rpc.test.ts
@@ -39,14 +39,14 @@ describe('Orchestrator RPC', () => {
             data: {
                 name: 'test-service',
                 endpoint: 'http://127.0.0.1:8080',
-                protocol: 'tcp:graphql',
+                protocol: 'http:graphql',
                 region: 'us-west-1'
             }
         };
 
         const result = await rpc.applyAction(action);
         expect(result.success).toBe(true);
-        expect(result.id).toBe('test-service:tcp:graphql');
+        expect(result.id).toBe('test-service:http:graphql');
     });
 
     it('should list local routes', async () => {

--- a/packages/orchestrator/tests/state.unit.test.ts
+++ b/packages/orchestrator/tests/state.unit.test.ts
@@ -8,7 +8,7 @@ describe('RouteTable Unit Tests', () => {
         const id = state.addInternalRoute({
             name: 'internal-service',
             endpoint: 'http://internal',
-            protocol: 'tcp:http'
+            protocol: 'http'
         });
 
         expect(state.getInternalRoutes()).toHaveLength(1);
@@ -25,7 +25,7 @@ describe('RouteTable Unit Tests', () => {
         const id = state.addProxiedRoute({
             name: 'proxied-service',
             endpoint: 'http://proxied',
-            protocol: 'tcp:http'
+            protocol: 'http'
         });
 
         expect(state.getProxiedRoutes()).toHaveLength(1);
@@ -39,7 +39,7 @@ describe('RouteTable Unit Tests', () => {
         const id = state.addExternalRoute({
             name: 'external-service',
             endpoint: 'http://external',
-            protocol: 'tcp:http'
+            protocol: 'http'
         });
 
         expect(state.getExternalRoutes()).toHaveLength(1);


### PR DESCRIPTION
### TL;DR

Updated service protocol naming from `tcp:graphql` to `http:graphql` to better reflect the actual protocol being used, and added protocol support documentation.

### What changed?

- Changed the default GraphQL protocol from `tcp:graphql` to `http:graphql` throughout the codebase
- Added a new "Protocol Support" section to the main README.md with a table showing the status of supported protocols
- Updated all references to GraphQL protocols in tests, documentation, and implementation code
- Added support for `http:gql` as an alias for `http:graphql`
- Updated the ServiceProtocolSchema to include the new protocol naming conventions

### How to test?

1. Register a new GraphQL service using the updated protocol:
   ```
   catalyst service add my-graphql-service http://localhost:4000/graphql -p http:graphql
   ```
2. Verify that the service is properly registered and federated
3. Test with the alias protocol as well:
   ```
   catalyst service add another-service http://localhost:4001/graphql -p http:gql
   ```

### Why make this change?

The previous protocol naming (`tcp:graphql`) was misleading since GraphQL services typically run over HTTP, not directly over TCP. This change makes the protocol naming more accurate and consistent with the actual underlying transport protocol being used. The documentation addition also provides clarity on which protocols are supported and their current status.