### PR TITLE
feat: pivot back to functional

### DIFF
--- a/docker-compose/example.m0p2.compose.yaml
+++ b/docker-compose/example.m0p2.compose.yaml
@@ -1,8 +1,8 @@
 services:
   orchestrator:
     build:
-      context: ../packages/orchestrator
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: packages/orchestrator/Dockerfile
     ports:
       - "3000:3000"
     environment:
@@ -13,8 +13,8 @@ services:
 
   gateway:
     build:
-      context: ../packages/gateway
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: packages/gateway/Dockerfile
     ports:
       - "4000:4000"
     environment:
@@ -25,8 +25,8 @@ services:
 
   books-service:
     build:
-      context: ../packages/examples
-      dockerfile: Dockerfile.books
+      context: ..
+      dockerfile: packages/examples/Dockerfile.books
     ports:
       - "8081:8080"
     environment:
@@ -34,8 +34,8 @@ services:
 
   movies-service:
     build:
-      context: ../packages/examples
-      dockerfile: Dockerfile.movies
+      context: ..
+      dockerfile: packages/examples/Dockerfile.movies
     ports:
       - "8082:8080"
     environment:

--- a/packages/examples/Dockerfile.books
+++ b/packages/examples/Dockerfile.books
@@ -2,18 +2,19 @@ FROM oven/bun:1
 
 WORKDIR /app
 
-# Copy root package.json and lockfile (to utilize cache if possible, though overly simple here)
-# For simplicity in this monorepo context without complex pruning, we'll assume we can copy the packages/examples dir
-# Setup workspace context usually requires more, but for an isolated example container:
+# Copy root config
+COPY package.json bun.lockb ./
 
-# Copy the examples workspace
-COPY . .
+# Copy examples package
+COPY packages/examples packages/examples
+RUN rm -rf packages/examples/node_modules
 
-# Install dependencies (frozen-lockfile might fail if unrelated packages are missing, so we just install)
+# Install dependencies from root to handle workspace hoisting correctly
+WORKDIR /app
 RUN bun install
 
 # Expose port
 ENV PORT=8080
 EXPOSE 8080
 
-CMD ["bun", "run", "src/books/index.ts"]
+CMD ["bun", "run", "packages/examples/src/books/index.ts"]

--- a/packages/examples/Dockerfile.movies
+++ b/packages/examples/Dockerfile.movies
@@ -2,11 +2,18 @@ FROM oven/bun:1
 
 WORKDIR /app
 
-COPY . .
+# Copy root config
+COPY package.json bun.lockb ./
 
+# Copy examples package
+COPY packages/examples packages/examples
+RUN rm -rf packages/examples/node_modules
+
+# Install dependencies from root to handle workspace hoisting correctly
+WORKDIR /app
 RUN bun install
 
 ENV PORT=8080
 EXPOSE 8080
 
-CMD ["bun", "run", "src/movies/index.ts"]
+CMD ["bun", "run", "packages/examples/src/movies/index.ts"]

--- a/packages/gateway/Dockerfile
+++ b/packages/gateway/Dockerfile
@@ -1,16 +1,20 @@
-# Builder stage
-FROM oven/bun:1 AS builder
+# Runtime stage (use bun directly)
+FROM oven/bun:1
 WORKDIR /app
-COPY package.json ./
-RUN bun install
-COPY . .
-RUN bun build --compile --minify --outfile server src/index.ts
 
-# Runtime stage
-# We use distroless/base-nossl-debian12 for a minimal glibc image
-FROM gcr.io/distroless/base-nossl-debian12
-WORKDIR /app
-COPY --from=builder /app/server .
+# Copy root config
+COPY package.json bun.lockb ./
+
+# Copy source
+COPY packages/gateway packages/gateway
+
+# Remove host node_modules to avoid broken symlinks
+RUN rm -rf packages/gateway/node_modules
+
+# Install dependencies from root
+RUN bun install
+
+WORKDIR /app/packages/gateway
 ENV PORT=4000
 EXPOSE 4000
-CMD ["./server"]
+CMD ["bun", "run", "src/index.ts"]

--- a/packages/orchestrator/Dockerfile
+++ b/packages/orchestrator/Dockerfile
@@ -1,37 +1,19 @@
-FROM oven/bun:1 as base
+FROM oven/bun:1
+
 WORKDIR /app
 
-# Install dependencies into temp directory
-# This will cache them and speed up future builds
-FROM base AS install
-RUN mkdir -p /temp/dev
-COPY package.json /temp/dev/
-RUN cd /temp/dev && bun install
+# Copy root config
+COPY package.json bun.lockb ./
 
-# Install with --production (exclude devDependencies)
-RUN mkdir -p /temp/prod
-COPY package.json /temp/prod/
-RUN cd /temp/prod && bun install --production
+# Copy orchestrator package
+COPY packages/orchestrator packages/orchestrator
+RUN rm -rf packages/orchestrator/node_modules
 
-# Copy node_modules from temp directory
-# Then copy all (non-ignored) project files into the image
-FROM base AS prerelease
-COPY --from=install /temp/dev/node_modules node_modules
-COPY . .
+# Install dependencies
+WORKDIR /app/packages/orchestrator
+RUN bun install
 
-# [optional] tests & build
-ENV NODE_ENV=production
-# RUN bun test
-# RUN bun run build
+ENV PORT=3000
+EXPOSE 3000
 
-# copy production dependencies and source code into final image
-FROM base AS release
-COPY --from=install /temp/prod/node_modules node_modules
-COPY --from=prerelease /app/src src
-COPY --from=prerelease /app/package.json .
-COPY --from=prerelease /app/tsconfig.json .
-
-# run the app
-USER bun
-EXPOSE 3000/tcp
-ENTRYPOINT [ "bun", "run", "src/index.ts" ]
+CMD ["bun", "run", "src/index.ts"]

--- a/packages/orchestrator/src/plugins/implementations/routing.ts
+++ b/packages/orchestrator/src/plugins/implementations/routing.ts
@@ -18,12 +18,14 @@ export class RouteTablePlugin extends BasePlugin {
                     return { success: true, ctx: context };
                 }
 
-                const id = state.addInternalRoute({
+                const { state: newState, id } = state.addInternalRoute({
                     name: action.data.name,
                     endpoint: action.data.endpoint!,
                     protocol: action.data.protocol,
                     region: action.data.region
                 });
+
+                context.state = newState;
                 context.result = { ...context.result, id };
             } else if (action.action === 'update') {
                 // Ignore Proxy protocols handled by DirectProxyRouteTablePlugin
@@ -32,14 +34,16 @@ export class RouteTablePlugin extends BasePlugin {
                     return { success: true, ctx: context };
                 }
 
-                const id = state.updateInternalRoute({
+                const result = state.updateInternalRoute({
                     name: action.data.name,
                     endpoint: action.data.endpoint!,
                     protocol: action.data.protocol,
                     region: action.data.region
                 });
 
-                if (id) {
+                if (result) {
+                    const { state: newState, id } = result;
+                    context.state = newState;
                     context.result = { ...context.result, id };
                 } else {
                     return {
@@ -53,7 +57,8 @@ export class RouteTablePlugin extends BasePlugin {
             } else if (action.action === 'delete') {
                 // Delete works for all route types - removeRoute checks all maps
                 const id = action.data.id;
-                state.removeRoute(id);
+                const newState = state.removeRoute(id);
+                context.state = newState;
                 context.result = { ...context.result, id };
             }
         }

--- a/packages/orchestrator/tests/composite.proxy.state.unit.test.ts
+++ b/packages/orchestrator/tests/composite.proxy.state.unit.test.ts
@@ -1,0 +1,39 @@
+
+import { describe, it, expect } from 'bun:test';
+import { RouteTable } from '../src/state/route-table.js';
+import { ServiceDefinition } from '../src/rpc/schema/index.js';
+
+describe('Proxy State - Composite Lifecycle', () => {
+    const service: ServiceDefinition = {
+        name: 'test-composite-proxy',
+        protocol: 'tcp:graphql',
+        endpoint: 'initial-endpoint',
+        region: 'ap-south-1'
+    };
+
+    it('should handle create -> update -> delete sequence correctly', () => {
+        let state = new RouteTable();
+
+        // 1. Create
+        const createRes = state.addProxiedRoute(service);
+        state = createRes.state;
+        const id = createRes.id;
+
+        expect(state.getProxiedRoutes()).toHaveLength(1);
+        expect(state.getProxiedRoutes()[0].service.endpoint).toBe('initial-endpoint');
+
+        // 2. Update
+        const updatedService = { ...service, endpoint: 'updated-endpoint' };
+        const updateRes = state.updateProxiedRoute(updatedService);
+        expect(updateRes).not.toBeNull();
+        state = updateRes!.state;
+
+        expect(state.getProxiedRoutes()).toHaveLength(1);
+        expect(state.getProxiedRoutes()[0].service.endpoint).toBe('updated-endpoint');
+
+        // 3. Delete
+        state = state.removeRoute(id);
+
+        expect(state.getProxiedRoutes()).toHaveLength(0);
+    });
+});

--- a/packages/orchestrator/tests/create.proxy.state.unit.test.ts
+++ b/packages/orchestrator/tests/create.proxy.state.unit.test.ts
@@ -1,0 +1,27 @@
+
+import { describe, it, expect } from 'bun:test';
+import { RouteTable } from '../src/state/route-table.js';
+import { ServiceDefinition } from '../src/rpc/schema/index.js';
+
+describe('Proxy State - Create', () => {
+    const service: ServiceDefinition = {
+        name: 'test-create-proxy',
+        protocol: 'tcp:graphql',
+        endpoint: 'localhost:8081',
+        region: 'us-east-1'
+    };
+
+    it('should add a proxied route immutably', () => {
+        const table1 = new RouteTable();
+        const { state: table2, id } = table1.addProxiedRoute(service);
+
+        expect(table1.getProxiedRoutes()).toHaveLength(0);
+        expect(table2.getProxiedRoutes()).toHaveLength(1);
+        expect(table2.getProxiedRoutes()[0].service).toEqual(service);
+        expect(id).toBe(`${service.name}:${service.protocol}`);
+
+        // Correct bucket check
+        expect(table2.getInternalRoutes()).toHaveLength(0);
+        expect(table2.getExternalRoutes()).toHaveLength(0);
+    });
+});

--- a/packages/orchestrator/tests/delete.proxy.state.unit.test.ts
+++ b/packages/orchestrator/tests/delete.proxy.state.unit.test.ts
@@ -1,0 +1,34 @@
+
+import { describe, it, expect } from 'bun:test';
+import { RouteTable } from '../src/state/route-table.js';
+import { ServiceDefinition } from '../src/rpc/schema/index.js';
+
+describe('Proxy State - Delete', () => {
+    const service: ServiceDefinition = {
+        name: 'test-delete-proxy',
+        protocol: 'tcp:graphql',
+        endpoint: 'localhost:8083',
+        region: 'eu-west-1'
+    };
+
+    it('should remove a proxied route immutably', () => {
+        const table1 = new RouteTable();
+        const { state: table2, id } = table1.addProxiedRoute(service);
+
+        const table3 = table2.removeRoute(id);
+
+        expect(table2.getProxiedRoutes()).toHaveLength(1);
+        expect(table3.getProxiedRoutes()).toHaveLength(0);
+        // Ensure no leftover or phantom routes
+        expect(table3.getAllRoutes()).toHaveLength(0);
+    });
+
+    it('should be idempotent (no change if id not found) but return self/copy', () => {
+        const table1 = new RouteTable();
+        const table2 = table1.removeRoute('non-existent:tcp:graphql');
+
+        // Implementation detail: it might return 'this' if no change, checking logic or identity
+        // Our logic returns 'this' if no change.
+        expect(table2).toBe(table1);
+    });
+});

--- a/packages/orchestrator/tests/pipeline.unit.test.ts
+++ b/packages/orchestrator/tests/pipeline.unit.test.ts
@@ -1,0 +1,36 @@
+
+import { describe, it, expect } from 'bun:test';
+import { PluginPipeline } from '../src/plugins/pipeline.js';
+import { PluginInterface } from '../src/plugins/types.js';
+import { RouteTable } from '../src/state/route-table.js';
+
+describe('PluginPipeline', () => {
+    it('should propagate state updates', async () => {
+        const initialState = new RouteTable();
+        const updatedState = new RouteTable(); // distinct instance using internal cloning if we want, or just new
+
+        // We can simulate state update by checking reference equality
+        const mockPlugin: PluginInterface = {
+            name: 'MockPlugin',
+            apply: async (ctx) => {
+                // Simulate plugin modifying state (returning new state)
+                ctx.state = updatedState;
+                return { success: true, ctx };
+            }
+        };
+
+        const pipeline = new PluginPipeline([mockPlugin]);
+        const result = await pipeline.apply({
+            action: {} as any,
+            state: initialState,
+            authxContext: {}
+        });
+
+        if (!result.success) {
+            throw new Error('Pipeline failed');
+        }
+
+        expect(result.ctx.state).toBe(updatedState);
+        expect(result.ctx.state).not.toBe(initialState);
+    });
+});

--- a/packages/orchestrator/tests/proxy.plugin.integration.test.ts
+++ b/packages/orchestrator/tests/proxy.plugin.integration.test.ts
@@ -15,7 +15,7 @@ describe('DirectProxyRouteTablePlugin Tests', () => {
                 data: {
                     name: 'test-proxy-service',
                     endpoint: 'http://proxy-target',
-                    protocol: 'tcp:http',
+                    protocol: 'tcp:graphql',
                     region: 'us-west'
                 }
             },
@@ -26,13 +26,14 @@ describe('DirectProxyRouteTablePlugin Tests', () => {
         const result = await plugin.apply(context);
 
         expect(result.success).toBe(true);
-        const proxied = state.getProxiedRoutes();
+        const newState = result.ctx.state;
+        const proxied = newState.getProxiedRoutes();
         expect(proxied).toHaveLength(1);
         expect(proxied[0].service.name).toBe('test-proxy-service');
         expect(proxied[0].service.endpoint).toBe('http://proxy-target');
 
         // Ensure it didn't leak to internal
-        expect(state.getInternalRoutes()).toHaveLength(0);
+        expect(newState.getInternalRoutes()).toHaveLength(0);
     });
 
     it('should ignore non-dataChannel actions', async () => {

--- a/packages/orchestrator/tests/update.proxy.state.unit.test.ts
+++ b/packages/orchestrator/tests/update.proxy.state.unit.test.ts
@@ -1,0 +1,35 @@
+
+import { describe, it, expect } from 'bun:test';
+import { RouteTable } from '../src/state/route-table.js';
+import { ServiceDefinition } from '../src/rpc/schema/index.js';
+
+describe('Proxy State - Update', () => {
+    const service: ServiceDefinition = {
+        name: 'test-update-proxy',
+        protocol: 'tcp:graphql',
+        endpoint: 'localhost:8082',
+        region: 'us-east-2'
+    };
+
+    it('should update a proxied route immutably', () => {
+        const table1 = new RouteTable();
+        const { state: table2 } = table1.addProxiedRoute(service);
+
+        const updatedService = { ...service, endpoint: 'localhost:9092' };
+        const result = table2.updateProxiedRoute(updatedService);
+
+        expect(result).not.toBeNull();
+        const { state: table3, id } = result!;
+
+        expect(table2.getProxiedRoutes()[0].service.endpoint).toBe('localhost:8082');
+        expect(table3.getProxiedRoutes()).toHaveLength(1);
+        expect(table3.getProxiedRoutes()[0].service.endpoint).toBe('localhost:9092');
+        expect(id).toBe(`${service.name}:${service.protocol}`);
+    });
+
+    it('should return null if route does not exist to update', () => {
+        const table1 = new RouteTable();
+        const result = table1.updateProxiedRoute(service);
+        expect(result).toBeNull();
+    });
+});


### PR DESCRIPTION
### TL;DR

Refactored Docker builds and implemented immutable state management in the orchestrator service.

### What changed?

- Updated Docker build contexts in compose files to build from the repository root
- Simplified Dockerfiles to use a consistent pattern across services
- Refactored the `RouteTable` class to use immutable state patterns
- Updated plugins to properly handle state updates through the pipeline
- Fixed state management in RPC server to maintain state between requests
- Added comprehensive unit tests for immutable state operations

### How to test?

1. Run the Docker Compose setup with `docker-compose -f docker-compose/example.m0p2.compose.yaml up`
2. Run the unit tests with `cd packages/orchestrator && bun test`
3. Verify the integration tests pass with `bun test tests/graphql.plugin.integration.test.ts`

### Why make this change?

The immutable state pattern prevents bugs caused by unexpected state mutations and makes the system more predictable. This change ensures that state updates are properly propagated through the plugin pipeline and that the RPC server maintains consistent state between requests. The Docker build improvements standardize the build process across services and make it more maintainable.

GitHub Copilot: 