### PR TITLE
feat(auth): add token revocation support

### DIFF
--- a/packages/auth/src/jwt.ts
+++ b/packages/auth/src/jwt.ts
@@ -11,8 +11,8 @@ const MAX_LIFETIME_SECONDS = 52 * 7 * 24 * 60 * 60;
 // Default issuer
 const DEFAULT_ISSUER = process.env.CATALYST_AUTH_ISSUER || 'catalyst-auth';
 
-// Clock tolerance for verification (seconds) - handles distributed system clock skew
-const CLOCK_TOLERANCE = 30;
+/** Clock tolerance for verification (seconds) - handles distributed system clock skew */
+export const CLOCK_TOLERANCE = 30;
 
 // Reserved JWT claims that cannot be overridden via custom claims
 const RESERVED_CLAIMS = ['iss', 'sub', 'aud', 'exp', 'nbf', 'iat', 'jti'] as const;

--- a/packages/auth/src/key-manager.ts
+++ b/packages/auth/src/key-manager.ts
@@ -42,6 +42,11 @@ export abstract class KeyManager {
      * Verifies a token against managed keys.
      */
     abstract verify(token: string): Promise<{ valid: boolean; payload?: any; error?: string }>;
+
+    /**
+     * Returns the current keypair (for revocation verification).
+     */
+    abstract getCurrentKeyPair(): Promise<KeyPair>;
 }
 
 export class FileSystemKeyManager extends KeyManager {
@@ -192,5 +197,10 @@ export class FileSystemKeyManager extends KeyManager {
         }
 
         return res;
+    }
+
+    async getCurrentKeyPair(): Promise<KeyPair> {
+        if (!this.currentKey) await this.init();
+        return this.currentKey!;
     }
 }

--- a/packages/auth/src/revocation.ts
+++ b/packages/auth/src/revocation.ts
@@ -1,0 +1,183 @@
+import { verifyToken, decodeToken, CLOCK_TOLERANCE } from './jwt.js';
+import type { KeyPair } from './keys.js';
+
+const CLOCK_TOLERANCE_MS = CLOCK_TOLERANCE * 1000;
+
+/**
+ * Interface for JTI revocation stores
+ * Implementations can be in-memory, Redis-backed, etc.
+ */
+export interface RevocationStore {
+    /** Add a JTI to the revocation list. Evicts oldest entries if at capacity. */
+    revoke(jti: string, expiresAt: Date): void;
+    isRevoked(jti: string): boolean;
+    /** @returns number of entries removed */
+    cleanup(): number;
+    readonly size: number;
+    readonly maxSize: number;
+}
+
+export interface RevocationStoreOptions {
+    maxSize?: number;
+}
+
+/**
+ * In-memory JTI revocation store
+ * TODO: Gotta deal with this ok ok
+ *
+ */
+export class InMemoryRevocationStore implements RevocationStore {
+    // Map of jti -> expiry timestamp (ms)
+    private revoked = new Map<string, number>();
+    readonly maxSize: number;
+
+    constructor(options?: RevocationStoreOptions) {
+        this.maxSize = options?.maxSize ?? 100_000;
+    }
+
+    revoke(jti: string, expiresAt: Date): void {
+        this.revoked.set(jti, expiresAt.getTime());
+
+        if (this.revoked.size > this.maxSize) {
+            this.cleanup();
+        }
+
+        const toEvict = this.revoked.size - this.maxSize;
+        // This gets gross when it is full but also see the earlier todo
+        if (toEvict > 0) {
+            const entries = [...this.revoked.entries()]
+                .filter(([id]) => id !== jti)
+                .sort((a, b) => a[1] - b[1]);
+
+            for (let i = 0; i < toEvict && i < entries.length; i++) {
+                this.revoked.delete(entries[i][0]);
+            }
+        }
+    }
+
+    isRevoked(jti: string): boolean {
+        const expiresAt = this.revoked.get(jti);
+        if (expiresAt === undefined) {
+            return false;
+        }
+        // Expired entries get deleted, not just ignored
+        if (expiresAt + CLOCK_TOLERANCE_MS < Date.now()) {
+            this.revoked.delete(jti);
+            return false;
+        }
+        return true;
+    }
+
+    cleanup(): number {
+        const now = Date.now();
+        const toDelete: string[] = [];
+        for (const [jti, expiresAt] of this.revoked) {
+            // Add tolerance to match jwt.ts verification behavior
+            if (expiresAt + CLOCK_TOLERANCE_MS < now) {
+                toDelete.push(jti);
+            }
+        }
+        for (const jti of toDelete) {
+            this.revoked.delete(jti);
+        }
+        return toDelete.length;
+    }
+
+    get size(): number {
+        return this.revoked.size;
+    }
+}
+
+/**
+ * Result of revoking a token
+ */
+export type RevokeTokenResult =
+    | { success: true }
+    | { success: false; error: string };
+
+/**
+ * Options for revoking a token
+ */
+export interface RevokeTokenOptions {
+    /** The revocation store */
+    store: RevocationStore;
+    /** KeyPair for signature verification */
+    keyPair: KeyPair;
+    /** Token to revoke */
+    token: string;
+    /** Caller's auth token for authorization */
+    authToken: string;
+}
+
+/**
+ * Check if caller is authorized to revoke a token
+ * Returns true if:
+ * - authToken.sub matches token.sub (revoking own token), OR
+ * - authToken has role: 'admin' claim
+ * TODO: roles n orgs
+ */
+export function isAuthorizedToRevoke(
+    authPayload: Record<string, unknown>,
+    tokenPayload: Record<string, unknown>
+): boolean {
+    if (authPayload.role === 'admin') {
+        return true;
+    }
+    if (
+        typeof authPayload.sub === 'string' &&
+        typeof tokenPayload.sub === 'string' &&
+        authPayload.sub === tokenPayload.sub
+    ) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Revoke a token with authorization check
+ *
+ * Authorization: caller must provide authToken proving identity.
+ * Revocation allowed if:
+ * - authToken.sub matches token.sub (revoking own token), OR
+ * - authToken has role: 'admin' claim (admin can revoke any token)
+ *
+ * Note: We only verify authToken (to prove caller identity). The target token
+ * is just decoded - we don't care if its signature is valid. If someone wants
+ * to revoke an expired or key-rotated token, that's fine.
+ */
+export async function revokeToken(opts: RevokeTokenOptions): Promise<RevokeTokenResult> {
+    const { store, keyPair, token, authToken } = opts;
+
+    // Verify auth token to prove caller identity
+    const authResult = await verifyToken(keyPair, authToken);
+    if (!authResult.valid) {
+        return { success: false, error: 'Invalid auth token' };
+    }
+
+    // Just decode target token - no signature verification needed
+    const decoded = decodeToken(token);
+    if (!decoded) {
+        return { success: false, error: 'Malformed token' };
+    }
+
+    // Authorization check
+    if (!isAuthorizedToRevoke(authResult.payload, decoded.payload as Record<string, unknown>)) {
+        return { success: false, error: 'Not authorized to revoke this token' };
+    }
+
+    const { jti, exp } = decoded.payload;
+
+    if (typeof jti !== 'string' || jti === '') {
+        return { success: false, error: 'Token missing jti claim' };
+    }
+    if (typeof exp !== 'number') {
+        return { success: false, error: 'Token missing exp claim' };
+    }
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    if (exp + CLOCK_TOLERANCE <= nowSeconds) {
+        return { success: false, error: 'Token already expired' };
+    }
+
+    store.revoke(jti, new Date(exp * 1000));
+    return { success: true };
+}

--- a/packages/auth/src/rpc-schema.ts
+++ b/packages/auth/src/rpc-schema.ts
@@ -49,3 +49,17 @@ export const RotateResponseSchema = z.object({
     success: z.boolean(),
 });
 export type RotateResponse = z.infer<typeof RotateResponseSchema>;
+
+// Request for revoke()
+export const RevokeRequestSchema = z.object({
+    token: z.string().min(1, 'Token is required'),
+    authToken: z.string().min(1, 'Auth token is required'),
+});
+export type RevokeRequest = z.infer<typeof RevokeRequestSchema>;
+
+// Response for revoke()
+export const RevokeResponseSchema = z.discriminatedUnion('success', [
+    z.object({ success: z.literal(true) }),
+    z.object({ success: z.literal(false), error: z.string() }),
+]);
+export type RevokeResponse = z.infer<typeof RevokeResponseSchema>;

--- a/packages/auth/tests/revocation.unit.test.ts
+++ b/packages/auth/tests/revocation.unit.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'bun:test';
+
+import { generateKeyPair, type KeyPair } from '../src/keys.js';
+import { signToken, decodeToken, CLOCK_TOLERANCE } from '../src/jwt.js';
+import { InMemoryRevocationStore, revokeToken } from '../src/revocation.js';
+
+const CLOCK_TOLERANCE_MS = CLOCK_TOLERANCE * 1000;
+const WELL_EXPIRED = CLOCK_TOLERANCE_MS + 5000;
+
+describe('RevocationStore', () => {
+    let keyPair: KeyPair;
+
+    beforeAll(async () => {
+        keyPair = await generateKeyPair();
+    });
+
+    describe('InMemoryRevocationStore', () => {
+        let store: InMemoryRevocationStore;
+
+        beforeEach(() => {
+            store = new InMemoryRevocationStore();
+        });
+
+        it('should track revoked JTIs', () => {
+            const expiresAt = new Date(Date.now() + 3600000);
+            expect(store.size).toBe(0);
+            expect(store.isRevoked('nonexistent')).toBe(false);
+
+            store.revoke('jti-1', expiresAt);
+            store.revoke('jti-2', expiresAt);
+
+            expect(store.size).toBe(2);
+            expect(store.isRevoked('jti-1')).toBe(true);
+            expect(store.isRevoked('jti-2')).toBe(true);
+            expect(store.isRevoked('jti-3')).toBe(false);
+        });
+
+        it('should handle expiry with clock tolerance', () => {
+            const wellExpired = new Date(Date.now() - WELL_EXPIRED);
+            const recentlyExpired = new Date(Date.now() - 1000); // within tolerance
+            const valid = new Date(Date.now() + 3600000);
+
+            store.revoke('expired', wellExpired);
+            store.revoke('recent', recentlyExpired);
+            store.revoke('valid', valid);
+            expect(store.size).toBe(3);
+
+            // Well-expired returns false AND gets deleted immediately
+            expect(store.isRevoked('expired')).toBe(false);
+            expect(store.size).toBe(2);
+
+            // Recently expired within tolerance should still be revoked
+            expect(store.isRevoked('recent')).toBe(true);
+            expect(store.isRevoked('valid')).toBe(true);
+
+            // Cleanup has nothing left to remove
+            const removed = store.cleanup();
+            expect(removed).toBe(0);
+            expect(store.size).toBe(2);
+        });
+
+        it('should enforce maxSize with auto-cleanup and eviction', () => {
+            const smallStore = new InMemoryRevocationStore({ maxSize: 2 });
+            const expired = new Date(Date.now() - WELL_EXPIRED);
+            const soonExp = new Date(Date.now() + 1000);
+            const laterExp = new Date(Date.now() + 3600000);
+
+            expect(smallStore.maxSize).toBe(2);
+
+            smallStore.revoke('expired', expired);
+            smallStore.revoke('valid-1', laterExp);
+            expect(smallStore.size).toBe(2);
+
+            // Should auto-cleanup expired and make room
+            smallStore.revoke('valid-2', laterExp);
+            expect(smallStore.size).toBe(2);
+            expect(smallStore.isRevoked('valid-1')).toBe(true);
+            expect(smallStore.isRevoked('valid-2')).toBe(true);
+
+            // When at capacity with no expired entries, evicts soonest-to-expire
+            smallStore.revoke('soon', soonExp);
+            expect(smallStore.size).toBe(2);
+            smallStore.revoke('valid-3', laterExp);
+            expect(smallStore.size).toBe(2);
+            // 'soon' should have been evicted (earliest expiry)
+            expect(smallStore.isRevoked('soon')).toBe(false);
+            expect(smallStore.isRevoked('valid-3')).toBe(true);
+        });
+    });
+
+    describe('revokeToken authorization', () => {
+        let store: InMemoryRevocationStore;
+
+        beforeEach(() => {
+            store = new InMemoryRevocationStore();
+        });
+
+        it('should allow user to revoke own token', async () => {
+            const userToken = await signToken(keyPair, { subject: 'user-123' });
+            const authToken = await signToken(keyPair, { subject: 'user-123' });
+
+            const result = await revokeToken({ store, keyPair, token: userToken, authToken });
+            expect(result.success).toBe(true);
+
+            const decoded = decodeToken(userToken);
+            expect(store.isRevoked(decoded!.payload.jti as string)).toBe(true);
+        });
+
+        it('should deny user from revoking other users token', async () => {
+            const otherToken = await signToken(keyPair, { subject: 'user-456' });
+            const authToken = await signToken(keyPair, { subject: 'user-123' });
+
+            const result = await revokeToken({ store, keyPair, token: otherToken, authToken });
+            expect(result.success).toBe(false);
+            expect((result as any).error).toBe('Not authorized to revoke this token');
+        });
+
+        it('should allow admin to revoke any token', async () => {
+            const userToken = await signToken(keyPair, { subject: 'user-123' });
+            const adminToken = await signToken(keyPair, {
+                subject: 'admin-1',
+                claims: { role: 'admin' },
+            });
+
+            const result = await revokeToken({ store, keyPair, token: userToken, authToken: adminToken });
+            expect(result.success).toBe(true);
+        });
+
+        it('should reject invalid auth tokens', async () => {
+            const userToken = await signToken(keyPair, { subject: 'user-123' });
+            const otherKeyPair = await generateKeyPair();
+            const wrongKeyToken = await signToken(otherKeyPair, { subject: 'user-123' });
+
+            // Garbage auth token
+            let result = await revokeToken({ store, keyPair, token: userToken, authToken: 'garbage' });
+            expect(result.success).toBe(false);
+            expect((result as any).error).toBe('Invalid auth token');
+
+            // Auth token signed with wrong key
+            result = await revokeToken({ store, keyPair, token: userToken, authToken: wrongKeyToken });
+            expect(result.success).toBe(false);
+            expect((result as any).error).toBe('Invalid auth token');
+
+            // Malformed target token (not a JWT at all)
+            const validAuth = await signToken(keyPair, { subject: 'user-123' });
+            result = await revokeToken({ store, keyPair, token: 'not-a-jwt', authToken: validAuth });
+            expect(result.success).toBe(false);
+            expect((result as any).error).toBe('Malformed token');
+        });
+
+        it('should allow revoking tokens signed with different keys', async () => {
+            // This is important: we only verify auth token, not target token
+            // So tokens signed with rotated/different keys can still be revoked
+            const otherKeyPair = await generateKeyPair();
+            const wrongKeyToken = await signToken(otherKeyPair, { subject: 'user-123' });
+            const validAuth = await signToken(keyPair, { subject: 'user-123' });
+
+            const result = await revokeToken({ store, keyPair, token: wrongKeyToken, authToken: validAuth });
+            expect(result.success).toBe(true);
+
+            const decoded = decodeToken(wrongKeyToken);
+            expect(store.isRevoked(decoded!.payload.jti as string)).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
### TL;DR

Added token revocation functionality to the auth package, allowing users to revoke their own tokens and admins to revoke any token.

### What changed?

- Created a new `revocation.ts` module with:
  - `RevocationStore` interface for tracking revoked tokens
  - `InMemoryRevocationStore` implementation with size limits and auto-cleanup
  - `revokeToken` function with authorization checks (users can revoke their own tokens, admins can revoke any token)
- Updated `JwtService` to:
  - Accept an optional `revocationStore` in constructor
  - Check for revoked tokens during verification
  - Add a new `revoke` RPC method
- Added RPC schema definitions for token revocation
- Made `CLOCK_TOLERANCE` exported from jwt.ts
- Added `getCurrentKeyPair()` method to KeyManager
- Added comprehensive unit tests for the revocation functionality

### How to test?

1. Create a JWT token using the sign method
2. Revoke the token using the new revoke method with proper authorization
3. Attempt to verify the revoked token - it should fail with "Token revoked" error
4. Test authorization rules:
   - Users can revoke their own tokens (same subject)
   - Admins can revoke any token (with role: 'admin' claim)
   - Users cannot revoke other users' tokens

### Why make this change?

Token revocation is a critical security feature for JWT-based authentication systems. It allows invalidating tokens before their natural expiration in cases like:
- User logout
- Security incidents
- Compromised credentials
- Permission changes

The implementation uses a space-efficient approach with automatic cleanup of expired entries and configurable size limits to prevent memory issues.