### PR TITLE
chore: update husky hooks to use bun

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-pnpm exec commitlint --edit $1
+bunx commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm exec lint-staged
+bunx run lint-staged


### PR DESCRIPTION
### TL;DR

Replace pnpm with bun in Husky hooks

### What changed?

- Updated `.husky/commit-msg` to use `bunx commitlint` instead of `pnpm exec commitlint`
- Updated `.husky/pre-commit` to use `bunx run lint-staged` instead of `pnpm exec lint-staged`

### How to test?

1. Make a git commit and verify that the commit message linting works
2. Stage changes and verify that lint-staged runs properly before committing

### Why make this change?

Migrating from pnpm to bun as the package manager for the project. This ensures that the git hooks use the correct package manager when running the commit linting and pre-commit checks.