### PR TITLE
refactor(auth): add new RPC server structure

### DIFF
--- a/packages/auth/src/rpc/schema.ts
+++ b/packages/auth/src/rpc/schema.ts
@@ -1,0 +1,138 @@
+import { z } from 'zod';
+
+/**
+ * SignToken Request/Response schemas
+ *
+ * Note: This endpoint is intended for internal/trusted callers only.
+ * Network-level access control should be used to restrict access.
+ */
+export const SignTokenRequestSchema = z.object({
+    subject: z.string().min(1, 'Subject is required'),
+    audience: z.union([z.string(), z.array(z.string())]).optional(),
+    expiresIn: z.string().optional(), // e.g., '1h', '7d', '30m'
+    claims: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type SignTokenRequest = z.infer<typeof SignTokenRequestSchema>;
+
+export const SignTokenResponseSchema = z.discriminatedUnion('success', [
+    z.object({
+        success: z.literal(true),
+        token: z.string(),
+    }),
+    z.object({
+        success: z.literal(false),
+        error: z.string(),
+    }),
+]);
+
+export type SignTokenResponse = z.infer<typeof SignTokenResponseSchema>;
+
+/**
+ * VerifyToken Request/Response schemas
+ */
+export const VerifyTokenRequestSchema = z.object({
+    token: z.string().min(1, 'Token is required'),
+    audience: z.string().optional(),
+});
+
+export type VerifyTokenRequest = z.infer<typeof VerifyTokenRequestSchema>;
+
+export const VerifyTokenResponseSchema = z.discriminatedUnion('valid', [
+    z.object({
+        valid: z.literal(true),
+        payload: z.record(z.string(), z.unknown()),
+    }),
+    z.object({
+        valid: z.literal(false),
+        error: z.string(),
+    }),
+]);
+
+export type VerifyTokenResponse = z.infer<typeof VerifyTokenResponseSchema>;
+
+/**
+ * GetPublicKey Response schema
+ */
+export const GetPublicKeyResponseSchema = z.discriminatedUnion('success', [
+    z.object({ success: z.literal(true), jwk: z.record(z.unknown()) }),
+    z.object({ success: z.literal(false), error: z.string() }),
+]);
+
+export type GetPublicKeyResponse = z.infer<typeof GetPublicKeyResponseSchema>;
+
+/**
+ * GetJwks Response schema
+ */
+export const GetJwksResponseSchema = z.discriminatedUnion('success', [
+    z.object({ success: z.literal(true), jwks: z.object({ keys: z.array(z.record(z.unknown())) }) }),
+    z.object({ success: z.literal(false), error: z.string() }),
+]);
+
+export type GetJwksResponse = z.infer<typeof GetJwksResponseSchema>;
+
+/**
+ * RevokeToken Request/Response schemas
+ *
+ * Authorization: caller must provide authToken proving identity.
+ * Revocation allowed if:
+ * - authToken.sub matches token.sub (revoking own token), OR
+ * - authToken has role: 'admin' claim (admin can revoke any token)
+ */
+export const RevokeTokenRequestSchema = z.object({
+    /** Token to revoke */
+    token: z.string().min(1, 'Token is required'),
+    /** Caller's auth token for authorization */
+    authToken: z.string().min(1, 'Auth token is required'),
+});
+
+export type RevokeTokenRequest = z.infer<typeof RevokeTokenRequestSchema>;
+
+export const RevokeTokenResponseSchema = z.discriminatedUnion('success', [
+    z.object({ success: z.literal(true) }),
+    z.object({ success: z.literal(false), error: z.string() }),
+]);
+
+export type RevokeTokenResponse = z.infer<typeof RevokeTokenResponseSchema>;
+
+/**
+ * Rotate Request/Response schemas
+ *
+ * Authorization: caller must provide authToken with role: 'admin' claim.
+ * Only admins can rotate keys.
+ */
+export const RotateRequestSchema = z.object({
+    /** Admin auth token for authorization */
+    authToken: z.string().min(1, 'Auth token is required'),
+    /** Skip grace period, invalidate old key immediately */
+    immediate: z.boolean().optional().default(false),
+    /** Custom grace period in milliseconds (default: 24 hours) */
+    gracePeriodMs: z.number().positive().optional(),
+});
+
+export type RotateRequest = z.infer<typeof RotateRequestSchema>;
+
+export const RotateResponseSchema = z.discriminatedUnion('success', [
+    z.object({
+        success: z.literal(true),
+        previousKeyId: z.string(),
+        newKeyId: z.string(),
+        gracePeriodEndsAt: z.string().optional(), // ISO date string
+    }),
+    z.object({
+        success: z.literal(false),
+        error: z.string(),
+    }),
+]);
+
+export type RotateResponse = z.infer<typeof RotateResponseSchema>;
+
+/**
+ * GetCurrentKeyId Response schema
+ */
+export const GetCurrentKeyIdResponseSchema = z.discriminatedUnion('success', [
+    z.object({ success: z.literal(true), kid: z.string() }),
+    z.object({ success: z.literal(false), error: z.string() }),
+]);
+
+export type GetCurrentKeyIdResponse = z.infer<typeof GetCurrentKeyIdResponseSchema>;

--- a/packages/auth/src/rpc/server.ts
+++ b/packages/auth/src/rpc/server.ts
@@ -1,0 +1,228 @@
+import { Hono } from 'hono';
+import { upgradeWebSocket } from 'hono/bun';
+import { RpcTarget } from 'capnweb';
+import { newRpcResponse } from '@hono/capnweb';
+
+import type { IKeyManager } from '../key-manager/types.js';
+import { isAuthorizedToRevoke, type RevocationStore } from '../revocation.js';
+import {
+    SignTokenRequestSchema,
+    VerifyTokenRequestSchema,
+    RevokeTokenRequestSchema,
+    RotateRequestSchema,
+    type SignTokenResponse,
+    type VerifyTokenResponse,
+    type GetPublicKeyResponse,
+    type GetJwksResponse,
+    type RevokeTokenResponse,
+    type RotateResponse,
+    type GetCurrentKeyIdResponse,
+} from './schema.js';
+
+export class AuthRpcServer extends RpcTarget {
+    constructor(
+        private keyManager: IKeyManager,
+        private revocationStore?: RevocationStore
+    ) {
+        super();
+    }
+
+    /**
+     * Sign a JWT with the provided options
+     *
+     * Note: This endpoint is intended for internal/trusted callers only.
+     * Network-level access control should be used to restrict access.
+     */
+    async signToken(request: unknown): Promise<SignTokenResponse> {
+        const parsed = SignTokenRequestSchema.safeParse(request);
+        if (!parsed.success) {
+            const errorMessages = parsed.error.issues.map(i => i.message).join(', ');
+            return { success: false, error: errorMessages };
+        }
+
+        try {
+            const token = await this.keyManager.sign({
+                subject: parsed.data.subject,
+                audience: parsed.data.audience,
+                expiresIn: parsed.data.expiresIn,
+                claims: parsed.data.claims,
+            });
+
+            return { success: true, token };
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Token signing failed';
+            return { success: false, error: message };
+        }
+    }
+
+    /**
+     * Verify a JWT and return the payload if valid
+     */
+    async verifyToken(request: unknown): Promise<VerifyTokenResponse> {
+        const parsed = VerifyTokenRequestSchema.safeParse(request);
+        if (!parsed.success) {
+            return { valid: false, error: 'Token verification failed' };
+        }
+
+        try {
+            const result = await this.keyManager.verify(parsed.data.token, {
+                audience: parsed.data.audience,
+            });
+
+            if (!result.valid) {
+                return { valid: false, error: 'Token verification failed' };
+            }
+
+            // Check revocation after cryptographic verification
+            if (this.revocationStore && typeof result.payload.jti === 'string') {
+                if (this.revocationStore.isRevoked(result.payload.jti)) {
+                    return { valid: false, error: 'Token revoked' };
+                }
+            }
+
+            return { valid: true, payload: result.payload };
+        } catch {
+            return { valid: false, error: 'Token verification failed' };
+        }
+    }
+
+    /**
+     * Revoke a JWT by adding its JTI to the revocation list
+     *
+     * Authorization: caller must provide authToken proving identity.
+     * Revocation allowed if:
+     * - authToken.sub matches token.sub (revoking own token), OR
+     * - authToken has role: 'admin' claim (admin can revoke any token)
+     */
+    async revokeToken(request: unknown): Promise<RevokeTokenResponse> {
+        if (!this.revocationStore) {
+            return { success: false, error: 'Revocation not enabled' };
+        }
+
+        const parsed = RevokeTokenRequestSchema.safeParse(request);
+        if (!parsed.success) {
+            return { success: false, error: 'Invalid request' };
+        }
+
+        const { token, authToken } = parsed.data;
+
+        // Verify the caller's auth token first
+        const authResult = await this.keyManager.verify(authToken);
+        if (!authResult.valid) {
+            return { success: false, error: 'Invalid auth token' };
+        }
+
+        // Verify the token to be revoked
+        const tokenResult = await this.keyManager.verify(token);
+        if (!tokenResult.valid) {
+            return { success: false, error: 'Invalid token signature' };
+        }
+
+        // Authorization check
+        if (!isAuthorizedToRevoke(authResult.payload, tokenResult.payload)) {
+            return { success: false, error: 'Not authorized to revoke this token' };
+        }
+
+        const { jti, exp } = tokenResult.payload;
+
+        if (typeof jti !== 'string' || jti === '') {
+            return { success: false, error: 'Token missing jti claim' };
+        }
+        if (typeof exp !== 'number' || exp <= 0) {
+            return { success: false, error: 'Token missing or invalid exp claim' };
+        }
+
+        const added = this.revocationStore.revoke(jti, new Date(exp * 1000));
+        if (!added) {
+            return { success: false, error: 'Revocation store full' };
+        }
+
+        return { success: true };
+    }
+
+    /**
+     * Get the public key in JWK format (first key from JWKS)
+     */
+    async getPublicKey(): Promise<GetPublicKeyResponse> {
+        try {
+            const jwks = await this.keyManager.getJwks();
+            if (jwks.keys.length === 0) {
+                return { success: false, error: 'No keys available' };
+            }
+            return { success: true, jwk: jwks.keys[0] as Record<string, unknown> };
+        } catch {
+            return { success: false, error: 'Failed to get public key' };
+        }
+    }
+
+    /**
+     * Get the JWKS (public keys) for token verification
+     */
+    async getJwks(): Promise<GetJwksResponse> {
+        try {
+            const jwks = await this.keyManager.getJwks();
+            return { success: true, jwks: { keys: jwks.keys as Record<string, unknown>[] } };
+        } catch {
+            return { success: false, error: 'Failed to get JWKS' };
+        }
+    }
+
+    /**
+     * Get the current signing key ID
+     */
+    async getCurrentKeyId(): Promise<GetCurrentKeyIdResponse> {
+        try {
+            const kid = await this.keyManager.getCurrentKeyId();
+            return { success: true, kid };
+        } catch {
+            return { success: false, error: 'Failed to get key ID' };
+        }
+    }
+
+    /**
+     * Rotate to a new signing key
+     *
+     * Authorization: requires authToken with role: 'admin' claim.
+     */
+    async rotate(request: unknown): Promise<RotateResponse> {
+        const parsed = RotateRequestSchema.safeParse(request);
+        if (!parsed.success) {
+            return { success: false, error: 'Invalid request' };
+        }
+
+        // Verify admin authorization
+        const authResult = await this.keyManager.verify(parsed.data.authToken);
+        if (!authResult.valid) {
+            return { success: false, error: 'Invalid auth token' };
+        }
+        if (authResult.payload.role !== 'admin') {
+            return { success: false, error: 'Admin authorization required' };
+        }
+
+        try {
+            const result = await this.keyManager.rotate({
+                immediate: parsed.data.immediate,
+                gracePeriodMs: parsed.data.gracePeriodMs,
+            });
+
+            return {
+                success: true,
+                previousKeyId: result.previousKeyId,
+                newKeyId: result.newKeyId,
+                gracePeriodEndsAt: result.gracePeriodEndsAt?.toISOString(),
+            };
+        } catch {
+            return { success: false, error: 'Rotation failed' };
+        }
+    }
+}
+
+export function createAuthRpcHandler(rpcServer: AuthRpcServer): Hono {
+    const app = new Hono();
+    app.get('/', (c) => {
+        return newRpcResponse(c, rpcServer, {
+            upgradeWebSocket,
+        });
+    });
+    return app;
+}


### PR DESCRIPTION
### TL;DR

Added RPC server and schema definitions for the auth package to enable JWT token management.

### What changed?

- Created `schema.ts` with Zod schemas for JWT operations:
  - `SignToken` - Create and sign new JWTs
  - `VerifyToken` - Validate JWT signatures and check revocation status
  - `RevokeToken` - Add tokens to revocation list
  - `Rotate` - Rotate signing keys with grace period support
  - `GetPublicKey` - Retrieve public key in JWK format
  - `GetJwks` - Get JWKS for token verification
  - `GetCurrentKeyId` - Get the current signing key ID

- Implemented `AuthRpcServer` class in `server.ts` that:
  - Handles all JWT operations defined in the schema
  - Implements proper authorization checks for sensitive operations
  - Integrates with the key manager and revocation store
  - Provides a Hono-based HTTP handler with WebSocket upgrade support

### How to test?

1. Create an instance of `AuthRpcServer` with a key manager and optional revocation store
2. Use the RPC methods to sign, verify, and manage tokens
3. Test authorization flows for token revocation (self or admin)
4. Test key rotation with both immediate and grace period options
5. Verify JWKS endpoint returns proper key material

### Why make this change?

This implementation provides a complete RPC interface for JWT operations, enabling secure token management across services. The server handles all aspects of the JWT lifecycle including signing, verification, revocation, and key rotation with proper authorization controls. This allows other services to securely manage authentication tokens without direct access to signing keys.