### PR TITLE
feat(orchestrator): add auth RPC client with integration tests

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "type": "module",
   "private": true,
+  "exports": {
+    ".": "./src/index.ts",
+    "./rpc/schema": "./src/rpc/schema.ts"
+  },
   "scripts": {
     "dev": "bun run --watch src/server.ts",
     "build": "tsc",

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -10,6 +10,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@catalyst/auth": "workspace:*",
     "@hono/capnweb": "catalog:",
     "capnweb": "catalog:",
     "hono": "catalog:",

--- a/packages/orchestrator/src/clients/auth.ts
+++ b/packages/orchestrator/src/clients/auth.ts
@@ -1,0 +1,146 @@
+/**
+ * Auth Service RPC Client
+ *
+ * Connects to the auth service via WebSocket RPC to perform
+ * token signing, verification, and JWKS retrieval.
+ */
+
+import { newWebSocketRpcSession } from 'capnweb';
+
+// Import types from the auth package (single source of truth)
+import type {
+    SignTokenRequest,
+    SignTokenResponse,
+    VerifyTokenResponse,
+    GetJwksResponse,
+} from '@catalyst/auth/rpc/schema';
+
+// Re-export for convenience
+export type { SignTokenRequest, SignTokenResponse, VerifyTokenResponse, GetJwksResponse };
+
+// RPC stub interface (what the remote service exposes)
+interface AuthRpcStub {
+    signToken(request: SignTokenRequest): Promise<SignTokenResponse>;
+    verifyToken(request: { token: string; audience?: string }): Promise<VerifyTokenResponse>;
+    getJwks(): Promise<GetJwksResponse>;
+}
+
+// Factory type for dependency injection (useful for testing)
+type RpcSessionFactory = (endpoint: string) => AuthRpcStub;
+
+/**
+ * Interface for auth client operations
+ */
+export interface IAuthClient {
+    signToken(request: SignTokenRequest): Promise<SignTokenResponse>;
+    verifyToken(token: string, audience?: string): Promise<VerifyTokenResponse>;
+    getJwks(): Promise<GetJwksResponse>;
+    close(): void;
+}
+
+/**
+ * Auth service RPC client
+ *
+ * Maintains a persistent WebSocket connection to the auth service.
+ * Connection is lazily established on first use.
+ *
+ * Example usage:
+ * ```typescript
+ * const client = new AuthClient('ws://auth:4020/rpc');
+ * const result = await client.signToken({ subject: 'user-123' });
+ * if (result.success) {
+ *     console.log('Token:', result.token);
+ * }
+ * // Clean up when done
+ * client.close();
+ * ```
+ */
+export class AuthClient implements IAuthClient {
+    private readonly endpoint: string;
+    private readonly sessionFactory: RpcSessionFactory;
+    private stub: AuthRpcStub | null = null;
+    private ws: WebSocket | null = null;
+
+    constructor(
+        endpoint: string,
+        sessionFactory?: RpcSessionFactory
+    ) {
+        this.endpoint = endpoint;
+        this.sessionFactory = sessionFactory ?? ((ep) => {
+            // Create and store WebSocket for cleanup
+            this.ws = new WebSocket(ep);
+            return newWebSocketRpcSession(this.ws as any) as AuthRpcStub;
+        });
+    }
+
+    /**
+     * Get or create the RPC stub (lazy connection)
+     */
+    private getStub(): AuthRpcStub {
+        if (!this.stub) {
+            this.stub = this.sessionFactory(this.endpoint);
+        }
+        return this.stub;
+    }
+
+    /**
+     * Close the WebSocket connection
+     */
+    close(): void {
+        if (this.ws) {
+            this.ws.close();
+            this.ws = null;
+        }
+        this.stub = null;
+    }
+
+    /**
+     * Sign a JWT token for the given subject
+     */
+    async signToken(request: SignTokenRequest): Promise<SignTokenResponse> {
+        try {
+            const stub = this.getStub();
+            return await stub.signToken(request);
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'RPC error';
+            return { success: false, error: message };
+        }
+    }
+
+    /**
+     * Verify a JWT token
+     */
+    async verifyToken(token: string, audience?: string): Promise<VerifyTokenResponse> {
+        try {
+            const stub = this.getStub();
+            return await stub.verifyToken({ token, audience });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'RPC error';
+            return { valid: false, error: message };
+        }
+    }
+
+    /**
+     * Get the JWKS (public keys) from the auth service
+     */
+    async getJwks(): Promise<GetJwksResponse> {
+        try {
+            const stub = this.getStub();
+            return await stub.getJwks();
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'RPC error';
+            return { success: false, error: message };
+        }
+    }
+}
+
+/**
+ * Create an auth client from environment variables
+ */
+export function createAuthClientFromEnv(): AuthClient | null {
+    const endpoint = process.env.CATALYST_AUTH_ENDPOINT;
+    if (!endpoint) {
+        return null;
+    }
+    return new AuthClient(endpoint);
+}

--- a/packages/orchestrator/tests/auth-client.integration.test.ts
+++ b/packages/orchestrator/tests/auth-client.integration.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { GenericContainer, Wait, StartedTestContainer } from 'testcontainers';
+import { resolve } from 'path';
+import { AuthClient } from '../src/clients/auth.js';
+
+// Increase timeout for container build
+const TIMEOUT = 180_000;
+
+describe('AuthClient Integration', () => {
+    let container: StartedTestContainer;
+    let client: AuthClient;
+    let rpcEndpoint: string;
+
+    beforeAll(async () => {
+        // Build auth service image from monorepo root
+        const buildContext = resolve(__dirname, '../../..');
+        const dockerfile = 'packages/auth/Dockerfile';
+
+        console.log('Building auth service image...');
+        const proc = Bun.spawn(['podman', 'build', '-t', 'auth-service:integration-test', '-f', dockerfile, '.'], {
+            cwd: buildContext,
+            stderr: 'inherit'
+        });
+        await proc.exited;
+
+        if (proc.exitCode !== 0) {
+            throw new Error(`Container build failed with exit code ${proc.exitCode}`);
+        }
+
+        console.log('Starting auth service container...');
+        container = await new GenericContainer('auth-service:integration-test')
+            .withExposedPorts(4020)
+            .withEnvironment({
+                PORT: '4020',
+                CATALYST_AUTH_KEYS_DIR: '/tmp/keys'
+            })
+            .withWaitStrategy(Wait.forHttp('/health', 4020))
+            .start();
+
+        const port = container.getMappedPort(4020);
+        const host = container.getHost();
+        rpcEndpoint = `ws://${host}:${port}/rpc`;
+        console.log(`Auth service running at ${rpcEndpoint}`);
+
+        client = new AuthClient(rpcEndpoint);
+    }, TIMEOUT);
+
+    afterAll(async () => {
+        client?.close();
+        await container?.stop();
+    });
+
+    it('should sign a token via RPC', async () => {
+        const result = await client.signToken({
+            subject: 'test-user-123',
+            expiresIn: '1h'
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.token).toBeDefined();
+            expect(typeof result.token).toBe('string');
+            // JWT format: header.payload.signature
+            expect(result.token.split('.')).toHaveLength(3);
+        }
+    });
+
+    it('should verify a valid token via RPC', async () => {
+        // First sign a token
+        const signResult = await client.signToken({
+            subject: 'verify-test-user',
+            expiresIn: '1h'
+        });
+        expect(signResult.success).toBe(true);
+        if (!signResult.success) return;
+
+        // Then verify it
+        const verifyResult = await client.verifyToken(signResult.token);
+
+        expect(verifyResult.valid).toBe(true);
+        if (verifyResult.valid) {
+            expect(verifyResult.payload.sub).toBe('verify-test-user');
+        }
+    });
+
+    it('should reject an invalid token', async () => {
+        const result = await client.verifyToken('invalid.token.here');
+
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+            expect(result.error).toBeDefined();
+        }
+    });
+
+    it('should get JWKS via RPC', async () => {
+        const result = await client.getJwks();
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.jwks).toBeDefined();
+            expect(result.jwks.keys).toBeInstanceOf(Array);
+            expect(result.jwks.keys.length).toBeGreaterThan(0);
+            // Check first key has expected ECDSA properties
+            const key = result.jwks.keys[0];
+            expect(key.kty).toBe('EC');
+            expect(key.crv).toBe('P-384');
+            expect(key.kid).toBeDefined();
+        }
+    });
+
+    it('should sign token with custom claims', async () => {
+        const result = await client.signToken({
+            subject: 'claims-test-user',
+            expiresIn: '30m',
+            claims: {
+                role: 'admin',
+                orgId: 'org-456'
+            }
+        });
+
+        expect(result.success).toBe(true);
+        if (!result.success) return;
+
+        // Verify and check claims
+        const verifyResult = await client.verifyToken(result.token);
+        expect(verifyResult.valid).toBe(true);
+        if (verifyResult.valid) {
+            expect(verifyResult.payload.role).toBe('admin');
+            expect(verifyResult.payload.orgId).toBe('org-456');
+        }
+    });
+
+    it('should reuse connection across multiple operations', async () => {
+        // Multiple sequential operations should work on same connection
+        const results = await Promise.all([
+            client.signToken({ subject: 'user-1' }),
+            client.signToken({ subject: 'user-2' }),
+            client.getJwks(),
+        ]);
+
+        expect(results[0].success).toBe(true);
+        expect(results[1].success).toBe(true);
+        expect(results[2].success).toBe(true);
+    });
+});


### PR DESCRIPTION
### TL;DR

Added an RPC client for the Auth service in the orchestrator package to enable secure token operations.

### What changed?

- Added exports configuration to the auth package to expose its RPC schema
- Created a new AuthClient class in the orchestrator package that connects to the auth service via WebSocket RPC
- Implemented methods for token signing, verification, and JWKS retrieval
- Added comprehensive integration tests that verify the client works correctly with the auth service
- Added dependency on the auth package to the orchestrator

### How to test?

1. Run the integration tests:
   ```bash
   cd packages/orchestrator
   bun test tests/auth-client.integration.test.ts
   ```

2. The tests will build and run the auth service in a container, then verify that:
   - Tokens can be signed with various parameters
   - Valid tokens can be verified
   - Invalid tokens are rejected
   - JWKS (public keys) can be retrieved
   - Custom claims work correctly
   - The connection is reused properly

### Why make this change?

This client enables the orchestrator to securely handle authentication operations by delegating token management to the dedicated auth service. The WebSocket RPC approach provides a lightweight, efficient communication channel between services while maintaining a clear separation of concerns. The integration tests ensure the client works correctly with the actual auth service implementation.