### PR TITLE
chore: patching graphql gateway plugin to work as expected

### DIFF
--- a/packages/orchestrator/src/plugins/implementations/gateway.ts
+++ b/packages/orchestrator/src/plugins/implementations/gateway.ts
@@ -6,17 +6,28 @@ import { OrchestratorConfig } from '../../config.js';
 export class GatewayIntegrationPlugin extends BasePlugin {
     name = 'GatewayIntegrationPlugin';
     private endpoint: string;
+    private triggers: string[];
 
-    constructor(config: OrchestratorConfig['gqlGatewayConfig']) {
+    constructor(
+        config: OrchestratorConfig['gqlGatewayConfig'],
+        options: { triggerOnResources?: string[] } = {}
+    ) {
         super();
         if (!config) {
             throw new Error('GatewayIntegrationPlugin requires gqlGatewayConfig');
         }
         this.endpoint = config.endpoint;
+        this.triggers = options.triggerOnResources || [];
     }
 
     async apply(context: PluginContext): Promise<PluginResult> {
-        const { state } = context;
+        const { action, state } = context;
+
+        // Check if action matches any trigger
+        if (!this.triggers.includes(action.resource)) {
+            return { success: true, ctx: context };
+        }
+
         console.log(`[GatewayIntegrationPlugin] Configuring Gateway at ${this.endpoint}`);
 
         // 1. Map RouteTable to GatewayConfig

--- a/packages/orchestrator/src/rpc/server.ts
+++ b/packages/orchestrator/src/rpc/server.ts
@@ -46,7 +46,13 @@ export class OrchestratorRpcServer extends RpcTarget {
 
         // Conditionally add Gateway Plugin
         if (config.gqlGatewayConfig) {
-            plugins.push(new GatewayIntegrationPlugin(config.gqlGatewayConfig));
+            plugins.push(new GatewayIntegrationPlugin(config.gqlGatewayConfig, {
+                triggerOnResources: [
+                    'create-datachannel:local-routing',
+                    'update-datachannel:local-routing',
+                    'delete-datachannel:local-routing'
+                ]
+            }));
         }
 
         // Initialize plugins

--- a/packages/orchestrator/tests/graphql.plugin.integration.test.ts
+++ b/packages/orchestrator/tests/graphql.plugin.integration.test.ts
@@ -112,11 +112,14 @@ describe('GraphQL Plugin E2E with Containers', () => {
     it('should handle full lifecycle: unconfigured -> add -> update -> delete', async () => {
         // Setup Plugin
         const rpcEndpoint = `ws://localhost:${gatewayPort}/api`;
-        const plugin = new GatewayIntegrationPlugin({ endpoint: rpcEndpoint });
+        const plugin = new GatewayIntegrationPlugin(
+            { endpoint: rpcEndpoint },
+            { triggerOnResources: ['create-datachannel:local-routing'] }
+        );
         let state = new RouteTable();
         const context: PluginContext = {
             // @ts-ignore - Dummy action for context, we manipulate state directly
-            action: { resource: 'local-routing', action: 'create-datachannel', data: {} },
+            action: { resource: 'create-datachannel:local-routing', data: {} },
             state,
             authxContext: {} as any
         };


### PR DESCRIPTION
### TL;DR

Added resource-based trigger filtering to the GatewayIntegrationPlugin to only execute when specific actions occur.

### What changed?

- Enhanced `GatewayIntegrationPlugin` to accept a new `triggerOnResources` option that specifies which resources should trigger the plugin
- Modified the plugin to check if the current action's resource matches any of the configured triggers before proceeding
- Updated the server configuration to only trigger the Gateway plugin for specific data channel operations (create, update, delete)
- Updated tests to include the new trigger configuration

### How to test?

1. Create, update, or delete a data channel with the resource type "local-routing"
2. Verify that the Gateway plugin is triggered only for these specific operations
3. Perform other operations and confirm the Gateway plugin is not triggered

### Why make this change?

This change improves performance and reduces unnecessary processing by ensuring the Gateway integration only runs when relevant resources are being modified. Previously, the plugin would execute for all actions regardless of relevance, which could lead to unnecessary API calls and processing overhead.