### PR TITLE
chore: patching the local routing table

### DIFF
--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -15,8 +15,7 @@ export async function addService(params: AddServiceParams): Promise<CliResult<vo
         const root = await createClient() as any;
 
         const action = {
-            resource: 'local-routing',
-            action: 'create-datachannel',
+            resource: 'create-datachannel:local-routing',
             data: params
         };
 

--- a/packages/orchestrator/src/plugins/implementations/local-routing.ts
+++ b/packages/orchestrator/src/plugins/implementations/local-routing.ts
@@ -6,20 +6,17 @@ import { ServiceDefinitionSchema } from '../../rpc/schema/direct.js';
 import { z } from 'zod';
 
 export const LocalRoutingCreateDataChannelSchema = z.object({
-    resource: z.literal('local-routing'),
-    action: z.literal('create-datachannel'),
+    resource: z.literal('create-datachannel:local-routing'),
     data: ServiceDefinitionSchema,
 });
 
 export const LocalRoutingUpdateDataChannelSchema = z.object({
-    resource: z.literal('local-routing'),
-    action: z.literal('update-datachannel'),
+    resource: z.literal('update-datachannel:local-routing'),
     data: ServiceDefinitionSchema,
 });
 
 export const LocalRoutingDeleteDataChannelSchema = z.object({
-    resource: z.literal('local-routing'),
-    action: z.literal('delete-datachannel'),
+    resource: z.literal('delete-datachannel:local-routing'),
     data: z.object({ id: z.string() }),
 });
 
@@ -37,12 +34,9 @@ export class LocalRoutingTablePlugin extends BasePlugin {
     async apply(context: PluginContext): Promise<PluginResult> {
         const { action, state } = context;
 
-        // Check if this is a local-routing action
-        if (action.resource !== 'local-routing') {
-            return { success: true, ctx: context };
-        }
 
-        if (action.action === 'create-datachannel') {
+
+        if (action.resource === 'create-datachannel:local-routing') {
             const data = action.data as DataChannel;
 
             // Logic: Distinguish by protocol
@@ -70,7 +64,7 @@ export class LocalRoutingTablePlugin extends BasePlugin {
                 context.result = { ...context.result, id };
             }
 
-        } else if (action.action === 'update-datachannel') {
+        } else if (action.resource === 'update-datachannel:local-routing') {
             const data = action.data as DataChannel;
 
             if (data.protocol === 'tcp:graphql' || data.protocol === 'tcp:gql') {
@@ -117,7 +111,7 @@ export class LocalRoutingTablePlugin extends BasePlugin {
                 }
             }
 
-        } else if (action.action === 'delete-datachannel') {
+        } else if (action.resource === 'delete-datachannel:local-routing') {
             const { id } = action.data as { id: string };
             // removeRoute works for both internal and proxied maps within RouteTable
             const newState = state.removeRoute(id);

--- a/packages/orchestrator/src/plugins/types.ts
+++ b/packages/orchestrator/src/plugins/types.ts
@@ -12,7 +12,7 @@ export type AuthContext = z.infer<typeof AuthContextSchema>;
 
 export interface PipelineAction {
     resource: string;
-    action: string;
+    action?: string;
     data: any;
 }
 

--- a/packages/orchestrator/src/rpc/schema/actions.ts
+++ b/packages/orchestrator/src/rpc/schema/actions.ts
@@ -60,20 +60,17 @@ export const InternalPeeringProtocolUpdateActionSchema = z.object({
 // Redefining here to avoid circular dependencies if plugin imports from here.
 
 export const LocalRoutingCreateDataChannelSchema = z.object({
-    resource: z.literal('local-routing'),
-    action: z.literal('create-datachannel'),
+    resource: z.literal('create-datachannel:local-routing'),
     data: ServiceDefinitionSchema,
 });
 
 export const LocalRoutingUpdateDataChannelSchema = z.object({
-    resource: z.literal('local-routing'),
-    action: z.literal('update-datachannel'),
+    resource: z.literal('update-datachannel:local-routing'),
     data: ServiceDefinitionSchema,
 });
 
 export const LocalRoutingDeleteDataChannelSchema = z.object({
-    resource: z.literal('local-routing'),
-    action: z.literal('delete-datachannel'),
+    resource: z.literal('delete-datachannel:local-routing'),
     data: z.object({ id: z.string() }),
 });
 

--- a/packages/orchestrator/tests/local.routing.plugin.unit.test.ts
+++ b/packages/orchestrator/tests/local.routing.plugin.unit.test.ts
@@ -1,0 +1,163 @@
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { LocalRoutingTablePlugin } from '../src/plugins/implementations/local-routing.js';
+import { PluginContext } from '../src/plugins/types.js';
+import { RouteTable } from '../src/state/route-table.js';
+import { DataChannel } from '../src/types.js';
+
+describe('LocalRoutingTablePlugin Comprehensive Tests', () => {
+    let plugin: LocalRoutingTablePlugin;
+    let state: RouteTable;
+
+    beforeEach(() => {
+        plugin = new LocalRoutingTablePlugin();
+        state = new RouteTable();
+    });
+
+    // Helper to create context
+    const createCtx = (resource: string, data: any): PluginContext => ({
+        action: { resource, data },
+        state,
+        authxContext: {} as any
+    });
+
+    describe('Create Actions', () => {
+        it('should correctly create an internal route', async () => {
+            const data: DataChannel = {
+                name: 'internal-service-1',
+                endpoint: 'tcp://10.0.0.1:8080',
+                protocol: 'tcp',
+                region: 'us-east-1'
+            };
+            const ctx = createCtx('create-datachannel:local-routing', data);
+
+            const result = await plugin.apply(ctx);
+
+            expect(result.success).toBe(true);
+            const internalRoutes = ctx.state.getInternalRoutes();
+            expect(internalRoutes).toHaveLength(1);
+            expect(internalRoutes[0].service).toEqual(data);
+            expect(ctx.state.getProxiedRoutes()).toHaveLength(0);
+        });
+
+        it('should correctly create a proxy route', async () => {
+            const data: DataChannel = {
+                name: 'proxy-service-1',
+                endpoint: 'http://proxy.target',
+                protocol: 'tcp:graphql',
+                region: 'us-west-1'
+            };
+            const ctx = createCtx('create-datachannel:local-routing', data);
+
+            const result = await plugin.apply(ctx);
+
+            expect(result.success).toBe(true);
+            const proxiedRoutes = ctx.state.getProxiedRoutes();
+            expect(proxiedRoutes).toHaveLength(1);
+            expect(proxiedRoutes[0].service).toEqual(data);
+            expect(ctx.state.getInternalRoutes()).toHaveLength(0);
+        });
+    });
+
+    describe('Update Actions', () => {
+        it('should update an existing internal route', async () => {
+            // Setup initial state
+            const initialData: DataChannel = {
+                name: 'internal-service-update',
+                endpoint: 'tcp://old:8080',
+                protocol: 'tcp'
+            };
+            // Update the state variable with the new state ensuring it has the route
+            const { state: stateWithRoute } = state.addInternalRoute(initialData);
+            state = stateWithRoute;
+
+            // Update action
+            const updateData: DataChannel = {
+                name: 'internal-service-update',
+                endpoint: 'tcp://new:9090',
+                protocol: 'tcp',
+                region: 'updated-region'
+            };
+            // createCtx uses the updated 'state'
+            const ctx = createCtx('update-datachannel:local-routing', updateData);
+
+            const result = await plugin.apply(ctx);
+
+            expect(result.success).toBe(true);
+            // Verify on the NEW state returned in context
+            const route = ctx.state.getInternalRoutes().find(r => r.service.name === 'internal-service-update');
+            expect(route).toBeDefined();
+            expect(route?.service.endpoint).toBe('tcp://new:9090');
+            expect(route?.service.region).toBe('updated-region');
+        });
+
+        it('should fail to update non-existent internal route', async () => {
+            const updateData: DataChannel = {
+                name: 'non-existent',
+                endpoint: 'tcp://new:9090',
+                protocol: 'tcp'
+            };
+            const ctx = createCtx('update-datachannel:local-routing', updateData);
+
+            const result = await plugin.apply(ctx);
+
+            expect(result.success).toBe(false);
+            if (!result.success) { // Type guard
+                expect(result.error.message).toContain('Internal route not found');
+            }
+        });
+
+        it('should update an existing proxy route', async () => {
+            // Setup
+            const initialData: DataChannel = {
+                name: 'proxy-service-update',
+                endpoint: 'http://old.proxy',
+                protocol: 'tcp:graphql'
+            };
+            const { state: stateWithRoute } = state.addProxiedRoute(initialData);
+            state = stateWithRoute;
+
+            // Update
+            const updateData: DataChannel = {
+                name: 'proxy-service-update',
+                endpoint: 'http://new.proxy',
+                protocol: 'tcp:graphql'
+            };
+            const ctx = createCtx('update-datachannel:local-routing', updateData);
+
+            const result = await plugin.apply(ctx);
+
+            expect(result.success).toBe(true);
+            const route = ctx.state.getProxiedRoutes().find(r => r.service.name === 'proxy-service-update');
+            expect(route?.service.endpoint).toBe('http://new.proxy');
+        });
+    });
+
+    describe('Delete Actions', () => {
+        it('should delete an existing route', async () => {
+            // Setup
+            const data: DataChannel = {
+                name: 'to-delete',
+                endpoint: 'tcp://host:port',
+                protocol: 'tcp'
+            };
+            const { state: stateWithRoute, id } = state.addInternalRoute(data);
+            state = stateWithRoute;
+
+            const ctx = createCtx('delete-datachannel:local-routing', { id });
+
+            const result = await plugin.apply(ctx);
+
+            expect(result.success).toBe(true);
+            expect(ctx.state.getInternalRoutes()).toHaveLength(0);
+        });
+
+        it('should handle deleting non-existent route gracefully (idempotent)', async () => {
+            const ctx = createCtx('delete-datachannel:local-routing', { id: 'missing-id' });
+
+            const result = await plugin.apply(ctx);
+
+            expect(result.success).toBe(true);
+        });
+    });
+});

--- a/packages/orchestrator/tests/proxy.plugin.integration.test.ts
+++ b/packages/orchestrator/tests/proxy.plugin.integration.test.ts
@@ -10,8 +10,7 @@ describe('LocalRoutingTablePlugin Tests', () => {
         const state = new RouteTable();
         const context: PluginContext = {
             action: {
-                resource: 'local-routing',
-                action: 'create-datachannel',
+                resource: 'create-datachannel:local-routing',
                 data: {
                     name: 'test-proxy-service',
                     endpoint: 'http://proxy-target',
@@ -44,8 +43,7 @@ describe('LocalRoutingTablePlugin Tests', () => {
         const state = new RouteTable();
         const context: PluginContext = {
             action: {
-                resource: 'local-routing',
-                action: 'create-datachannel',
+                resource: 'create-datachannel:local-routing',
                 data: {
                     name: 'test-internal-service',
                     endpoint: 'tcp://localhost:9090',


### PR DESCRIPTION
### TL;DR

Refactored the resource/action pattern to use a combined resource string format (`action:resource`) for better API consistency.

### What changed?

- Changed the API format from separate `resource` and `action` fields to a combined `resource` field in the format `action:resource`
- Updated all schema definitions to use the new format (e.g., `create-datachannel:local-routing` instead of resource: `local-routing`, action: `create-datachannel`)
- Made the `action` field optional in the `PipelineAction` interface
- Refactored the `LocalRoutingTablePlugin` to check for the new combined resource strings
- Added comprehensive unit tests for the `LocalRoutingTablePlugin` to verify all CRUD operations work correctly with the new format

### How to test?

1. Run the new unit tests: `bun test packages/orchestrator/tests/local.routing.plugin.unit.test.ts`
2. Verify that existing integration tests pass with the updated format
3. Test the CLI's `addService` command to ensure it works with the new resource format

### Why make this change?

This change simplifies the API by combining the resource and action into a single string, making it more intuitive and consistent. The new format (`action:resource`) is clearer about what operation is being performed on which resource, reducing ambiguity and making the code more maintainable. The addition of comprehensive tests ensures the refactoring doesn't break existing functionality.