### PR TITLE
fix: safe parsing added for cli

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,7 +9,9 @@ const program = new Command();
 program
     .name('catalyst')
     .description('Catalyst Node CLI')
-    .version(process.env.VERSION || '0.0.0-dev');
+    .version(process.env.VERSION || '0.0.0-dev')
+    .option('--orchestrator-url <url>', 'Orchestrator RPC URL', 'ws://localhost:3000/rpc')
+    .option('--log-level <level>', 'Log level', 'info');
 
 program.addCommand(serviceCommands());
 program.addCommand(metricsCommands());

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,3 +1,23 @@
+import { ServiceDefinitionSchema } from '@catalyst/orchestrator';
+import { z } from 'zod';
+
 export type CliResult<T> =
     | { success: true; data?: T }
     | { success: false; error: string };
+
+export const BaseCliConfigSchema = z.object({
+    orchestratorUrl: z.string().url().default('ws://localhost:3000/rpc'),
+    logLevel: z.enum(['debug', 'info', 'warn', 'error']).default('info')
+});
+export type BaseCliConfig = z.infer<typeof BaseCliConfigSchema>;
+
+export const AddServiceInputSchema = ServiceDefinitionSchema.pick({
+    name: true,
+    endpoint: true,
+    protocol: true
+}).merge(BaseCliConfigSchema);
+
+export type AddServiceInput = z.infer<typeof AddServiceInputSchema>;
+
+export const ListServicesInputSchema = BaseCliConfigSchema;
+export type ListServicesInput = z.infer<typeof ListServicesInputSchema>;

--- a/packages/cli/tests/service.unit.test.ts
+++ b/packages/cli/tests/service.unit.test.ts
@@ -34,7 +34,13 @@ describe('Service Commands', () => {
 
     describe('addService', () => {
         it('should add a service successfully', async () => {
-            const result = await addService({ name: 'test-service', endpoint: 'http://localhost:8080', protocol: 'http:graphql' });
+            const result = await addService({
+                name: 'test-service',
+                endpoint: 'http://localhost:8080',
+                protocol: 'http:graphql',
+                orchestratorUrl: 'ws://localhost:3000/rpc',
+                logLevel: 'info'
+            });
             expect(result.success).toBe(true);
             expect(mockApplyAction).toHaveBeenCalled();
             const lastCall = mockApplyAction.mock.calls[0][0];
@@ -51,7 +57,20 @@ describe('Service Commands', () => {
 
         it('should handle failure when adding service', async () => {
             mockApplyAction.mockImplementationOnce(() => Promise.resolve({ success: false, error: 'Failed' }));
-            const result = await addService({ name: 'fail', endpoint: 'err', protocol: 'http:graphql' });
+            const result = await addService({
+                name: 'fail',
+                endpoint: 'err', // Invalid URL but valid string type. Logic validation? Zod type enforces URL!
+                // Wait. 'err' is NOT a valid URL.
+                // If addService takes AddServiceInput, expecting VALID data.
+                // But in unit test I am bypassing Zod parser.
+                // So I pass manual object.
+                // If I pass 'err', and AddServiceInput.endpoint is `string`. It IS string.
+                // Zod "brand" types? No, just string.
+                // So TS allows 'err'.
+                protocol: 'http:graphql',
+                orchestratorUrl: 'ws://localhost:3000/rpc',
+                logLevel: 'info'
+            });
             expect(result.success).toBe(false);
             if (!result.success) { // logic check
                 expect(result.error).toBe('Failed');
@@ -60,7 +79,13 @@ describe('Service Commands', () => {
 
         it('should handle connection errors', async () => {
             mockCreateClient.mockRejectedValueOnce(new Error('Connect Error'));
-            const result = await addService({ name: 'fail', endpoint: 'err', protocol: 'http:graphql' });
+            const result = await addService({
+                name: 'fail',
+                endpoint: 'http://valid-url-for-this-test', // updated to avoid confusion, though logic is mocked
+                protocol: 'http:graphql',
+                orchestratorUrl: 'ws://localhost:3000/rpc',
+                logLevel: 'info'
+            });
             expect(result.success).toBe(false);
             if (!result.success) {
                 expect(result.error).toContain('Connect Error');
@@ -80,3 +105,29 @@ describe('Service Commands', () => {
         });
     });
 });
+
+describe('Validation Schema', () => {
+    const { AddServiceInputSchema } = require('../src/types.js'); // Lazy load if needed or imported at top
+
+    it('should validate correct input', () => {
+        const input = { name: 'valid', endpoint: 'http://valid.com', protocol: 'http:graphql' };
+        const result = AddServiceInputSchema.safeParse(input);
+        expect(result.success).toBe(true);
+    });
+
+    it('should fail on invalid url', () => {
+        const input = { name: 'valid', endpoint: 'not-a-url', protocol: 'http:graphql' };
+        const result = AddServiceInputSchema.safeParse(input);
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.issues[0].message).toContain('Invalid url');
+        }
+    });
+
+    it('should fail on invalid protocol', () => {
+        const input = { name: 'valid', endpoint: 'http://valid.com', protocol: 'invalid-proto' };
+        const result = AddServiceInputSchema.safeParse(input);
+        expect(result.success).toBe(false);
+    });
+});
+


### PR DESCRIPTION
### TL;DR

Added input validation and global configuration options to the CLI service commands.

### What changed?

- Added Zod schema validation for service command inputs
- Implemented global CLI options for `--orchestrator-url` and `--log-level`
- Updated `addService` and `listServices` functions to accept orchestrator URL parameter
- Created type definitions with Zod schemas for CLI inputs
- Enhanced error handling with better validation feedback
- Fixed service protocol handling in the add service command
- Added unit tests for the new validation schemas

### How to test?

1. Run the CLI with global options:
   ```
   catalyst --orchestrator-url ws://custom-host:3000/rpc --log-level debug service list
   ```

2. Test the add service command with validation:
   ```
   catalyst service add my-service http://my-service-endpoint.com --protocol http:graphql
   ```

3. Verify validation errors by providing invalid inputs:
   ```
   catalyst service add my-service invalid-url --protocol http:graphql
   ```

### Why make this change?

This change improves the CLI's usability by adding proper input validation and configuration options. Users can now specify custom orchestrator URLs and log levels globally, making the CLI more flexible for different environments. The added validation ensures that invalid inputs are caught early with clear error messages, preventing runtime errors when connecting to services.