### PR TITLE
fix: applyAction return is not list of composite types

### DIFF
--- a/packages/cli/src/commands/peer.ts
+++ b/packages/cli/src/commands/peer.ts
@@ -45,7 +45,9 @@ export const peerCommands = () => {
                 });
 
                 if (result.success) {
-                    console.log(chalk.green(`Peer added successfully. ID: ${result.id}`));
+                    // Extract ID from results if available (assuming first result has id)
+                    const id = result.results?.[0]?.id || 'unknown';
+                    console.log(chalk.green(`Peer added successfully. ID: ${id}`));
                 } else {
                     console.error(chalk.red(`Failed to add peer: ${result.error}`));
                     process.exit(1);

--- a/packages/orchestrator/src/plugins/implementations/local-routing.ts
+++ b/packages/orchestrator/src/plugins/implementations/local-routing.ts
@@ -50,7 +50,14 @@ export class LocalRoutingTablePlugin extends BasePlugin {
                     region: data.region
                 });
                 context.state = newState;
-                context.result = { ...context.result, id };
+                context.results.push({
+                    plugin: this.name,
+                    resource: action.resource,
+                    id,
+                    name: data.name,
+                    protocol: data.protocol,
+                    type: 'proxy-route-created'
+                });
             } else {
                 // Internal Route
                 console.log(`[LocalRoutingTablePlugin] Adding INTERNAL route for ${data.name}`);
@@ -61,7 +68,14 @@ export class LocalRoutingTablePlugin extends BasePlugin {
                     region: data.region
                 });
                 context.state = newState;
-                context.result = { ...context.result, id };
+                context.results.push({
+                    plugin: this.name,
+                    resource: action.resource,
+                    id,
+                    name: data.name,
+                    protocol: data.protocol,
+                    type: 'internal-route-created'
+                });
             }
 
         } else if (action.resource === 'update-datachannel:local-routing') {
@@ -78,7 +92,14 @@ export class LocalRoutingTablePlugin extends BasePlugin {
 
                 if (result) {
                     context.state = result.state;
-                    context.result = { ...context.result, id: result.id };
+                    context.results.push({
+                        plugin: this.name,
+                        resource: action.resource,
+                        id: result.id,
+                        name: data.name,
+                        protocol: data.protocol,
+                        type: 'proxy-route-updated'
+                    });
                 } else {
                     return {
                         success: false,
@@ -99,7 +120,14 @@ export class LocalRoutingTablePlugin extends BasePlugin {
 
                 if (result) {
                     context.state = result.state;
-                    context.result = { ...context.result, id: result.id };
+                    context.results.push({
+                        plugin: this.name,
+                        resource: action.resource,
+                        id: result.id,
+                        name: data.name,
+                        protocol: data.protocol,
+                        type: 'internal-route-updated'
+                    });
                 } else {
                     return {
                         success: false,
@@ -116,7 +144,12 @@ export class LocalRoutingTablePlugin extends BasePlugin {
             // removeRoute works for both internal and proxied maps within RouteTable
             const newState = state.removeRoute(id);
             context.state = newState;
-            context.result = { ...context.result, id };
+            context.results.push({
+                plugin: this.name,
+                resource: action.resource,
+                id,
+                type: 'route-deleted'
+            });
         }
 
         return { success: true, ctx: context };

--- a/packages/orchestrator/src/plugins/types.ts
+++ b/packages/orchestrator/src/plugins/types.ts
@@ -20,7 +20,7 @@ export const PluginContextSchema = z.object({
     action: z.custom<PipelineAction>(),
     state: z.instanceof(RouteTable),
     authxContext: AuthContextSchema,
-    result: z.record(z.any()).optional(),
+    results: z.array(z.any()).default([]),
 });
 export type PluginContext = z.infer<typeof PluginContextSchema>;
 

--- a/packages/orchestrator/src/rpc/schema/index.ts
+++ b/packages/orchestrator/src/rpc/schema/index.ts
@@ -35,3 +35,10 @@ export const ListMetricsResultSchema = z.object({
     metrics: z.array(DataChannelMetricsSchema),
 });
 export type ListMetricsResult = z.infer<typeof ListMetricsResultSchema>;
+
+export const ApplyActionResultSchema = z.object({
+    success: z.boolean(),
+    results: z.array(z.any()),
+    error: z.string().optional()
+});
+export type ApplyActionResult = z.infer<typeof ApplyActionResultSchema>;

--- a/packages/orchestrator/tests/local.routing.plugin.unit.test.ts
+++ b/packages/orchestrator/tests/local.routing.plugin.unit.test.ts
@@ -18,6 +18,7 @@ describe('LocalRoutingTablePlugin Comprehensive Tests', () => {
     const createCtx = (resource: string, data: any): PluginContext => ({
         action: { resource, data },
         state,
+        results: [],
         authxContext: {} as any
     });
 

--- a/packages/orchestrator/tests/proxy.plugin.integration.test.ts
+++ b/packages/orchestrator/tests/proxy.plugin.integration.test.ts
@@ -19,6 +19,7 @@ describe('LocalRoutingTablePlugin Tests', () => {
                 }
             },
             state,
+            results: [],
             authxContext: {} as any
         };
 
@@ -52,6 +53,7 @@ describe('LocalRoutingTablePlugin Tests', () => {
                 }
             },
             state,
+            results: [],
             authxContext: {} as any
         };
 
@@ -73,6 +75,7 @@ describe('LocalRoutingTablePlugin Tests', () => {
         const context: PluginContext = {
             action: { resource: 'unknown', action: 'create', data: {} } as any,
             state,
+            results: [],
             authxContext: {} as any
         };
 

--- a/packages/orchestrator/tests/rpc.test.ts
+++ b/packages/orchestrator/tests/rpc.test.ts
@@ -34,8 +34,7 @@ describe('Orchestrator RPC', () => {
 
     it('should apply create data channel action', async () => {
         const action = {
-            resource: 'local-routing',
-            action: 'create-datachannel',
+            resource: 'create-datachannel:local-routing',
             data: {
                 name: 'test-service',
                 endpoint: 'http://127.0.0.1:8080',
@@ -46,7 +45,7 @@ describe('Orchestrator RPC', () => {
 
         const result = await rpc.applyAction(action);
         expect(result.success).toBe(true);
-        expect(result.id).toBe('test-service:tcp:graphql');
+        expect(result.results[0].id).toBe('test-service:tcp:graphql');
     });
 
     it('should list local routes', async () => {


### PR DESCRIPTION
### TL;DR

Refactored the plugin result handling to use an array of results instead of a single result object, improving the ability to track actions across multiple plugins.

### What changed?

- Changed the `PluginContext` type to use a `results` array instead of a single `result` object
- Updated the `LocalRoutingTablePlugin` to push detailed result objects to the `results` array
- Added a new `ApplyActionResultSchema` to properly type the response from RPC actions
- Modified the CLI peer command to extract IDs from the new results array structure
- Updated all relevant tests to accommodate the new results array pattern

### How to test?

1. Add a peer using the CLI command and verify the ID is correctly displayed
2. Test various routing operations to ensure they correctly populate the results array
3. Verify that the RPC server correctly returns the array of results from plugin operations
4. Run the updated tests to confirm they pass with the new structure

### Why make this change?

This change improves the plugin architecture by allowing multiple plugins to contribute results to a single action. The array-based approach provides more detailed information about each operation performed during an action, making it easier to track what happened across the plugin pipeline. This is particularly useful for debugging and for providing more comprehensive feedback to API consumers.