### PR TITLE
feat: add service token command for manual JWT generation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "catalyst-monorepo",
@@ -72,6 +71,7 @@
         "catalyst": "./src/index.ts",
       },
       "dependencies": {
+        "@catalyst/auth": "workspace:*",
         "capnweb": "catalog:",
         "chalk": "^5.3.0",
         "commander": "catalog:",
@@ -80,6 +80,7 @@
         "zod": "catalog:",
       },
       "devDependencies": {
+        "@types/bun": "catalog:dev",
         "@types/inquirer": "^9.0.7",
         "@types/node": "catalog:dev",
         "@types/ws": "^8.18.1",

--- a/packages/auth/Dockerfile
+++ b/packages/auth/Dockerfile
@@ -3,7 +3,7 @@ FROM oven/bun:1 AS builder
 WORKDIR /app
 
 # Copy workspace config files (catalog definitions are in root package.json)
-COPY package.json bun.lockb ./
+COPY package.json bun.lock ./
 COPY packages/auth/package.json ./packages/auth/
 
 # Install from workspace root

--- a/packages/auth/src/rpc/schema.ts
+++ b/packages/auth/src/rpc/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod'
 
 /**
  * SignToken Request/Response schemas
@@ -7,69 +7,72 @@ import { z } from 'zod';
  * Network-level access control should be used to restrict access.
  */
 export const SignTokenRequestSchema = z.object({
-    subject: z.string().min(1, 'Subject is required'),
-    audience: z.union([z.string(), z.array(z.string())]).optional(),
-    expiresIn: z.string().optional(), // e.g., '1h', '7d', '30m'
-    claims: z.record(z.string(), z.unknown()).optional(),
-});
+  subject: z.string().min(1, 'Subject is required'),
+  audience: z.union([z.string(), z.array(z.string())]).optional(),
+  expiresIn: z.string().optional(), // e.g., '1h', '7d', '30m'
+  claims: z.record(z.string(), z.unknown()).optional(),
+})
 
-export type SignTokenRequest = z.infer<typeof SignTokenRequestSchema>;
+export type SignTokenRequest = z.infer<typeof SignTokenRequestSchema>
 
 export const SignTokenResponseSchema = z.discriminatedUnion('success', [
-    z.object({
-        success: z.literal(true),
-        token: z.string(),
-    }),
-    z.object({
-        success: z.literal(false),
-        error: z.string(),
-    }),
-]);
+  z.object({
+    success: z.literal(true),
+    token: z.string(),
+  }),
+  z.object({
+    success: z.literal(false),
+    error: z.string(),
+  }),
+])
 
-export type SignTokenResponse = z.infer<typeof SignTokenResponseSchema>;
+export type SignTokenResponse = z.infer<typeof SignTokenResponseSchema>
 
 /**
  * VerifyToken Request/Response schemas
  */
 export const VerifyTokenRequestSchema = z.object({
-    token: z.string().min(1, 'Token is required'),
-    audience: z.string().optional(),
-});
+  token: z.string().min(1, 'Token is required'),
+  audience: z.string().optional(),
+})
 
-export type VerifyTokenRequest = z.infer<typeof VerifyTokenRequestSchema>;
+export type VerifyTokenRequest = z.infer<typeof VerifyTokenRequestSchema>
 
 export const VerifyTokenResponseSchema = z.discriminatedUnion('valid', [
-    z.object({
-        valid: z.literal(true),
-        payload: z.record(z.string(), z.unknown()),
-    }),
-    z.object({
-        valid: z.literal(false),
-        error: z.string(),
-    }),
-]);
+  z.object({
+    valid: z.literal(true),
+    payload: z.record(z.string(), z.unknown()),
+  }),
+  z.object({
+    valid: z.literal(false),
+    error: z.string(),
+  }),
+])
 
-export type VerifyTokenResponse = z.infer<typeof VerifyTokenResponseSchema>;
+export type VerifyTokenResponse = z.infer<typeof VerifyTokenResponseSchema>
 
 /**
  * GetPublicKey Response schema
  */
 export const GetPublicKeyResponseSchema = z.discriminatedUnion('success', [
-    z.object({ success: z.literal(true), jwk: z.record(z.unknown()) }),
-    z.object({ success: z.literal(false), error: z.string() }),
-]);
+  z.object({ success: z.literal(true), jwk: z.record(z.string(), z.unknown()) }),
+  z.object({ success: z.literal(false), error: z.string() }),
+])
 
-export type GetPublicKeyResponse = z.infer<typeof GetPublicKeyResponseSchema>;
+export type GetPublicKeyResponse = z.infer<typeof GetPublicKeyResponseSchema>
 
 /**
  * GetJwks Response schema
  */
 export const GetJwksResponseSchema = z.discriminatedUnion('success', [
-    z.object({ success: z.literal(true), jwks: z.object({ keys: z.array(z.record(z.unknown())) }) }),
-    z.object({ success: z.literal(false), error: z.string() }),
-]);
+  z.object({
+    success: z.literal(true),
+    jwks: z.object({ keys: z.array(z.record(z.string(), z.unknown())) }),
+  }),
+  z.object({ success: z.literal(false), error: z.string() }),
+])
 
-export type GetJwksResponse = z.infer<typeof GetJwksResponseSchema>;
+export type GetJwksResponse = z.infer<typeof GetJwksResponseSchema>
 
 /**
  * RevokeToken Request/Response schemas
@@ -80,20 +83,20 @@ export type GetJwksResponse = z.infer<typeof GetJwksResponseSchema>;
  * - authToken has role: 'admin' claim (admin can revoke any token)
  */
 export const RevokeTokenRequestSchema = z.object({
-    /** Token to revoke */
-    token: z.string().min(1, 'Token is required'),
-    /** Caller's auth token for authorization */
-    authToken: z.string().min(1, 'Auth token is required'),
-});
+  /** Token to revoke */
+  token: z.string().min(1, 'Token is required'),
+  /** Caller's auth token for authorization */
+  authToken: z.string().min(1, 'Auth token is required'),
+})
 
-export type RevokeTokenRequest = z.infer<typeof RevokeTokenRequestSchema>;
+export type RevokeTokenRequest = z.infer<typeof RevokeTokenRequestSchema>
 
 export const RevokeTokenResponseSchema = z.discriminatedUnion('success', [
-    z.object({ success: z.literal(true) }),
-    z.object({ success: z.literal(false), error: z.string() }),
-]);
+  z.object({ success: z.literal(true) }),
+  z.object({ success: z.literal(false), error: z.string() }),
+])
 
-export type RevokeTokenResponse = z.infer<typeof RevokeTokenResponseSchema>;
+export type RevokeTokenResponse = z.infer<typeof RevokeTokenResponseSchema>
 
 /**
  * Rotate Request/Response schemas
@@ -102,37 +105,37 @@ export type RevokeTokenResponse = z.infer<typeof RevokeTokenResponseSchema>;
  * Only admins can rotate keys.
  */
 export const RotateRequestSchema = z.object({
-    /** Admin auth token for authorization */
-    authToken: z.string().min(1, 'Auth token is required'),
-    /** Skip grace period, invalidate old key immediately */
-    immediate: z.boolean().optional().default(false),
-    /** Custom grace period in milliseconds (default: 24 hours) */
-    gracePeriodMs: z.number().positive().optional(),
-});
+  /** Admin auth token for authorization */
+  authToken: z.string().min(1, 'Auth token is required'),
+  /** Skip grace period, invalidate old key immediately */
+  immediate: z.boolean().optional().default(false),
+  /** Custom grace period in milliseconds (default: 24 hours) */
+  gracePeriodMs: z.number().positive().optional(),
+})
 
-export type RotateRequest = z.infer<typeof RotateRequestSchema>;
+export type RotateRequest = z.infer<typeof RotateRequestSchema>
 
 export const RotateResponseSchema = z.discriminatedUnion('success', [
-    z.object({
-        success: z.literal(true),
-        previousKeyId: z.string(),
-        newKeyId: z.string(),
-        gracePeriodEndsAt: z.string().optional(), // ISO date string
-    }),
-    z.object({
-        success: z.literal(false),
-        error: z.string(),
-    }),
-]);
+  z.object({
+    success: z.literal(true),
+    previousKeyId: z.string(),
+    newKeyId: z.string(),
+    gracePeriodEndsAt: z.string().optional(), // ISO date string
+  }),
+  z.object({
+    success: z.literal(false),
+    error: z.string(),
+  }),
+])
 
-export type RotateResponse = z.infer<typeof RotateResponseSchema>;
+export type RotateResponse = z.infer<typeof RotateResponseSchema>
 
 /**
  * GetCurrentKeyId Response schema
  */
 export const GetCurrentKeyIdResponseSchema = z.discriminatedUnion('success', [
-    z.object({ success: z.literal(true), kid: z.string() }),
-    z.object({ success: z.literal(false), error: z.string() }),
-]);
+  z.object({ success: z.literal(true), kid: z.string() }),
+  z.object({ success: z.literal(false), error: z.string() }),
+])
 
-export type GetCurrentKeyIdResponse = z.infer<typeof GetCurrentKeyIdResponseSchema>;
+export type GetCurrentKeyIdResponse = z.infer<typeof GetCurrentKeyIdResponseSchema>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,6 +11,7 @@
     "test": "bun test tests/*.unit.test.ts && bun test tests/*.integration.test.ts"
   },
   "dependencies": {
+    "@catalyst/auth": "workspace:*",
     "capnweb": "catalog:",
     "chalk": "^5.3.0",
     "commander": "catalog:",
@@ -19,6 +20,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@types/bun": "catalog:dev",
     "@types/inquirer": "^9.0.7",
     "@types/node": "catalog:dev",
     "@types/ws": "^8.18.1",

--- a/packages/cli/src/commands/service-token.ts
+++ b/packages/cli/src/commands/service-token.ts
@@ -1,0 +1,158 @@
+import { Command } from 'commander'
+import { WebSocket } from 'ws'
+import { newWebSocketRpcSession } from 'capnweb'
+import chalk from 'chalk'
+import type { SignTokenRequest, SignTokenResponse } from '@catalyst/auth/rpc/schema'
+
+// RPC stub interface (what the remote service exposes)
+interface AuthRpcStub {
+  signToken(request: SignTokenRequest): Promise<SignTokenResponse>
+}
+
+/**
+ * Create an auth service RPC client
+ */
+function createAuthClient(endpoint: string): AuthRpcStub {
+  // Polyfill WebSocket for CapnWeb in Node environment
+  if (!globalThis.WebSocket) {
+    // @ts-expect-error WebSocket is not typed
+    globalThis.WebSocket = WebSocket
+  }
+
+  return newWebSocketRpcSession(endpoint, {
+    WebSocket: WebSocket as any,
+  }) as unknown as AuthRpcStub
+}
+
+/**
+ * Parse JSON claims from CLI input
+ */
+export function parseClaims(claimsJson?: string): Record<string, unknown> | undefined {
+  if (!claimsJson) {
+    return undefined
+  }
+
+  try {
+    const parsed = JSON.parse(claimsJson)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('Claims must be a JSON object')
+    }
+    return parsed as Record<string, unknown>
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(`Invalid JSON for claims: ${error.message}`)
+    }
+    throw error
+  }
+}
+
+/**
+ * Generate a service token via the auth service RPC
+ */
+async function generateToken(
+  subject: string,
+  options: {
+    audience?: string[]
+    expiresIn?: string
+    claims?: string
+    authEndpoint?: string
+    raw?: boolean
+  }
+): Promise<void> {
+  const authEndpoint =
+    options.authEndpoint || process.env.CATALYST_AUTH_ENDPOINT || 'ws://localhost:4020/rpc'
+
+  let client: AuthRpcStub | null = null
+  try {
+    client = createAuthClient(authEndpoint)
+
+    // Parse claims if provided
+    let parsedClaims: Record<string, unknown> | undefined
+    if (options.claims) {
+      parsedClaims = parseClaims(options.claims)
+    }
+
+    // Build request
+    const request: SignTokenRequest = {
+      subject,
+      ...(options.audience &&
+        options.audience.length > 0 && {
+          audience: options.audience.length === 1 ? options.audience[0] : options.audience,
+        }),
+      ...(options.expiresIn && { expiresIn: options.expiresIn }),
+      ...(parsedClaims && { claims: parsedClaims }),
+    }
+
+    // Call RPC
+    const response = await client.signToken(request)
+
+    if (!response.success) {
+      console.error(chalk.red('Failed to generate token:'), response.error)
+      process.exit(1)
+    }
+
+    // Output result
+    if (options.raw) {
+      // Raw output: just the token, no newline (for piping)
+      process.stdout.write(response.token)
+    } else {
+      // Formatted output: JSON with token and metadata
+      const output = {
+        token: response.token,
+        subject,
+        ...(options.audience && options.audience.length > 0 && { audience: options.audience }),
+        ...(options.expiresIn && { expiresIn: options.expiresIn }),
+        ...(parsedClaims && { claims: parsedClaims }),
+      }
+      console.log(JSON.stringify(output, null, 2))
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    console.error(chalk.red('Error generating token:'), message)
+    process.exit(1)
+  }
+}
+
+export function serviceTokenCommands() {
+  const serviceToken = new Command('service-token').description('Generate service tokens')
+
+  serviceToken
+    .command('generate')
+    .description('Generate a new JWT service token')
+    .requiredOption('-s, --subject <subject>', 'Token subject (required)')
+    .option(
+      '-a, --audience <audience>',
+      'Token audience (can be specified multiple times)',
+      (value, previous: string[] = []) => {
+        return [...previous, value]
+      },
+      []
+    )
+    .option(
+      '-e, --expires-in <duration>',
+      "Token expiration (format: '1h', '30m', '7d', etc., default: '1h')"
+    )
+    .option(
+      '-c, --claims <json>',
+      'Custom claims as JSON string (e.g., \'{"role":"admin","permissions":["read","write"]}\')'
+    )
+    .option('-r, --raw', 'Output only the raw JWT token (no formatting, useful for piping)')
+    .option(
+      '--auth-endpoint <url>',
+      'Auth service RPC endpoint (defaults to CATALYST_AUTH_ENDPOINT env var or ws://localhost:4020/rpc)'
+    )
+    .action(async (options) => {
+      await generateToken(options.subject, {
+        audience:
+          Array.isArray(options.audience) && options.audience.length > 0
+            ? options.audience
+            : undefined,
+        expiresIn: options.expiresIn,
+        claims: options.claims,
+        authEndpoint: options.authEndpoint,
+        raw: options.raw,
+      })
+    })
+
+  return serviceToken
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,17 +1,15 @@
 #!/usr/bin/env bun
-import { Command } from 'commander';
-import chalk from 'chalk';
-import { serviceCommands } from './commands/service.js';
-import { metricsCommands } from './commands/metrics.js';
+import { Command } from 'commander'
+import { serviceCommands } from './commands/service.js'
+import { metricsCommands } from './commands/metrics.js'
+import { serviceTokenCommands } from './commands/service-token.js'
 
-const program = new Command();
+const program = new Command()
 
-program
-    .name('catalyst')
-    .description('Catalyst Node CLI')
-    .version('0.0.1');
+program.name('catalyst').description('Catalyst Node CLI').version('0.0.1')
 
-program.addCommand(serviceCommands());
-program.addCommand(metricsCommands());
+program.addCommand(serviceCommands())
+program.addCommand(metricsCommands())
+program.addCommand(serviceTokenCommands())
 
-program.parse(process.argv);
+program.parse(process.argv)

--- a/packages/cli/tests/service-token.integration.test.ts
+++ b/packages/cli/tests/service-token.integration.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import type { StartedTestContainer } from 'testcontainers'
+import { GenericContainer, Wait } from 'testcontainers'
+import { resolve } from 'path'
+import { execSync } from 'child_process'
+
+// Increase timeout for container build
+const TIMEOUT = 180_000
+const RUN_CONTAINER_TESTS = process.env.RUN_CONTAINER_TESTS === 'true'
+
+// Skip rebuild if image exists (set REBUILD_IMAGES=true to force rebuild)
+const FORCE_REBUILD = process.env.REBUILD_IMAGES === 'true'
+
+function imageExists(imageName: string): boolean {
+  try {
+    const output = execSync(`podman images -q ${imageName}`, { encoding: 'utf-8' })
+    return output.trim().length > 0
+  } catch {
+    return false
+  }
+}
+
+function ensureImage(imageName: string, dockerfile: string, buildContext: string): void {
+  if (!FORCE_REBUILD && imageExists(imageName)) {
+    console.log(`Using existing image: ${imageName}`)
+    return
+  }
+
+  console.log(`Building image: ${imageName}...`)
+  try {
+    execSync(`podman build -t ${imageName} -f ${dockerfile} .`, {
+      cwd: buildContext,
+      stdio: 'inherit',
+    })
+  } catch (error) {
+    // Check if it's a Podman connection error
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    if (errorMessage.includes('Cannot connect to Podman') || errorMessage.includes('podman')) {
+      throw new Error(
+        'Podman/Docker is not available. Integration tests require Podman/Docker to be running. Skipping integration tests.'
+      )
+    }
+    throw error
+  }
+}
+
+if (!RUN_CONTAINER_TESTS) {
+  console.warn(
+    'Skipping Service Token CLI integration tests (set RUN_CONTAINER_TESTS=true to enable).'
+  )
+  describe.skip('Service Token CLI Integration', () => {})
+} else {
+  describe('Service Token CLI Integration', () => {
+    let container: StartedTestContainer | null = null
+    let port: number
+    const buildContext = resolve(__dirname, '../../..')
+    let skipTests = false
+
+    beforeAll(
+      'setup auth container',
+      async () => {
+        try {
+          const imageName = 'auth-service:test'
+          const dockerfile = 'packages/auth/Dockerfile'
+
+          ensureImage(imageName, dockerfile, buildContext)
+
+          console.log('Starting auth service container...')
+          container = await new GenericContainer(imageName)
+            .withExposedPorts(4020)
+            .withEnvironment({
+              CATALYST_AUTH_PORT: '4020',
+              CATALYST_AUTH_KEYS_DIR: '/tmp/keys',
+            })
+            .withWaitStrategy(Wait.forHttp('/health', 4020))
+            .withStartupTimeout(TIMEOUT)
+            .start()
+
+          port = container.getMappedPort(4020)
+          console.log(`Auth service started on port ${port}`)
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error)
+          if (
+            errorMessage.includes('Podman') ||
+            errorMessage.includes('Docker') ||
+            errorMessage.includes('not available')
+          ) {
+            console.warn('Skipping integration tests: Podman/Docker not available')
+            skipTests = true
+          } else {
+            throw error
+          }
+        }
+      },
+      TIMEOUT
+    )
+
+    afterAll(async () => {
+      if (container) {
+        await container.stop()
+      }
+    })
+
+    async function runCLI(
+      args: string[]
+    ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+      if (!container || !port) {
+        throw new Error('Container not initialized')
+      }
+      const cliPath = resolve(__dirname, '../src/index.ts')
+      // Use the same bun executable that's running this test
+      const bunExecutable = process.execPath || 'bun'
+      const env = {
+        ...process.env,
+        CATALYST_AUTH_ENDPOINT: `ws://localhost:${port}/rpc`,
+      }
+
+      try {
+        const proc = Bun.spawn([bunExecutable, cliPath, ...args], {
+          env,
+          stdout: 'pipe',
+          stderr: 'pipe',
+        })
+
+        const [stdout, stderr, exitCode] = await Promise.all([
+          new Response(proc.stdout).text(),
+          new Response(proc.stderr).text(),
+          proc.exited,
+        ])
+
+        return {
+          stdout,
+          stderr,
+          exitCode: exitCode ?? 0,
+        }
+      } catch (error) {
+        return {
+          stdout: '',
+          stderr: error instanceof Error ? error.message : String(error),
+          exitCode: 1,
+        }
+      }
+    }
+
+    it('should generate a basic token', async () => {
+      if (skipTests || !container) {
+        console.log('Skipping test: Podman/Docker not available')
+        return
+      }
+      const result = await runCLI(['service-token', 'generate', '--subject', 'test-user'])
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('"token"')
+      expect(result.stdout).toContain('"subject"')
+      expect(result.stdout).toContain('test-user')
+
+      // Verify it's valid JSON
+      const output = JSON.parse(result.stdout)
+      expect(output.token).toBeDefined()
+      expect(typeof output.token).toBe('string')
+      expect(output.subject).toBe('test-user')
+    })
+
+    it('should generate token with expiry', async () => {
+      if (skipTests || !container) {
+        console.log('Skipping test: Podman/Docker not available')
+        return
+      }
+      const result = await runCLI([
+        'service-token',
+        'generate',
+        '--subject',
+        'test-user',
+        '--expires-in',
+        '30m',
+      ])
+
+      expect(result.exitCode).toBe(0)
+      const output = JSON.parse(result.stdout)
+      expect(output.token).toBeDefined()
+      expect(output.expiresIn).toBe('30m')
+    })
+
+    it('should generate token with audience', async () => {
+      if (skipTests || !container) {
+        console.log('Skipping test: Podman/Docker not available')
+        return
+      }
+      const result = await runCLI([
+        'service-token',
+        'generate',
+        '--subject',
+        'test-user',
+        '--audience',
+        'service-a',
+        '--audience',
+        'service-b',
+      ])
+
+      expect(result.exitCode).toBe(0)
+      const output = JSON.parse(result.stdout)
+      expect(output.token).toBeDefined()
+      expect(output.audience).toEqual(['service-a', 'service-b'])
+    })
+
+    it('should generate token with custom claims', async () => {
+      if (skipTests || !container) {
+        console.log('Skipping test: Podman/Docker not available')
+        return
+      }
+      const claims = '{"role":"admin","permissions":["read","write"]}'
+      const result = await runCLI([
+        'service-token',
+        'generate',
+        '--subject',
+        'test-user',
+        '--claims',
+        claims,
+      ])
+
+      expect(result.exitCode).toBe(0)
+      const output = JSON.parse(result.stdout)
+      expect(output.token).toBeDefined()
+      expect(output.claims).toEqual({
+        role: 'admin',
+        permissions: ['read', 'write'],
+      })
+    })
+
+    it('should output raw token with --raw flag', async () => {
+      if (skipTests || !container) {
+        console.log('Skipping test: Podman/Docker not available')
+        return
+      }
+      const result = await runCLI(['service-token', 'generate', '--subject', 'test-user', '--raw'])
+
+      expect(result.exitCode).toBe(0)
+      // Raw output should be just the token, no JSON
+      expect(result.stdout).not.toContain('"token"')
+      expect(result.stdout).not.toContain('"subject"')
+      // Should be a JWT (three parts separated by dots)
+      const parts = result.stdout.trim().split('.')
+      expect(parts.length).toBe(3)
+    })
+
+    it('should fail without required subject', async () => {
+      if (skipTests || !container) {
+        console.log('Skipping test: Podman/Docker not available')
+        return
+      }
+      const result = await runCLI(['service-token', 'generate'])
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toContain('required option')
+      expect(result.stderr).toContain('subject')
+    })
+
+    it('should fail with invalid claims JSON', async () => {
+      if (skipTests || !container) {
+        console.log('Skipping test: Podman/Docker not available')
+        return
+      }
+      const result = await runCLI([
+        'service-token',
+        'generate',
+        '--subject',
+        'test-user',
+        '--claims',
+        '{invalid json}',
+      ])
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toContain('Invalid JSON')
+    })
+
+    it('should generate token with all options', async () => {
+      if (skipTests || !container) {
+        console.log('Skipping test: Podman/Docker not available')
+        return
+      }
+      const claims = '{"role":"admin"}'
+      const result = await runCLI([
+        'service-token',
+        'generate',
+        '--subject',
+        'test-user',
+        '--expires-in',
+        '7d',
+        '--audience',
+        'service-a',
+        '--audience',
+        'service-b',
+        '--claims',
+        claims,
+      ])
+
+      expect(result.exitCode).toBe(0)
+      const output = JSON.parse(result.stdout)
+      expect(output.token).toBeDefined()
+      expect(output.subject).toBe('test-user')
+      expect(output.expiresIn).toBe('7d')
+      expect(output.audience).toEqual(['service-a', 'service-b'])
+      expect(output.claims).toEqual({ role: 'admin' })
+    })
+  })
+}

--- a/packages/cli/tests/service-token.unit.test.ts
+++ b/packages/cli/tests/service-token.unit.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'bun:test'
+import { parseClaims } from '../src/commands/service-token.js'
+
+describe('Service Token Commands', () => {
+  describe('parseClaims', () => {
+    it('should parse valid JSON claims', () => {
+      const claims = '{"role":"admin","permissions":["read","write"]}'
+      const result = parseClaims(claims)
+      expect(result).toEqual({
+        role: 'admin',
+        permissions: ['read', 'write'],
+      })
+    })
+
+    it('should return undefined for empty input', () => {
+      expect(parseClaims(undefined)).toBeUndefined()
+      expect(parseClaims('')).toBeUndefined()
+    })
+
+    it('should throw error for invalid JSON', () => {
+      expect(() => parseClaims('{invalid json}')).toThrow('Invalid JSON for claims')
+    })
+
+    it('should throw error for non-object JSON', () => {
+      expect(() => parseClaims('"string"')).toThrow('Claims must be a JSON object')
+      expect(() => parseClaims('123')).toThrow('Claims must be a JSON object')
+      expect(() => parseClaims('["array"]')).toThrow('Claims must be a JSON object')
+      expect(() => parseClaims('null')).toThrow('Claims must be a JSON object')
+    })
+
+    it('should parse nested objects', () => {
+      const claims = '{"user":{"id":"123","name":"test"},"metadata":{"version":1}}'
+      const result = parseClaims(claims)
+      expect(result).toEqual({
+        user: { id: '123', name: 'test' },
+        metadata: { version: 1 },
+      })
+    })
+  })
+})

--- a/packages/cli/tests/service.integration.test.ts
+++ b/packages/cli/tests/service.integration.test.ts
@@ -1,194 +1,210 @@
-import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
-import { GenericContainer, Network, Wait, StartedTestContainer, StartedNetwork } from 'testcontainers';
-import { join, resolve } from 'path';
-import { addService, listServices } from '../src/commands/service.js';
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import type { StartedTestContainer, StartedNetwork } from 'testcontainers'
+import { GenericContainer, Network, Wait } from 'testcontainers'
+import { join, resolve } from 'path'
+import { addService, listServices } from '../src/commands/service.js'
 
 // Increase timeout for builds
-const TIMEOUT = 180_000;
+const TIMEOUT = 180_000
+const RUN_CONTAINER_TESTS = process.env.RUN_CONTAINER_TESTS === 'true'
 
-describe('CLI E2E with Containers', () => {
-    let network: StartedNetwork;
-    let gatewayContainer: StartedTestContainer;
-    let orchestratorContainer: StartedTestContainer;
-    let booksContainer: StartedTestContainer;
-    let moviesContainer: StartedTestContainer;
+if (!RUN_CONTAINER_TESTS) {
+  console.warn('Skipping CLI container integration tests (set RUN_CONTAINER_TESTS=true to enable).')
+  describe.skip('CLI E2E with Containers', () => {})
+} else {
+  describe('CLI E2E with Containers', () => {
+    let network: StartedNetwork
+    let gatewayContainer: StartedTestContainer
+    let orchestratorContainer: StartedTestContainer
+    let booksContainer: StartedTestContainer
+    let moviesContainer: StartedTestContainer
 
-    let gatewayPort: number;
-    let orchestratorPort: number;
-    let booksUri: string;
-    let moviesUri: string;
+    let gatewayPort: number
+    let orchestratorPort: number
+    let booksUri: string
+    let moviesUri: string
 
-    beforeAll(async () => {
-        network = await new Network().start();
+    beforeAll(
+      'setup CLI containers',
+      async () => {
+        network = await new Network().start()
 
-        const repoRoot = resolve(__dirname, '../../..');
-        const examplesDir = join(repoRoot, 'packages/examples');
-        const gatewayDir = join(repoRoot, 'packages/gateway');
-        const orchestratorDir = join(repoRoot, 'packages/orchestrator');
+        const repoRoot = resolve(__dirname, '../../..')
+        const examplesDir = join(repoRoot, 'packages/examples')
+        const gatewayDir = join(repoRoot, 'packages/gateway')
+        const orchestratorDir = join(repoRoot, 'packages/orchestrator')
 
-        console.log('Building container images...');
+        console.log('Building container images...')
 
         const buildBooks = async () => {
-            await Bun.spawn(['podman', 'build', '-t', 'books-service:test', '-f', 'Dockerfile.books', '.'], {
-                cwd: examplesDir,
-                stdout: 'ignore',
-                stderr: 'inherit'
-            }).exited;
-        };
+          await Bun.spawn(
+            ['podman', 'build', '-t', 'books-service:test', '-f', 'Dockerfile.books', '.'],
+            {
+              cwd: examplesDir,
+              stdout: 'ignore',
+              stderr: 'inherit',
+            }
+          ).exited
+        }
 
         const buildMovies = async () => {
-            await Bun.spawn(['podman', 'build', '-t', 'movies-service:test', '-f', 'Dockerfile.movies', '.'], {
-                cwd: examplesDir,
-                stdout: 'ignore',
-                stderr: 'inherit'
-            }).exited;
-        };
+          await Bun.spawn(
+            ['podman', 'build', '-t', 'movies-service:test', '-f', 'Dockerfile.movies', '.'],
+            {
+              cwd: examplesDir,
+              stdout: 'ignore',
+              stderr: 'inherit',
+            }
+          ).exited
+        }
 
         const buildGateway = async () => {
-            await Bun.spawn(['podman', 'build', '-t', 'gateway-service:test', '.'], {
-                cwd: gatewayDir,
-                stdout: 'ignore',
-                stderr: 'inherit'
-            }).exited;
-        };
+          await Bun.spawn(['podman', 'build', '-t', 'gateway-service:test', '.'], {
+            cwd: gatewayDir,
+            stdout: 'ignore',
+            stderr: 'inherit',
+          }).exited
+        }
 
         // We build orchestrator manually instead of using existing image to ensure fresh code
         const buildOrchestrator = async () => {
-            await Bun.spawn(['podman', 'build', '-t', 'orchestrator-service:test', '.'], {
-                cwd: orchestratorDir,
-                stdout: 'ignore',
-                stderr: 'inherit'
-            }).exited;
+          await Bun.spawn(['podman', 'build', '-t', 'orchestrator-service:test', '.'], {
+            cwd: orchestratorDir,
+            stdout: 'ignore',
+            stderr: 'inherit',
+          }).exited
         }
 
-        await Promise.all([buildBooks(), buildMovies(), buildGateway(), buildOrchestrator()]);
-        console.log('Container images built successfully.');
+        await Promise.all([buildBooks(), buildMovies(), buildGateway(), buildOrchestrator()])
+        console.log('Container images built successfully.')
 
-        console.log('Starting Containers...');
+        console.log('Starting Containers...')
 
         booksContainer = await new GenericContainer('books-service:test')
-            .withExposedPorts(8080)
-            .withNetwork(network)
-            .withNetworkAliases('books')
-            .withStartupTimeout(180_000)
-            .withWaitStrategy(Wait.forHttp('/health', 8080))
-            .start();
+          .withExposedPorts(8080)
+          .withNetwork(network)
+          .withNetworkAliases('books')
+          .withStartupTimeout(180_000)
+          .withWaitStrategy(Wait.forHttp('/health', 8080))
+          .start()
 
-        const booksPort = booksContainer.getMappedPort(8080);
+        const booksPort = booksContainer.getMappedPort(8080)
         // Inside container network, use alias
-        booksUri = 'http://books:8080/graphql';
-        console.log(`Books started on port ${booksPort}`);
+        booksUri = 'http://books:8080/graphql'
+        console.log(`Books started on port ${booksPort}`)
 
         moviesContainer = await new GenericContainer('movies-service:test')
-            .withExposedPorts(8080)
-            .withNetwork(network)
-            .withNetworkAliases('movies')
-            .withStartupTimeout(180_000)
-            .withWaitStrategy(Wait.forHttp('/health', 8080))
-            .start();
+          .withExposedPorts(8080)
+          .withNetwork(network)
+          .withNetworkAliases('movies')
+          .withStartupTimeout(180_000)
+          .withWaitStrategy(Wait.forHttp('/health', 8080))
+          .start()
 
-        moviesUri = 'http://movies:8080/graphql';
+        moviesUri = 'http://movies:8080/graphql'
 
         gatewayContainer = await new GenericContainer('gateway-service:test')
-            .withExposedPorts(4000)
-            .withNetwork(network)
-            .withNetworkAliases('gateway')
-            .withStartupTimeout(180_000)
-            .withWaitStrategy(Wait.forHttp('/', 4000))
-            .start();
+          .withExposedPorts(4000)
+          .withNetwork(network)
+          .withNetworkAliases('gateway')
+          .withStartupTimeout(180_000)
+          .withWaitStrategy(Wait.forHttp('/', 4000))
+          .start()
 
-        gatewayPort = gatewayContainer.getMappedPort(4000);
-        console.log(`Gateway started on port ${gatewayPort}`);
+        gatewayPort = gatewayContainer.getMappedPort(4000)
+        console.log(`Gateway started on port ${gatewayPort}`)
 
         orchestratorContainer = await new GenericContainer('orchestrator-service:test')
-            .withExposedPorts(3000)
-            .withNetwork(network)
-            .withNetworkAliases('orchestrator')
-            // Tell Orchestrator where Gateway is (internal container network alias)
-            .withEnvironment({
-                CATALYST_GQL_GATEWAY_ENDPOINT: 'ws://gateway:4000/api',
-                PORT: '3000'
-            })
-            .withStartupTimeout(180_000)
-            .withWaitStrategy(Wait.forHttp('/health', 3000))
-            .start();
+          .withExposedPorts(3000)
+          .withNetwork(network)
+          .withNetworkAliases('orchestrator')
+          // Tell Orchestrator where Gateway is (internal container network alias)
+          .withEnvironment({
+            CATALYST_GQL_GATEWAY_ENDPOINT: 'ws://gateway:4000/api',
+            PORT: '3000',
+          })
+          .withStartupTimeout(180_000)
+          .withWaitStrategy(Wait.forHttp('/health', 3000))
+          .start()
 
-        orchestratorPort = orchestratorContainer.getMappedPort(3000);
-        console.log(`Orchestrator started on port ${orchestratorPort}`);
+        orchestratorPort = orchestratorContainer.getMappedPort(3000)
+        console.log(`Orchestrator started on port ${orchestratorPort}`)
 
         // --- Configure CLI to point to this Orchestrator ---
-        process.env.CATALYST_ORCHESTRATOR_URL = `ws://localhost:${orchestratorPort}/rpc`;
-
-    }, TIMEOUT);
+        process.env.CATALYST_ORCHESTRATOR_URL = `ws://localhost:${orchestratorPort}/rpc`
+      },
+      TIMEOUT
+    )
 
     afterAll(async () => {
-        await moviesContainer?.stop();
-        await booksContainer?.stop();
-        await gatewayContainer?.stop();
-        await orchestratorContainer?.stop();
-        await network?.stop();
-    });
+      await moviesContainer?.stop()
+      await booksContainer?.stop()
+      await gatewayContainer?.stop()
+      await orchestratorContainer?.stop()
+      await network?.stop()
+    })
 
     it('should add services via CLI and reflect in list', async () => {
-        // 1. Initial State: Empty
-        console.log('--- Step 1: List Empty ---');
-        const listRes1 = await listServices();
-        expect(listRes1.success).toBe(true);
-        if (listRes1.success) {
-            expect(listRes1.data).toHaveLength(0);
-        }
+      // 1. Initial State: Empty
+      console.log('--- Step 1: List Empty ---')
+      const listRes1 = await listServices()
+      expect(listRes1.success).toBe(true)
+      if (listRes1.success) {
+        expect(listRes1.data).toHaveLength(0)
+      }
 
-        // 2. Add Books
-        console.log('--- Step 2: Add Books ---');
-        const addRes1 = await addService({
-            name: 'books',
-            endpoint: booksUri,
-            protocol: 'tcp:graphql'
-        });
-        expect(addRes1.success).toBe(true);
+      // 2. Add Books
+      console.log('--- Step 2: Add Books ---')
+      const addRes1 = await addService({
+        name: 'books',
+        endpoint: booksUri,
+        protocol: 'tcp:graphql',
+      })
+      expect(addRes1.success).toBe(true)
 
-        // 3. Verify List has Books
-        console.log('--- Step 3: Verify Books ---');
-        const listRes2 = await listServices();
-        expect(listRes2.success).toBe(true);
-        if (listRes2.success) {
-            expect(listRes2.data).toHaveLength(1);
-            expect(listRes2.data![0].service.name).toBe('books');
-            expect(listRes2.data![0].service.endpoint).toBe(booksUri);
-        }
+      // 3. Verify List has Books
+      console.log('--- Step 3: Verify Books ---')
+      const listRes2 = await listServices()
+      expect(listRes2.success).toBe(true)
+      if (listRes2.success) {
+        expect(listRes2.data).toHaveLength(1)
+        expect(listRes2.data![0].service.name).toBe('books')
+        expect(listRes2.data![0].service.endpoint).toBe(booksUri)
+      }
 
-        // 4. Add Movies
-        console.log('--- Step 4: Add Movies ---');
-        const addRes2 = await addService({
-            name: 'movies',
-            endpoint: moviesUri,
-            protocol: 'tcp:graphql'
-        });
-        expect(addRes2.success).toBe(true);
+      // 4. Add Movies
+      console.log('--- Step 4: Add Movies ---')
+      const addRes2 = await addService({
+        name: 'movies',
+        endpoint: moviesUri,
+        protocol: 'tcp:graphql',
+      })
+      expect(addRes2.success).toBe(true)
 
-        // 5. Verify List has Both
-        console.log('--- Step 5: Verify Both ---');
-        const listRes3 = await listServices();
-        expect(listRes3.success).toBe(true);
-        if (listRes3.success) {
-            expect(listRes3.data).toHaveLength(2);
-            const names = listRes3.data!.map(d => d.service.name).sort();
-            expect(names).toEqual(['books', 'movies']);
-        }
+      // 5. Verify List has Both
+      console.log('--- Step 5: Verify Both ---')
+      const listRes3 = await listServices()
+      expect(listRes3.success).toBe(true)
+      if (listRes3.success) {
+        expect(listRes3.data).toHaveLength(2)
+        const names = listRes3.data!.map((d) => d.service.name).sort()
+        expect(names).toEqual(['books', 'movies'])
+      }
 
-        // 6. Verify Metrics
-        console.log('--- Step 6: Verify Metrics ---');
-        const { fetchMetrics } = await import('../src/commands/metrics.js');
-        const metricsRes = await fetchMetrics();
-        expect(metricsRes.success).toBe(true);
-        if (metricsRes.success) {
-            expect(metricsRes.data).toBeDefined();
-            // Metrics might be empty or match routes, just verify success and structure
-            expect(metricsRes.data.metrics).toBeDefined();
-        }
+      // 6. Verify Metrics
+      console.log('--- Step 6: Verify Metrics ---')
+      const { fetchMetrics } = await import('../src/commands/metrics.js')
+      const metricsRes = await fetchMetrics()
+      expect(metricsRes.success).toBe(true)
+      if (metricsRes.success) {
+        expect(metricsRes.data).toBeDefined()
+        // Metrics might be empty or match routes, just verify success and structure
+        expect(metricsRes.data.metrics).toBeDefined()
+      }
 
-        // Note: We could verify gateway connectivity here too by querying localhost:${gatewayPort},
-        // but that logic is covered in orchestrator's integration test. 
-        // Here we focus on: CLI -> Orchestrator communication.
-    });
-});
+      // Note: We could verify gateway connectivity here too by querying localhost:${gatewayPort},
+      // but that logic is covered in orchestrator's integration test.
+      // Here we focus on: CLI -> Orchestrator communication.
+    })
+  })
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,19 +1,14 @@
 {
-    "compilerOptions": {
-        "target": "ESNext",
-        "module": "ESNext",
-        "moduleResolution": "bundler",
-        "strict": true,
-        "skipLibCheck": true,
-        "outDir": "./dist",
-        "types": [
-            "node",
-            "bun-types"
-        ],
-        "allowImportingTsExtensions": true,
-        "noEmit": true
-    },
-    "include": [
-        "src/**/*"
-    ]
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "types": ["bun"],
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
 }

--- a/packages/orchestrator/src/plugins/types.ts
+++ b/packages/orchestrator/src/plugins/types.ts
@@ -1,40 +1,40 @@
-import { z } from 'zod';
-import { ActionSchema } from '../rpc/schema/index.js';
-export { ActionSchema };
-import { RouteTable } from '../state/route-table.js';
+import { z } from 'zod'
+import { ActionSchema } from '../rpc/schema/index.js'
+export { ActionSchema }
+import { RouteTable } from '../state/route-table.js'
 
 export const AuthContextSchema = z.object({
-    userId: z.string().optional(),
-    orgId: z.string().optional(),
-    roles: z.array(z.string()).optional(),
-});
-export type AuthContext = z.infer<typeof AuthContextSchema>;
+  userId: z.string().optional(),
+  orgId: z.string().optional(),
+  roles: z.array(z.string()).optional(),
+})
+export type AuthContext = z.infer<typeof AuthContextSchema>
 
 export const PluginContextSchema = z.object({
-    action: ActionSchema,
-    state: z.instanceof(RouteTable),
-    authxContext: AuthContextSchema,
-    result: z.record(z.any()).optional(),
-});
-export type PluginContext = z.infer<typeof PluginContextSchema>;
+  action: ActionSchema,
+  state: z.instanceof(RouteTable),
+  authxContext: AuthContextSchema,
+  result: z.record(z.string(), z.any()).optional(),
+})
+export type PluginContext = z.infer<typeof PluginContextSchema>
 
 export const PluginResultSchema = z.discriminatedUnion('success', [
-    z.object({
-        success: z.literal(true),
-        ctx: PluginContextSchema,
+  z.object({
+    success: z.literal(true),
+    ctx: PluginContextSchema,
+  }),
+  z.object({
+    success: z.literal(false),
+    error: z.object({
+      pluginName: z.string(),
+      message: z.string(),
+      error: z.any().optional(),
     }),
-    z.object({
-        success: z.literal(false),
-        error: z.object({
-            pluginName: z.string(),
-            message: z.string(),
-            error: z.any().optional(),
-        }),
-    }),
-]);
-export type PluginResult = z.infer<typeof PluginResultSchema>;
+  }),
+])
+export type PluginResult = z.infer<typeof PluginResultSchema>
 
 export interface PluginInterface {
-    name: string;
-    apply(context: PluginContext): Promise<PluginResult>;
+  name: string
+  apply(context: PluginContext): Promise<PluginResult>
 }


### PR DESCRIPTION
### TL;DR

Added a service token generation command to the CLI that interacts with the auth service.

### What changed?

- Added a new `service-token` command to the CLI that allows generating JWT tokens via the auth service
- Added dependency on `@catalyst/auth` package to the CLI
- Fixed type definitions in the auth service schema (improved record type safety)
- Updated Dockerfile to use `bun.lock` instead of `bun.lockb`
- Added unit and integration tests for the new service token functionality
- Made integration tests conditional based on the `RUN_CONTAINER_TESTS` environment variable

### How to test?

1. Run the CLI with the new command:
```bash
bun run cli service-token generate --subject user-123 --audience my-service --expires-in 1h --claims '{"role":"admin"}'
```

2. Run the unit tests:
```bash
cd packages/cli
bun test tests/service-token.unit.test.ts
```

3. Run the integration tests (requires Podman/Docker):
```bash
RUN_CONTAINER_TESTS=true bun test tests/service-token.integration.test.ts
```

### Why make this change?

This adds a convenient way to generate service tokens from the command line, which is useful for development, testing, and automation workflows. The CLI now provides a user-friendly interface to the auth service's token generation capabilities, with support for customizing subject, audience, expiration, and custom claims.