### PR TITLE
feat(orchestrator): wire AuthPlugin

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -5,7 +5,11 @@
   "private": true,
   "exports": {
     ".": "./src/index.ts",
-    "./rpc/schema": "./src/rpc/schema.ts"
+    "./rpc/schema": "./src/rpc/schema.ts",
+    "./rpc/server": "./src/rpc/server.ts",
+    "./key-manager": "./src/key-manager/index.ts",
+    "./keys": "./src/keys.ts",
+    "./jwt": "./src/jwt.ts"
   },
   "scripts": {
     "dev": "bun run --watch src/server.ts",

--- a/packages/orchestrator/src/plugins/implementations/auth.ts
+++ b/packages/orchestrator/src/plugins/implementations/auth.ts
@@ -1,16 +1,117 @@
-
 import { BasePlugin } from '../base.js';
-import { PluginContext, PluginResult } from '../types.js';
+import type { PluginContext, PluginResult, AuthContext } from '../types.js';
+import type { IAuthClient } from '../../clients/auth.js';
+
+export interface AuthPluginOptions {
+    /** Expected audience claim - if set, tokens must have this audience */
+    audience?: string;
+}
 
 export class AuthPlugin extends BasePlugin {
     name = 'AuthPlugin';
 
-    async apply(context: PluginContext): Promise<PluginResult> {
-        // Stub: Check auth
-        // In reality, verify context.authx matches requirements for context.action
-        // console.log('[AuthPlugin] Verifying auth...');
+    constructor(
+        private authClient: IAuthClient,
+        private options: AuthPluginOptions = {}
+    ) {
+        super();
+    }
 
-        // For now, just allow everything
-        return { success: true, ctx: context };
+    async apply(context: PluginContext): Promise<PluginResult> {
+        // Runtime check for authToken - kept local until pattern solidifies
+        const authToken = (context as Record<string, unknown>).authToken as string | undefined;
+
+        // No token = deny access
+        if (!authToken) {
+            return {
+                success: false,
+                error: {
+                    pluginName: this.name,
+                    message: 'Authentication token required',
+                }
+            };
+        }
+
+        try {
+            const result = await this.authClient.verifyToken(authToken, this.options.audience);
+
+            if (!result.valid) {
+                return {
+                    success: false,
+                    error: {
+                        pluginName: this.name,
+                        message: 'Invalid authentication token',
+                    }
+                };
+            }
+
+            // Extract auth context from JWT payload
+            const extractedAuth = this.extractAuthContext(result.payload);
+
+            // Require subject claim - a token without identity is useless
+            if (!extractedAuth.userId) {
+                return {
+                    success: false,
+                    error: {
+                        pluginName: this.name,
+                        message: 'Token missing subject claim',
+                    }
+                };
+            }
+
+            return {
+                success: true,
+                ctx: {
+                    ...context,
+                    // Merge with existing context instead of overwriting
+                    authxContext: { ...context.authxContext, ...extractedAuth },
+                }
+            };
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Authentication failed';
+            return {
+                success: false,
+                error: {
+                    pluginName: this.name,
+                    message,
+                    error,
+                }
+            };
+        }
+    }
+
+    /**
+     * Extract AuthContext from JWT payload
+     *
+     * Maps standard JWT claims to our internal auth context:
+     * - sub -> userId
+     * - orgId -> orgId (custom claim)
+     * - role/roles -> roles (normalize to array)
+     */
+    private extractAuthContext(payload: Record<string, unknown>): AuthContext {
+        const authContext: AuthContext = {};
+
+        // User ID from subject claim
+        if (typeof payload.sub === 'string') {
+            authContext.userId = payload.sub;
+        }
+
+        // Organization ID (custom claim)
+        if (typeof payload.orgId === 'string') {
+            authContext.orgId = payload.orgId;
+        }
+
+        // Roles - handle both single role and array of roles
+        if (Array.isArray(payload.roles)) {
+            // Reject malformed roles - all elements must be strings
+            if (!payload.roles.every((r): r is string => typeof r === 'string')) {
+                throw new Error('Malformed roles claim: all roles must be strings');
+            }
+            authContext.roles = payload.roles;
+        } else if (typeof payload.role === 'string') {
+            authContext.roles = [payload.role];
+        }
+
+        return authContext;
     }
 }

--- a/packages/orchestrator/tests/auth-plugin.integration.test.ts
+++ b/packages/orchestrator/tests/auth-plugin.integration.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { AuthPlugin } from '../src/plugins/implementations/auth.js';
+import { RouteTable } from '../src/state/route-table.js';
+import type { IAuthClient } from '../src/clients/auth.js';
+import type { PluginContext } from '../src/plugins/types.js';
+
+// Import real auth service components
+import { EphemeralKeyManager } from '@catalyst/auth/key-manager';
+import { AuthRpcServer } from '@catalyst/auth/rpc/server';
+import type { SignTokenResponse, VerifyTokenResponse, GetJwksResponse } from '@catalyst/auth/rpc/schema';
+
+/**
+ * Integration test client that calls AuthRpcServer directly.
+ * Tests real JWT signing/verification without WebSocket transport.
+ */
+class DirectAuthClient implements IAuthClient {
+    constructor(private rpcServer: AuthRpcServer) {}
+
+    async signToken(request: { subject: string; audience?: string; claims?: Record<string, unknown> }): Promise<SignTokenResponse> {
+        return this.rpcServer.signToken(request);
+    }
+
+    async verifyToken(token: string, audience?: string): Promise<VerifyTokenResponse> {
+        return this.rpcServer.verifyToken({ token, audience });
+    }
+
+    async getJwks(): Promise<GetJwksResponse> {
+        return this.rpcServer.getJwks();
+    }
+
+    close(): void {
+        // No-op for direct client
+    }
+}
+
+describe('AuthPlugin integration', () => {
+    let keyManager: EphemeralKeyManager;
+    let rpcServer: AuthRpcServer;
+    let authClient: IAuthClient;
+    let plugin: AuthPlugin;
+
+    beforeAll(async () => {
+        keyManager = new EphemeralKeyManager();
+        await keyManager.initialize();
+        rpcServer = new AuthRpcServer(keyManager);
+        authClient = new DirectAuthClient(rpcServer);
+        plugin = new AuthPlugin(authClient);
+    });
+
+    afterAll(async () => {
+        await keyManager.shutdown();
+    });
+
+    function createContext(authToken?: string): PluginContext {
+        const ctx: PluginContext & { authToken?: string } = {
+            action: { type: 'add', service: { name: 'test', url: 'http://test' } },
+            state: new RouteTable(),
+            authxContext: {},
+        };
+        if (authToken) {
+            ctx.authToken = authToken;
+        }
+        return ctx;
+    }
+
+    it('should reject requests without token', async () => {
+        const result = await plugin.apply(createContext());
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.message).toContain('required');
+        }
+    });
+
+    it('should accept valid token and extract claims', async () => {
+        // Sign a real token
+        const signResult = await authClient.signToken({
+            subject: 'user-123',
+            claims: { role: 'admin', orgId: 'org-456' },
+        });
+        expect(signResult.success).toBe(true);
+        if (!signResult.success) return;
+
+        // Verify through the plugin
+        const result = await plugin.apply(createContext(signResult.token));
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.ctx.authxContext.userId).toBe('user-123');
+            expect(result.ctx.authxContext.roles).toEqual(['admin']);
+            expect(result.ctx.authxContext.orgId).toBe('org-456');
+        }
+    });
+
+    it('should reject tampered token', async () => {
+        const signResult = await authClient.signToken({ subject: 'user-123' });
+        expect(signResult.success).toBe(true);
+        if (!signResult.success) return;
+
+        // Tamper with the token (flip a character in the signature)
+        const parts = signResult.token.split('.');
+        const sig = parts[2];
+        const tamperedSig = sig[0] === 'a' ? 'b' + sig.slice(1) : 'a' + sig.slice(1);
+        const tamperedToken = `${parts[0]}.${parts[1]}.${tamperedSig}`;
+
+        const result = await plugin.apply(createContext(tamperedToken));
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.message).toContain('Invalid');
+        }
+    });
+
+    it('should reject token with wrong audience', async () => {
+        const pluginWithAudience = new AuthPlugin(authClient, { audience: 'service-a' });
+
+        // Sign token for different audience
+        const signResult = await authClient.signToken({
+            subject: 'user-123',
+            audience: 'service-b',
+        });
+        expect(signResult.success).toBe(true);
+        if (!signResult.success) return;
+
+        const result = await pluginWithAudience.apply(createContext(signResult.token));
+
+        expect(result.success).toBe(false);
+    });
+
+    it('should accept token with matching audience', async () => {
+        const pluginWithAudience = new AuthPlugin(authClient, { audience: 'service-a' });
+
+        const signResult = await authClient.signToken({
+            subject: 'user-123',
+            audience: 'service-a',
+        });
+        expect(signResult.success).toBe(true);
+        if (!signResult.success) return;
+
+        const result = await pluginWithAudience.apply(createContext(signResult.token));
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.ctx.authxContext.userId).toBe('user-123');
+        }
+    });
+
+    it('should handle multiple roles', async () => {
+        const signResult = await authClient.signToken({
+            subject: 'user-123',
+            claims: { roles: ['admin', 'developer', 'viewer'] },
+        });
+        expect(signResult.success).toBe(true);
+        if (!signResult.success) return;
+
+        const result = await plugin.apply(createContext(signResult.token));
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.ctx.authxContext.roles).toEqual(['admin', 'developer', 'viewer']);
+        }
+    });
+
+    it('should reject garbage token', async () => {
+        const result = await plugin.apply(createContext('not.a.jwt'));
+
+        expect(result.success).toBe(false);
+    });
+});


### PR DESCRIPTION
### TL;DR

Implemented JWT authentication in the AuthPlugin with proper token verification and claim extraction.

### What changed?

- Added new exports in the auth package to expose key-manager, JWT utilities, and RPC server
- Implemented the AuthPlugin with JWT verification logic:
  - Validates tokens against the auth service
  - Extracts claims (userId, orgId, roles) into the auth context
  - Supports audience validation for enhanced security
  - Properly handles different role formats (single role or array)
- Added comprehensive integration tests that verify:
  - Token validation and rejection
  - Claim extraction
  - Audience validation
  - Tamper detection
  - Multiple role formats

### How to test?

Run the integration tests with:
```
cd packages/orchestrator
bun test tests/auth-plugin.integration.test.ts
```

The tests verify all aspects of the authentication flow using real JWT signing and verification.

### Why make this change?

This change implements proper authentication in the orchestrator, allowing it to validate user identity and permissions before processing requests. The JWT-based approach provides a secure, stateless authentication mechanism that can be verified across services.