### PR TITLE
chore: standardize Dockerfiles to build from monorepo root context

### DIFF
--- a/docker-compose/example.m0p2.compose.yaml
+++ b/docker-compose/example.m0p2.compose.yaml
@@ -1,8 +1,8 @@
 services:
   orchestrator:
     build:
-      context: ../packages/orchestrator
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: packages/orchestrator/Dockerfile
     ports:
       - "3000:3000"
     environment:
@@ -13,8 +13,8 @@ services:
 
   gateway:
     build:
-      context: ../packages/gateway
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: packages/gateway/Dockerfile
     ports:
       - "4000:4000"
     environment:
@@ -25,8 +25,8 @@ services:
 
   books-service:
     build:
-      context: ../packages/examples
-      dockerfile: Dockerfile.books
+      context: ..
+      dockerfile: packages/examples/Dockerfile.books
     ports:
       - "8081:8080"
     environment:
@@ -34,8 +34,8 @@ services:
 
   movies-service:
     build:
-      context: ../packages/examples
-      dockerfile: Dockerfile.movies
+      context: ..
+      dockerfile: packages/examples/Dockerfile.movies
     ports:
       - "8082:8080"
     environment:

--- a/package.json
+++ b/package.json
@@ -63,5 +63,8 @@
     "lint-staged": "^16.2.7",
     "prettier": "^3.7.4",
     "typescript-eslint": "^8.52.0"
-  }
+  },
+  "trustedDependencies": [
+    "protobufjs"
+  ]
 }

--- a/packages/auth/Dockerfile
+++ b/packages/auth/Dockerfile
@@ -1,36 +1,28 @@
-FROM oven/bun:1 as base
+# Build from monorepo root context for consistency with other packages
+FROM oven/bun:1 AS builder
 WORKDIR /app
 
-# Install dependencies into temp directory
-# This will cache them and speed up future builds
-FROM base AS install
-RUN mkdir -p /temp/dev
-COPY package.json /temp/dev/
-RUN cd /temp/dev && bun install
+# Copy workspace config files (catalog definitions are in root package.json)
+COPY package.json bun.lockb ./
+COPY packages/auth/package.json ./packages/auth/
 
-# Install with --production (exclude devDependencies)
-RUN mkdir -p /temp/prod
-COPY package.json /temp/prod/
-RUN cd /temp/prod && bun install --production
+# Install from workspace root
+RUN bun install --filter @catalyst/auth
 
-# Copy node_modules from temp directory
-# Then copy all (non-ignored) project files into the image
-FROM base AS prerelease
-COPY --from=install /temp/dev/node_modules node_modules
-COPY . .
+# Copy source code
+COPY packages/auth/src ./packages/auth/src
+COPY packages/auth/tsconfig.json ./packages/auth/
 
-# [optional] tests & build
-ENV NODE_ENV=production
-# RUN bun test
+# Runtime stage
+FROM oven/bun:1
+WORKDIR /app
 
-# copy production dependencies and source code into final image
-FROM base AS release
-COPY --from=install /temp/prod/node_modules node_modules
-COPY --from=prerelease /app/src src
-COPY --from=prerelease /app/package.json .
-COPY --from=prerelease /app/tsconfig.json .
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/packages/auth ./packages/auth
 
-# run the app
+WORKDIR /app/packages/auth
+
 USER bun
-EXPOSE 4020/tcp
-ENTRYPOINT [ "bun", "run", "src/server.ts" ]
+ENV PORT=4020
+EXPOSE 4020
+CMD ["bun", "run", "src/server.ts"]

--- a/packages/examples/Dockerfile.books
+++ b/packages/examples/Dockerfile.books
@@ -1,19 +1,27 @@
-FROM oven/bun:1
-
+# Build from monorepo root context to resolve catalog references
+FROM oven/bun:1 AS builder
 WORKDIR /app
 
-# Copy root package.json and lockfile (to utilize cache if possible, though overly simple here)
-# For simplicity in this monorepo context without complex pruning, we'll assume we can copy the packages/examples dir
-# Setup workspace context usually requires more, but for an isolated example container:
+# Copy workspace config files (catalog definitions are in root package.json)
+COPY package.json bun.lockb ./
+COPY packages/examples/package.json ./packages/examples/
 
-# Copy the examples workspace
-COPY . .
+# Install from workspace root - bun resolves catalogs from root package.json
+RUN bun install --filter @catalyst/examples
 
-# Install dependencies (frozen-lockfile might fail if unrelated packages are missing, so we just install)
-RUN bun install
+# Copy source code
+COPY packages/examples/src ./packages/examples/src
+COPY packages/examples/tsconfig.json ./packages/examples/
 
-# Expose port
+# Runtime stage
+FROM oven/bun:1
+WORKDIR /app
+
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/packages/examples ./packages/examples
+
+WORKDIR /app/packages/examples
+
 ENV PORT=8080
 EXPOSE 8080
-
 CMD ["bun", "run", "src/books/index.ts"]

--- a/packages/examples/Dockerfile.movies
+++ b/packages/examples/Dockerfile.movies
@@ -1,12 +1,27 @@
-FROM oven/bun:1
-
+# Build from monorepo root context to resolve catalog references
+FROM oven/bun:1 AS builder
 WORKDIR /app
 
-COPY . .
+# Copy workspace config files (catalog definitions are in root package.json)
+COPY package.json bun.lockb ./
+COPY packages/examples/package.json ./packages/examples/
 
-RUN bun install
+# Install from workspace root - bun resolves catalogs from root package.json
+RUN bun install --filter @catalyst/examples
+
+# Copy source code
+COPY packages/examples/src ./packages/examples/src
+COPY packages/examples/tsconfig.json ./packages/examples/
+
+# Runtime stage
+FROM oven/bun:1
+WORKDIR /app
+
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/packages/examples ./packages/examples
+
+WORKDIR /app/packages/examples
 
 ENV PORT=8080
 EXPOSE 8080
-
 CMD ["bun", "run", "src/movies/index.ts"]

--- a/packages/gateway/Dockerfile
+++ b/packages/gateway/Dockerfile
@@ -1,16 +1,29 @@
-# Builder stage
+# Build from monorepo root context to resolve catalog references
 FROM oven/bun:1 AS builder
 WORKDIR /app
-COPY package.json ./
-RUN bun install
-COPY . .
+
+# Copy workspace config files (catalog definitions are in root package.json)
+COPY package.json bun.lockb ./
+COPY packages/gateway/package.json ./packages/gateway/
+
+# Install from workspace root - bun resolves catalogs from root package.json
+RUN bun install --filter @catalyst/gateway
+
+# Copy source code
+COPY packages/gateway/src ./packages/gateway/src
+COPY packages/gateway/tsconfig.json ./packages/gateway/
+
+# Build binary
+WORKDIR /app/packages/gateway
 RUN bun build --compile --minify --outfile server src/index.ts
 
 # Runtime stage
 # We use distroless/base-nossl-debian12 for a minimal glibc image
 FROM gcr.io/distroless/base-nossl-debian12
 WORKDIR /app
-COPY --from=builder /app/server .
+
+COPY --from=builder /app/packages/gateway/server .
+
 ENV PORT=4000
 EXPOSE 4000
 CMD ["./server"]

--- a/packages/orchestrator/Dockerfile
+++ b/packages/orchestrator/Dockerfile
@@ -1,37 +1,28 @@
-FROM oven/bun:1 as base
+# Build from monorepo root context to resolve catalog references
+FROM oven/bun:1 AS builder
 WORKDIR /app
 
-# Install dependencies into temp directory
-# This will cache them and speed up future builds
-FROM base AS install
-RUN mkdir -p /temp/dev
-COPY package.json /temp/dev/
-RUN cd /temp/dev && bun install
+# Copy workspace config files (catalog definitions are in root package.json)
+COPY package.json bun.lockb ./
+COPY packages/orchestrator/package.json ./packages/orchestrator/
 
-# Install with --production (exclude devDependencies)
-RUN mkdir -p /temp/prod
-COPY package.json /temp/prod/
-RUN cd /temp/prod && bun install --production
+# Install from workspace root - bun resolves catalogs from root package.json
+RUN bun install --filter @catalyst/orchestrator
 
-# Copy node_modules from temp directory
-# Then copy all (non-ignored) project files into the image
-FROM base AS prerelease
-COPY --from=install /temp/dev/node_modules node_modules
-COPY . .
+# Copy source code
+COPY packages/orchestrator/src ./packages/orchestrator/src
+COPY packages/orchestrator/tsconfig.json ./packages/orchestrator/
 
-# [optional] tests & build
-ENV NODE_ENV=production
-# RUN bun test
-# RUN bun run build
+# Build binary
+WORKDIR /app/packages/orchestrator
+RUN bun build --compile --minify --outfile server src/index.ts
 
-# copy production dependencies and source code into final image
-FROM base AS release
-COPY --from=install /temp/prod/node_modules node_modules
-COPY --from=prerelease /app/src src
-COPY --from=prerelease /app/package.json .
-COPY --from=prerelease /app/tsconfig.json .
+# Runtime stage
+FROM gcr.io/distroless/base-nossl-debian12
+WORKDIR /app
 
-# run the app
-USER bun
-EXPOSE 3000/tcp
-ENTRYPOINT [ "bun", "run", "src/index.ts" ]
+COPY --from=builder /app/packages/orchestrator/server .
+
+ENV PORT=3000
+EXPOSE 3000
+CMD ["./server"]


### PR DESCRIPTION
### TL;DR

Refactored Docker build process for all services to use monorepo root as build context and implemented multi-stage builds for improved efficiency.

### What changed?

- Updated all Dockerfiles to use a two-stage build process with a builder stage and runtime stage
- Modified build contexts in docker-compose to use the monorepo root (`..`) instead of individual package directories
- Standardized the Docker build process across all services (auth, gateway, orchestrator, examples)
- Added `protobufjs` to `trustedDependencies` in root package.json
- Improved dependency management by using `bun install --filter` to install only required packages
- Compiled the gateway and orchestrator services to binaries for smaller, more secure runtime images
- Switched to distroless containers for gateway and orchestrator services

### How to test?

1. Build and run the services using docker-compose:
   ```
   docker-compose -f docker-compose/example.m0p2.compose.yaml up --build
   ```
2. Verify all services start correctly and can communicate with each other
3. Test the gateway endpoint at http://localhost:4000
4. Test the orchestrator endpoint at http://localhost:3000

### Why make this change?

This change improves the Docker build process by:
- Ensuring proper resolution of workspace dependencies and catalog references
- Reducing image sizes through multi-stage builds
- Enhancing security by using distroless containers where appropriate
- Standardizing the build approach across all services
- Enabling more efficient builds with better caching
- Properly handling monorepo dependencies without duplicating code