### PR TITLE
chore: replace docker with podman in code

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,12 @@
   "name": "catalyst-monorepo",
   "private": true,
   "scripts": {
-    "start:m0p2": "docker compose -f docker-compose/example.m0p2.compose.yaml up --build",
+    "start:m0p2": "podman compose -f docker-compose/example.m0p2.compose.yaml up --build",
     "cli": "bun packages/cli/src/index.ts",
+    "test": "bun test --ignore '**/container*'",
+    "test:containers": "bun run test:containers:examples && bun run test:containers:auth",
+    "test:containers:examples": "cd packages/examples && bun run test:containers",
+    "test:containers:auth": "cd packages/auth && bun run test:containers",
     "prepare": "husky",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "bun run --watch src/server.ts",
     "build": "tsc",
-    "test": "bun test",
+    "test": "bun test --ignore '**/container*'",
+    "test:containers": "DOCKER_HOST=\"unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')\" TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock TESTCONTAINERS_RYUK_DISABLED=true vitest run container",
     "start": "bun run src/server.ts"
   },
   "dependencies": {

--- a/packages/auth/tests/container.test.ts
+++ b/packages/auth/tests/container.test.ts
@@ -1,73 +1,79 @@
-
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { GenericContainer, Wait, StartedTestContainer } from 'testcontainers';
+import { GenericContainer, StartedTestContainer } from 'testcontainers';
 import { resolve } from 'path';
+import { execSync } from 'child_process';
 
-// Increase timeout for docker build
+// Increase timeout for container build
 const TIMEOUT = 180_000;
+
+// Skip rebuild if image exists (set REBUILD_IMAGES=true to force rebuild)
+const FORCE_REBUILD = process.env.REBUILD_IMAGES === 'true';
+
+function imageExists(imageName: string): boolean {
+    try {
+        const output = execSync(`podman images -q ${imageName}`, { encoding: 'utf-8' });
+        return output.trim().length > 0;
+    } catch {
+        return false;
+    }
+}
+
+function ensureImage(imageName: string, dockerfile: string, buildContext: string): void {
+    if (!FORCE_REBUILD && imageExists(imageName)) {
+        console.log(`Using existing image: ${imageName}`);
+        return;
+    }
+
+    console.log(`Building image: ${imageName}...`);
+    execSync(`podman build -t ${imageName} -f ${dockerfile} .`, {
+        cwd: buildContext,
+        stdio: 'inherit',
+    });
+}
 
 describe('Auth Service Container', () => {
     let container: StartedTestContainer;
     let port: number;
+    const buildContext = resolve(__dirname, '../../..');
 
     beforeAll(async () => {
-        // Build image
-        const buildContext = resolve(__dirname, '..');
-        console.log('Building Docker image from', buildContext);
+        const imageName = 'auth-service:test';
+        const dockerfile = 'packages/auth/Dockerfile';
 
-        const proc = Bun.spawn(['docker', 'build', '-t', 'auth-service:test', '.'], {
-            cwd: buildContext,
-            // stdout: 'inherit', // Uncomment for debugging build
-            stderr: 'inherit'
-        });
-        await proc.exited;
+        ensureImage(imageName, dockerfile, buildContext);
 
-        if (proc.exitCode !== 0) {
-            throw new Error(`Docker build failed with exit code ${proc.exitCode}`);
-        }
-
-        container = await new GenericContainer('auth-service:test')
+        console.log('Starting container with testcontainers...');
+        container = await new GenericContainer(imageName)
             .withExposedPorts(4020)
             .withEnvironment({
                 CATALYST_AUTH_PORT: '4020',
                 CATALYST_AUTH_KEYS_DIR: '/tmp/keys'
             })
-            .withWaitStrategy(Wait.forHttp('/health', 4020))
             .start();
 
         port = container.getMappedPort(4020);
-        console.log(`Container started on port ${port}`);
+        console.log(`Auth service started on port ${port}`);
     }, TIMEOUT);
 
     afterAll(async () => {
-        await container?.stop();
-    });
+        if (container) await container.stop();
+    }, TIMEOUT);
 
     it('should expose RPC and sign/verify tokens', async () => {
         const url = `ws://localhost:${port}/rpc`;
         console.log(`Connecting to RPC at ${url}`);
 
-        // Use newWebSocketRpcSession from capnweb
-        // It returns a proxy object we can call directly? Or a session?
-        // CLI client says it returns the stub. 
-        // We need to cast it to our service type (conceptual)
-
-        // dynamically import to ensure we get the right module if needed, 
-        // but static import should work if we fix the name
         const { newWebSocketRpcSession } = await import('capnweb');
 
-        // Bun has global WebSocket
         const client = newWebSocketRpcSession(url, {
             WebSocket: WebSocket as any
         });
 
-        // client IS the service (remote capability)
         const service = client as any;
 
         // 1. Get JWKS
         const jwks = await service.getJwks();
         expect(jwks).toBeDefined();
-        // Since schema return { keys: ... }
         expect(Array.isArray(jwks.keys)).toBe(true);
         expect(jwks.keys.length).toBeGreaterThanOrEqual(1);
 
@@ -79,21 +85,15 @@ describe('Auth Service Container', () => {
         // 3. Verify
         const verifyRes = await service.verify({ token });
         expect(verifyRes.valid).toBe(true);
-        // Access payload from discriminated union
         if (verifyRes.valid) {
             expect(verifyRes.payload.sub).toBe('test-user');
         }
 
         // 4. Rotate
-        // Provide immediate: false
         const rotateRes = await service.rotate({ immediate: false });
         expect(rotateRes.success).toBe(true);
 
         const jwks2 = await service.getJwks();
-        expect(jwks2.keys.length).toBeGreaterThan(jwks.keys.length); // Should have added a key (or at least rotated)
-
-        // Close? capnweb session might not expose close easily on the proxy object 
-        // usually it relies on connection drop or has a .close() method if it is a session object
-        // but for test we can just let it be or close container
+        expect(jwks2.keys.length).toBeGreaterThan(jwks.keys.length);
     });
 });

--- a/packages/cli/tests/service.integration.test.ts
+++ b/packages/cli/tests/service.integration.test.ts
@@ -26,10 +26,10 @@ describe('CLI E2E with Containers', () => {
         const gatewayDir = join(repoRoot, 'packages/gateway');
         const orchestratorDir = join(repoRoot, 'packages/orchestrator');
 
-        console.log('Building Docker images...');
+        console.log('Building container images...');
 
         const buildBooks = async () => {
-            await Bun.spawn(['docker', 'build', '-t', 'books-service:test', '-f', 'Dockerfile.books', '.'], {
+            await Bun.spawn(['podman', 'build', '-t', 'books-service:test', '-f', 'Dockerfile.books', '.'], {
                 cwd: examplesDir,
                 stdout: 'ignore',
                 stderr: 'inherit'
@@ -37,7 +37,7 @@ describe('CLI E2E with Containers', () => {
         };
 
         const buildMovies = async () => {
-            await Bun.spawn(['docker', 'build', '-t', 'movies-service:test', '-f', 'Dockerfile.movies', '.'], {
+            await Bun.spawn(['podman', 'build', '-t', 'movies-service:test', '-f', 'Dockerfile.movies', '.'], {
                 cwd: examplesDir,
                 stdout: 'ignore',
                 stderr: 'inherit'
@@ -45,7 +45,7 @@ describe('CLI E2E with Containers', () => {
         };
 
         const buildGateway = async () => {
-            await Bun.spawn(['docker', 'build', '-t', 'gateway-service:test', '.'], {
+            await Bun.spawn(['podman', 'build', '-t', 'gateway-service:test', '.'], {
                 cwd: gatewayDir,
                 stdout: 'ignore',
                 stderr: 'inherit'
@@ -54,7 +54,7 @@ describe('CLI E2E with Containers', () => {
 
         // We build orchestrator manually instead of using existing image to ensure fresh code
         const buildOrchestrator = async () => {
-            await Bun.spawn(['docker', 'build', '-t', 'orchestrator-service:test', '.'], {
+            await Bun.spawn(['podman', 'build', '-t', 'orchestrator-service:test', '.'], {
                 cwd: orchestratorDir,
                 stdout: 'ignore',
                 stderr: 'inherit'
@@ -62,7 +62,7 @@ describe('CLI E2E with Containers', () => {
         }
 
         await Promise.all([buildBooks(), buildMovies(), buildGateway(), buildOrchestrator()]);
-        console.log('Docker images built successfully.');
+        console.log('Container images built successfully.');
 
         console.log('Starting Containers...');
 
@@ -75,7 +75,7 @@ describe('CLI E2E with Containers', () => {
             .start();
 
         const booksPort = booksContainer.getMappedPort(8080);
-        // Inside docker network, use alias
+        // Inside container network, use alias
         booksUri = 'http://books:8080/graphql';
         console.log(`Books started on port ${booksPort}`);
 
@@ -104,7 +104,7 @@ describe('CLI E2E with Containers', () => {
             .withExposedPorts(3000)
             .withNetwork(network)
             .withNetworkAliases('orchestrator')
-            // Tell Orchestrator where Gateway is (internal docker network alias)
+            // Tell Orchestrator where Gateway is (internal container network alias)
             .withEnvironment({
                 CATALYST_GQL_GATEWAY_ENDPOINT: 'ws://gateway:4000/api',
                 PORT: '3000'

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start:books": "bun run src/books/index.ts",
     "start:movies": "bun run src/movies/index.ts",
-    "test": "bun test"
+    "test": "bun test --ignore '**/container*'",
+    "test:containers": "DOCKER_HOST=\"unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')\" TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock TESTCONTAINERS_RYUK_DISABLED=true vitest run containers"
   },
   "dependencies": {
     "@graphql-tools/schema": "catalog:",

--- a/packages/gateway/tests/container.gateway.test.ts
+++ b/packages/gateway/tests/container.gateway.test.ts
@@ -24,7 +24,7 @@ describe('Gateway Container Integration', () => {
         // 1. Build & Start Books (Background)
         const startBooks = async () => {
             const imageName = 'books-service:test';
-            await Bun.spawn(['docker', 'build', '-t', imageName, '-f', 'Dockerfile.books', '.'], {
+            await Bun.spawn(['podman', 'build', '-t', imageName, '-f', 'Dockerfile.books', '.'], {
                 cwd: examplesDir, stdout: 'ignore', stderr: 'inherit'
             }).exited;
 
@@ -39,7 +39,7 @@ describe('Gateway Container Integration', () => {
         // 2. Build & Start Movies (Background)
         const startMovies = async () => {
             const imageName = 'movies-service:test';
-            await Bun.spawn(['docker', 'build', '-t', imageName, '-f', 'Dockerfile.movies', '.'], {
+            await Bun.spawn(['podman', 'build', '-t', imageName, '-f', 'Dockerfile.movies', '.'], {
                 cwd: examplesDir, stdout: 'ignore', stderr: 'inherit'
             }).exited;
 
@@ -54,7 +54,7 @@ describe('Gateway Container Integration', () => {
         // 3. Build & Start Gateway (Background)
         const startGateway = async () => {
             const imageName = 'gateway-service:test';
-            await Bun.spawn(['docker', 'build', '-t', imageName, '.'], {
+            await Bun.spawn(['podman', 'build', '-t', imageName, '.'], {
                 cwd: gatewayDir, stdout: 'ignore', stderr: 'inherit'
             }).exited;
 
@@ -116,7 +116,7 @@ describe('Gateway Container Integration', () => {
         const client = await getRpcClient();
         const config = {
             services: [
-                // Use the Docker network alias 'books'
+                // Use the container network alias 'books'
                 { name: 'books', url: 'http://books:8080/graphql' }
             ]
         };

--- a/packages/gateway/tests/integration.graphql.test.ts
+++ b/packages/gateway/tests/integration.graphql.test.ts
@@ -18,7 +18,7 @@ describe('Gateway Integration', () => {
             const imageName = 'books-service:test';
             const dockerfile = 'Dockerfile.books';
             // Workaround for Bun tar-stream issue
-            const proc = Bun.spawn(['docker', 'build', '-t', imageName, '-f', dockerfile, '.'], {
+            const proc = Bun.spawn(['podman', 'build', '-t', imageName, '-f', dockerfile, '.'], {
                 cwd: examplesDir,
                 stdout: 'ignore',
                 stderr: 'inherit',
@@ -36,7 +36,7 @@ describe('Gateway Integration', () => {
             const imageName = 'movies-service:test';
             const dockerfile = 'Dockerfile.movies';
             // Workaround for Bun tar-stream issue
-            const proc = Bun.spawn(['docker', 'build', '-t', imageName, '-f', dockerfile, '.'], {
+            const proc = Bun.spawn(['podman', 'build', '-t', imageName, '-f', dockerfile, '.'], {
                 cwd: examplesDir,
                 stdout: 'ignore',
                 stderr: 'inherit',

--- a/packages/orchestrator/tests/graphql.plugin.integration.test.ts
+++ b/packages/orchestrator/tests/graphql.plugin.integration.test.ts
@@ -26,10 +26,10 @@ describe('GraphQL Plugin E2E with Containers', () => {
         const examplesDir = join(repoRoot, 'packages/examples');
         const gatewayDir = join(repoRoot, 'packages/gateway');
 
-        console.log('Building Docker images...');
+        console.log('Building container images...');
 
         const buildBooks = async () => {
-            await Bun.spawn(['docker', 'build', '-t', 'books-service:test', '-f', 'Dockerfile.books', '.'], {
+            await Bun.spawn(['podman', 'build', '-t', 'books-service:test', '-f', 'Dockerfile.books', '.'], {
                 cwd: examplesDir,
                 stdout: 'ignore',
                 stderr: 'inherit'
@@ -37,7 +37,7 @@ describe('GraphQL Plugin E2E with Containers', () => {
         };
 
         const buildMovies = async () => {
-            await Bun.spawn(['docker', 'build', '-t', 'movies-service:test', '-f', 'Dockerfile.movies', '.'], {
+            await Bun.spawn(['podman', 'build', '-t', 'movies-service:test', '-f', 'Dockerfile.movies', '.'], {
                 cwd: examplesDir,
                 stdout: 'ignore',
                 stderr: 'inherit'
@@ -45,7 +45,7 @@ describe('GraphQL Plugin E2E with Containers', () => {
         };
 
         const buildGateway = async () => {
-            await Bun.spawn(['docker', 'build', '-t', 'gateway-service:test', '.'], {
+            await Bun.spawn(['podman', 'build', '-t', 'gateway-service:test', '.'], {
                 cwd: gatewayDir,
                 stdout: 'ignore',
                 stderr: 'inherit'
@@ -53,7 +53,7 @@ describe('GraphQL Plugin E2E with Containers', () => {
         };
 
         await Promise.all([buildBooks(), buildMovies(), buildGateway()]);
-        console.log('Docker images built successfully.');
+        console.log('Container images built successfully.');
 
         console.log('Starting Containers...');
 


### PR DESCRIPTION
### TL;DR

Migrated from Docker to Podman for container management and implemented a hybrid testing approach to work around Bun's testcontainers compatibility issues.

### What changed?

- Replaced Docker with Podman in all build and run commands
- Added comprehensive development documentation to README.md
- Implemented a hybrid testing approach:
  - `bun test` for unit tests (runs in Bun)
  - `bun run test:containers` for container tests (runs in Node.js via vitest)
- Added container test optimization to avoid rebuilding images unnecessarily
- Added environment variable configuration for testcontainers to work with Podman
- Updated container test scripts in package.json files

### How to test?

1. Install prerequisites:
   ```bash
   # Install Bun and Podman
   ```

2. Run unit tests:
   ```bash
   bun test
   ```

3. Run container tests:
   ```bash
   bun run test:containers
   ```

4. Force rebuild container images:
   ```bash
   REBUILD_IMAGES=true bun run test:containers
   ```

5. Start example services:
   ```bash
   bun run start:m0p2
   ```

### Why make this change?

Bun has a [stream handling bug](https://github.com/oven-sh/bun/issues/21342) that causes testcontainers to hang indefinitely when starting containers. This change implements a workaround by running container tests with vitest (Node.js) instead of Bun. Additionally, migrating to Podman provides a more modern, rootless container solution that's compatible with the project's needs.