### PR TITLE
feat: add auth service to docker-compose

### DIFF
--- a/docker-compose/example.m0p2.compose.yaml
+++ b/docker-compose/example.m0p2.compose.yaml
@@ -7,9 +7,11 @@ services:
       - "3000:3000"
     environment:
       - CATALYST_GQL_GATEWAY_ENDPOINT=ws://gateway:4000/api
+      - CATALYST_AUTH_ENDPOINT=ws://auth:4020/rpc
       - PORT=3000
     depends_on:
       - gateway
+      - auth
 
   gateway:
     build:
@@ -40,3 +42,18 @@ services:
       - "8082:8080"
     environment:
       - PORT=8080
+
+  auth:
+    build:
+      context: ..
+      dockerfile: packages/auth/Dockerfile
+    ports:
+      - "4020:4020"
+    environment:
+      - PORT=4020
+      - CATALYST_AUTH_KEYS_DIR=/data/keys
+    volumes:
+      - auth-keys:/data/keys
+
+volumes:
+  auth-keys:


### PR DESCRIPTION
### TL;DR

Added authentication service to the docker-compose configuration.

### What changed?

- Added a new `auth` service to the docker-compose configuration
- Connected the auth service to the frontend by adding the `CATALYST_AUTH_ENDPOINT` environment variable
- Added the auth service as a dependency for the frontend
- Created a persistent volume `auth-keys` for storing authentication keys

### How to test?

1. Start the updated configuration:
   ```
   podman-compose -f docker-compose/example.m0p2.compose.yaml up
   ```
2. Verify the auth service is running on port 4020
3. Confirm the frontend can connect to the auth service via the WebSocket endpoint

### Why make this change?

This change introduces authentication capabilities to the application stack, allowing for secure user authentication and authorization. The auth service exposes an RPC endpoint that the frontend can use to handle user authentication flows.