### PR TITLE
feat(auth): session auth w RBAC and token expiry

### DIFF
--- a/packages/orchestrator/src/auth/extract.ts
+++ b/packages/orchestrator/src/auth/extract.ts
@@ -1,0 +1,87 @@
+import type { AuthContext } from '../plugins/types.js'
+import type { IAuthClient } from '../clients/auth.js'
+
+/**
+ * Result of token verification and auth extraction.
+ */
+export interface AuthExtractionResult {
+  auth: AuthContext
+  /** Token expiry time from JWT exp claim */
+  expiresAt: Date | null
+}
+
+/**
+ * Extract Bearer token from Authorization header
+ */
+export function extractBearerToken(headers: Headers): string | null {
+  const authHeader = headers.get('Authorization')
+  if (authHeader?.startsWith('Bearer ')) {
+    return authHeader.slice(7)
+  }
+  return null
+}
+
+/**
+ * Verify token and extract auth context using the auth service.
+ * Returns null if token is missing or invalid.
+ */
+export async function verifyAndExtractAuth(
+  headers: Headers,
+  authClient: IAuthClient,
+  audience?: string
+): Promise<AuthExtractionResult | null> {
+  const token = extractBearerToken(headers)
+
+  if (!token) {
+    return null
+  }
+
+  const result = await authClient.verifyToken(token, audience)
+
+  if (!result.valid || !result.payload) {
+    return null
+  }
+
+  try {
+    return extractAuthFromPayload(result.payload)
+  } catch (err) {
+    console.warn('[Auth] Failed to extract auth context:', err instanceof Error ? err.message : err)
+    return null
+  }
+}
+
+/**
+ * Extract AuthContext and expiry from JWT payload.
+ * Maps standard JWT claims to internal auth context.
+ */
+export function extractAuthFromPayload(payload: Record<string, unknown>): AuthExtractionResult {
+  const auth: AuthContext = {}
+
+  // User ID from subject claim
+  if (typeof payload.sub === 'string') {
+    auth.userId = payload.sub
+  }
+
+  // Organization ID (custom claim)
+  if (typeof payload.orgId === 'string') {
+    auth.orgId = payload.orgId
+  }
+
+  // Roles - handle both single role and array of roles
+  if (Array.isArray(payload.roles)) {
+    if (!payload.roles.every((r): r is string => typeof r === 'string')) {
+      throw new Error('Malformed roles claim: all roles must be strings')
+    }
+    auth.roles = payload.roles
+  } else if (typeof payload.role === 'string') {
+    auth.roles = [payload.role]
+  }
+
+  // Extract expiry from standard JWT exp claim (Unix timestamp in seconds)
+  let expiresAt: Date | null = null
+  if (typeof payload.exp === 'number') {
+    expiresAt = new Date(payload.exp * 1000)
+  }
+
+  return { auth, expiresAt }
+}

--- a/packages/orchestrator/src/auth/permissions.ts
+++ b/packages/orchestrator/src/auth/permissions.ts
@@ -1,0 +1,39 @@
+/**
+ * Role-based access control (RBAC) for actions.
+ *
+ * Permission format: 'resource:action' or '*' for all.
+ */
+
+export const ROLE_PERMISSIONS: Record<string, string[]> = {
+  // Full access
+  admin: ['*'],
+
+  // Can manage data channels
+  operator: ['dataChannel:create', 'dataChannel:update', 'dataChannel:delete'],
+
+  // Read-only access (no write actions allowed)
+  viewer: [],
+}
+
+/**
+ * Check if any of the given roles grants permission for the action.
+ */
+export function hasPermission(
+  roles: string[] | undefined,
+  resource: string,
+  action: string
+): boolean {
+  if (!roles || roles.length === 0) {
+    return false
+  }
+
+  const requiredPermission = `${resource}:${action}`
+
+  return roles.some((role) => {
+    const allowed = ROLE_PERMISSIONS[role]
+    if (!allowed) {
+      return false
+    }
+    return allowed.includes('*') || allowed.includes(requiredPermission)
+  })
+}

--- a/packages/orchestrator/src/auth/session.ts
+++ b/packages/orchestrator/src/auth/session.ts
@@ -1,0 +1,53 @@
+import type { AuthContext } from '../plugins/types.js'
+
+export interface SessionOptions {
+  auth: AuthContext
+  /** Token expiry time (from JWT exp claim). If not set, session never expires. */
+  expiresAt?: Date
+}
+
+/**
+ * Session holds authenticated user context for a WebSocket connection.
+ * Created once at connection time, used for all actions on that connection.
+ *
+ * Sessions track token expiry to handle long-lived WebSocket connections.
+ * When a token expires, subsequent actions are rejected and the client
+ * must reconnect with a fresh token.
+ */
+export class Session {
+  readonly auth: AuthContext
+  readonly connectionId: string
+  readonly connectedAt: Date
+  readonly expiresAt: Date | null
+
+  constructor(options: SessionOptions) {
+    this.auth = options.auth
+    this.expiresAt = options.expiresAt ?? null
+    this.connectionId = crypto.randomUUID()
+    this.connectedAt = new Date()
+  }
+
+  /**
+   * Check if the session's token has expired.
+   * Sessions without an expiry time never expire.
+   * Note: A token is considered expired at exactly its expiry time (>=).
+   */
+  isExpired(): boolean {
+    if (!this.expiresAt) {
+      return false
+    }
+    return Date.now() >= this.expiresAt.getTime()
+  }
+
+  /**
+   * Get remaining time until session expires in milliseconds.
+   * Returns null if session has no expiry, 0 if already expired.
+   */
+  remainingMs(): number | null {
+    if (!this.expiresAt) {
+      return null
+    }
+    const remaining = this.expiresAt.getTime() - Date.now()
+    return Math.max(0, remaining)
+  }
+}

--- a/packages/orchestrator/src/config.ts
+++ b/packages/orchestrator/src/config.ts
@@ -1,52 +1,64 @@
-
-import { z } from 'zod';
+import { z } from 'zod'
 
 export const OrchestratorConfigSchema = z.object({
-    authConfig: z.object({
-        endpoint: z.string().url(),
-        jwksUrl: z.string().url().optional(), // JWKS URL for gateway auth
-    }).optional(),
-    gqlGatewayConfig: z.object({
-        endpoint: z.string().url(),
-    }).optional(),
-});
+  authConfig: z
+    .object({
+      endpoint: z.string().url(),
+      jwksUrl: z.string().url().optional(), // JWKS URL for gateway auth
+      audience: z.string().optional(), // Expected JWT audience claim
+    })
+    .optional(),
+  gqlGatewayConfig: z
+    .object({
+      endpoint: z.string().url(),
+    })
+    .optional(),
+})
 
-export type OrchestratorConfig = z.infer<typeof OrchestratorConfigSchema>;
+export type OrchestratorConfig = z.infer<typeof OrchestratorConfigSchema>
 
 export function getConfig(): OrchestratorConfig {
-    const authEndpoint = process.env.CATALYST_AUTH_ENDPOINT;
-    const gatewayEndpoint = process.env.CATALYST_GQL_GATEWAY_ENDPOINT;
+  const authEndpoint = process.env.CATALYST_AUTH_ENDPOINT
+  const gatewayEndpoint = process.env.CATALYST_GQL_GATEWAY_ENDPOINT
 
-    const config: OrchestratorConfig = {};
+  const config: OrchestratorConfig = {}
 
-    if (authEndpoint) {
-        console.log(`[Config] Found CATALYST_AUTH_ENDPOINT: ${authEndpoint}`);
-        // Derive JWKS URL from auth endpoint or use explicit env var
-        const jwksUrl = process.env.CATALYST_AUTH_JWKS_URL ||
-            authEndpoint.replace(/^ws/, 'http').replace(/\/rpc$/, '') + '/.well-known/jwks.json';
-        config.authConfig = {
-            endpoint: authEndpoint,
-            jwksUrl,
-        };
-        console.log(`[Config] Auth JWKS URL: ${jwksUrl}`);
-    } else {
-        console.log('[Config] No CATALYST_AUTH_ENDPOINT found. Auth disabled.');
+  if (authEndpoint) {
+    console.log(`[Config] Found CATALYST_AUTH_ENDPOINT: ${authEndpoint}`)
+    // Derive JWKS URL from auth endpoint or use explicit env var
+    const jwksUrl =
+      process.env.CATALYST_AUTH_JWKS_URL ||
+      authEndpoint.replace(/^ws/, 'http').replace(/\/rpc$/, '') + '/.well-known/jwks.json'
+    const audience = process.env.CATALYST_AUTH_AUDIENCE
+    config.authConfig = {
+      endpoint: authEndpoint,
+      jwksUrl,
+      audience,
     }
-
-    if (gatewayEndpoint) {
-        console.log(`[Config] Found CATALYST_GQL_GATEWAY_ENDPOINT: ${gatewayEndpoint}`);
-        config.gqlGatewayConfig = {
-            endpoint: gatewayEndpoint,
-        };
-    } else {
-        console.log('[Config] No CATALYST_GQL_GATEWAY_ENDPOINT found. GraphQL Gateway integration disabled.');
+    console.log(`[Config] Auth JWKS URL: ${jwksUrl}`)
+    if (audience) {
+      console.log(`[Config] Auth audience: ${audience}`)
     }
+  } else {
+    console.log('[Config] No CATALYST_AUTH_ENDPOINT found. Auth disabled.')
+  }
 
-    // Validate the config
-    try {
-        return OrchestratorConfigSchema.parse(config);
-    } catch (error) {
-        console.error('[Config] Invalid configuration:', error);
-        throw error;
+  if (gatewayEndpoint) {
+    console.log(`[Config] Found CATALYST_GQL_GATEWAY_ENDPOINT: ${gatewayEndpoint}`)
+    config.gqlGatewayConfig = {
+      endpoint: gatewayEndpoint,
     }
+  } else {
+    console.log(
+      '[Config] No CATALYST_GQL_GATEWAY_ENDPOINT found. GraphQL Gateway integration disabled.'
+    )
+  }
+
+  // Validate the config
+  try {
+    return OrchestratorConfigSchema.parse(config)
+  } catch (error) {
+    console.error('[Config] Invalid configuration:', error)
+    throw error
+  }
 }

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -1,26 +1,77 @@
+import { Hono } from 'hono'
+import { upgradeWebSocket, websocket } from 'hono/bun'
+import { newRpcResponse } from '@hono/capnweb'
+import { OrchestratorRpcServer } from './rpc/server.js'
+import { Session } from './auth/session.js'
+import { verifyAndExtractAuth } from './auth/extract.js'
+import { AuthClient, type IAuthClient } from './clients/auth.js'
+import { getConfig } from './config.js'
 
-import { Hono } from 'hono';
-import { upgradeWebSocket, websocket } from 'hono/bun';
-import { newRpcResponse } from '@hono/capnweb';
-import { OrchestratorRpcServer } from './rpc/server.js';
-export * from './rpc/schema/index.js';
+export * from './rpc/schema/index.js'
 
-const app = new Hono();
-const rpcServer = new OrchestratorRpcServer();
+const app = new Hono()
+const config = getConfig()
 
-app.get('/rpc', (c) => {
-    return newRpcResponse(c, rpcServer, {
-        upgradeWebSocket,
-    });
-});
+// Initialize auth client if auth is configured
+let authClient: IAuthClient | null = null
+if (config.authConfig) {
+  authClient = new AuthClient(config.authConfig.endpoint)
+  console.log('[Auth] Auth client initialized')
+}
 
-app.get('/health', (c) => c.text('OK'));
+app.get('/rpc', async (c) => {
+  let session: Session
 
-const port = process.env.PORT || 4015;
-console.log(`Orchestrator running on port ${port}`);
+  if (authClient) {
+    // Auth enabled: verify token at connection time
+    const result = await verifyAndExtractAuth(
+      c.req.raw.headers,
+      authClient,
+      config.authConfig?.audience
+    )
+
+    if (!result) {
+      return c.text('Unauthorized: Valid JWT required', 401)
+    }
+
+    if (!result.auth.userId) {
+      return c.text('Unauthorized: Token missing subject claim', 401)
+    }
+
+    session = new Session({ auth: result.auth, expiresAt: result.expiresAt })
+    const expiryInfo = result.expiresAt
+      ? ` expires=${result.expiresAt.toISOString()}`
+      : ' expires=never'
+    console.log(
+      `[RPC] New connection: user=${result.auth.userId} session=${session.connectionId}${expiryInfo}`
+    )
+  } else {
+    return c.text('Service Unavailable: Auth not configured', 503)
+  }
+
+  const rpcServer = new OrchestratorRpcServer({ session, config })
+
+  return newRpcResponse(c, rpcServer, {
+    upgradeWebSocket,
+  })
+})
+
+app.get('/health', (c) => c.text('OK'))
+
+const port = process.env.PORT || 4015
+console.log(`Orchestrator running on port ${port}`)
+
+// Cleanup on shutdown
+const shutdown = () => {
+  console.log('[Shutdown] Closing auth client...')
+  authClient?.close()
+  process.exit(0)
+}
+process.on('SIGTERM', shutdown)
+process.on('SIGINT', shutdown)
 
 export default {
-    port,
-    fetch: app.fetch,
-    websocket,
-};
+  port,
+  fetch: app.fetch,
+  websocket,
+}

--- a/packages/orchestrator/src/plugins/implementations/auth.ts
+++ b/packages/orchestrator/src/plugins/implementations/auth.ts
@@ -1,117 +1,46 @@
-import { BasePlugin } from '../base.js';
-import type { PluginContext, PluginResult, AuthContext } from '../types.js';
-import type { IAuthClient } from '../../clients/auth.js';
+import { BasePlugin } from '../base.js'
+import type { PluginContext, PluginResult } from '../types.js'
+import { hasPermission } from '../../auth/permissions.js'
 
-export interface AuthPluginOptions {
-    /** Expected audience claim - if set, tokens must have this audience */
-    audience?: string;
-}
-
+/**
+ * Auth plugin that enforces RBAC permissions.
+ *
+ * Token verification is done at connection time (session creation).
+ * This plugin checks that the authenticated user has permission
+ * to perform the requested action.
+ */
 export class AuthPlugin extends BasePlugin {
-    name = 'AuthPlugin';
+  name = 'AuthPlugin'
 
-    constructor(
-        private authClient: IAuthClient,
-        private options: AuthPluginOptions = {}
-    ) {
-        super();
+  async apply(context: PluginContext): Promise<PluginResult> {
+    const { action, authxContext } = context
+    const { resource, action: resourceAction } = action
+    const roles = authxContext.roles
+    const userId = authxContext.userId ?? 'anonymous'
+
+    // Check RBAC permissions
+    const allowed = hasPermission(roles, resource, resourceAction)
+
+    if (!allowed) {
+      console.warn(
+        `[AuthPlugin] Denied: user=${userId} roles=[${roles?.join(',') ?? ''}] ` +
+          `action=${resource}:${resourceAction}`
+      )
+
+      return {
+        success: false,
+        error: {
+          pluginName: this.name,
+          message: `Permission denied: ${resource}:${resourceAction} requires elevated privileges`,
+        },
+      }
     }
 
-    async apply(context: PluginContext): Promise<PluginResult> {
-        // Runtime check for authToken - kept local until pattern solidifies
-        const authToken = (context as Record<string, unknown>).authToken as string | undefined;
+    console.log(
+      `[AuthPlugin] Allowed: user=${userId} roles=[${roles?.join(',') ?? ''}] ` +
+        `action=${resource}:${resourceAction}`
+    )
 
-        // No token = deny access
-        if (!authToken) {
-            return {
-                success: false,
-                error: {
-                    pluginName: this.name,
-                    message: 'Authentication token required',
-                }
-            };
-        }
-
-        try {
-            const result = await this.authClient.verifyToken(authToken, this.options.audience);
-
-            if (!result.valid) {
-                return {
-                    success: false,
-                    error: {
-                        pluginName: this.name,
-                        message: 'Invalid authentication token',
-                    }
-                };
-            }
-
-            // Extract auth context from JWT payload
-            const extractedAuth = this.extractAuthContext(result.payload);
-
-            // Require subject claim - a token without identity is useless
-            if (!extractedAuth.userId) {
-                return {
-                    success: false,
-                    error: {
-                        pluginName: this.name,
-                        message: 'Token missing subject claim',
-                    }
-                };
-            }
-
-            return {
-                success: true,
-                ctx: {
-                    ...context,
-                    // Merge with existing context instead of overwriting
-                    authxContext: { ...context.authxContext, ...extractedAuth },
-                }
-            };
-        } catch (error) {
-            const message = error instanceof Error ? error.message : 'Authentication failed';
-            return {
-                success: false,
-                error: {
-                    pluginName: this.name,
-                    message,
-                    error,
-                }
-            };
-        }
-    }
-
-    /**
-     * Extract AuthContext from JWT payload
-     *
-     * Maps standard JWT claims to our internal auth context:
-     * - sub -> userId
-     * - orgId -> orgId (custom claim)
-     * - role/roles -> roles (normalize to array)
-     */
-    private extractAuthContext(payload: Record<string, unknown>): AuthContext {
-        const authContext: AuthContext = {};
-
-        // User ID from subject claim
-        if (typeof payload.sub === 'string') {
-            authContext.userId = payload.sub;
-        }
-
-        // Organization ID (custom claim)
-        if (typeof payload.orgId === 'string') {
-            authContext.orgId = payload.orgId;
-        }
-
-        // Roles - handle both single role and array of roles
-        if (Array.isArray(payload.roles)) {
-            // Reject malformed roles - all elements must be strings
-            if (!payload.roles.every((r): r is string => typeof r === 'string')) {
-                throw new Error('Malformed roles claim: all roles must be strings');
-            }
-            authContext.roles = payload.roles;
-        } else if (typeof payload.role === 'string') {
-            authContext.roles = [payload.role];
-        }
-
-        return authContext;
-    }
+    return { success: true, ctx: context }
+  }
 }

--- a/packages/orchestrator/src/rpc/server.ts
+++ b/packages/orchestrator/src/rpc/server.ts
@@ -1,93 +1,107 @@
-
-import { RpcTarget } from 'capnweb';
-import {
-    Action,
-    AddDataChannelResult,
-    ListLocalRoutesResult,
-    ListMetricsResult,
-} from './schema/index.js';
-import { GlobalRouteTable } from '../state/route-table.js';
-import { PluginPipeline } from '../plugins/pipeline.js';
-import { AuthPlugin } from '../plugins/implementations/auth.js';
-import { LoggerPlugin } from '../plugins/implementations/logger.js';
+import { RpcTarget } from 'capnweb'
+import type {
+  Action,
+  AddDataChannelResult,
+  ListLocalRoutesResult,
+  ListMetricsResult,
+} from './schema/index.js'
+import { GlobalRouteTable } from '../state/route-table.js'
+import { PluginPipeline } from '../plugins/pipeline.js'
+import { AuthPlugin } from '../plugins/implementations/auth.js'
+import { LoggerPlugin } from '../plugins/implementations/logger.js'
 // import { StatePersistencePlugin } from '../plugins/implementations/state.js';
-import { RouteTablePlugin } from '../plugins/implementations/routing.js';
+import { RouteTablePlugin } from '../plugins/implementations/routing.js'
 // import { RouteAnnouncerPlugin } from '../plugins/implementations/announcer.js';
-import { GatewayIntegrationPlugin } from '../plugins/implementations/gateway.js';
-import { DirectProxyRouteTablePlugin } from '../plugins/implementations/proxy-route.js';
-import { getConfig } from '../config.js';
-import { AuthClient, type IAuthClient } from '../clients/auth.js';
+import { GatewayIntegrationPlugin } from '../plugins/implementations/gateway.js'
+import { DirectProxyRouteTablePlugin } from '../plugins/implementations/proxy-route.js'
+import type { OrchestratorConfig } from '../config.js'
+import type { Session } from '../auth/session.js'
+
+export interface OrchestratorRpcServerOptions {
+  session: Session
+  config: OrchestratorConfig
+}
 
 export class OrchestratorRpcServer extends RpcTarget {
-    private pipeline: PluginPipeline;
-    private authClient: IAuthClient | null = null;
+  private pipeline: PluginPipeline
+  private session: Session
 
-    constructor() {
-        super();
-        const config = getConfig();
+  constructor(options: OrchestratorRpcServerOptions) {
+    super()
+    const { session, config } = options
+    this.session = session
 
-        // Initialize Plugins
-        const plugins: any[] = [];
+    // Initialize Plugins
+    const plugins: any[] = []
 
-        // Conditionally add Auth Plugin
-        if (config.authConfig) {
-            this.authClient = new AuthClient(config.authConfig.endpoint);
-            plugins.push(new AuthPlugin(this.authClient));
-        }
+    // Auth plugin checks RBAC permissions using session auth
+    plugins.push(new AuthPlugin())
 
-        plugins.push(
-            new LoggerPlugin(),
-            // new StatePersistencePlugin(),
-            new RouteTablePlugin(),
-            new DirectProxyRouteTablePlugin(),
-            // new RouteAnnouncerPlugin(),
-        );
+    plugins.push(
+      new LoggerPlugin(),
+      // new StatePersistencePlugin(),
+      new RouteTablePlugin(),
+      new DirectProxyRouteTablePlugin()
+      // new RouteAnnouncerPlugin(),
+    )
 
-        // Conditionally add Gateway Plugin
-        if (config.gqlGatewayConfig) {
-            plugins.push(new GatewayIntegrationPlugin({
-                gatewayEndpoint: config.gqlGatewayConfig.endpoint,
-                authJwksUrl: config.authConfig?.jwksUrl,
-            }));
-        }
-
-        this.pipeline = new PluginPipeline(plugins);
+    // Conditionally add Gateway Plugin
+    if (config.gqlGatewayConfig) {
+      plugins.push(
+        new GatewayIntegrationPlugin({
+          gatewayEndpoint: config.gqlGatewayConfig.endpoint,
+          authJwksUrl: config.authConfig?.jwksUrl,
+        })
+      )
     }
 
-    shutdown(): void {
-        this.authClient?.close();
+    this.pipeline = new PluginPipeline(plugins)
+  }
+
+  getSession(): Session {
+    return this.session
+  }
+
+  async applyAction(request: { action: Action }): Promise<AddDataChannelResult> {
+    // Check if session token has expired
+    if (this.session.isExpired()) {
+      console.warn(
+        `[RPC] Session expired: user=${this.session.auth.userId} ` +
+          `session=${this.session.connectionId} expired=${this.session.expiresAt?.toISOString()}`
+      )
+      return {
+        success: false,
+        error: 'Session expired: Please reconnect with a fresh token',
+      }
     }
 
-    async applyAction(request: { action: Action; authToken?: string }): Promise<AddDataChannelResult> {
-        try {
-            const result = await this.pipeline.apply({
-                action: request.action,
-                state: GlobalRouteTable,
-                authxContext: {},
-                authToken: request.authToken,
-            } as any); // authToken is handled by AuthPlugin
+    try {
+      const result = await this.pipeline.apply({
+        action: request.action,
+        state: GlobalRouteTable,
+        authxContext: this.session.auth,
+      })
 
-            if (!result.success) {
-                return { success: false, error: result.error.message };
-            }
+      if (!result.success) {
+        return { success: false, error: result.error.message }
+      }
 
-            return {
-                success: true,
-                id: result.ctx.result?.id
-            };
-        } catch (e: any) {
-            return { success: false, error: e.message };
-        }
+      return {
+        success: true,
+        id: result.ctx.result?.id,
+      }
+    } catch (e: any) {
+      return { success: false, error: e.message }
     }
+  }
 
+  async listLocalRoutes(): Promise<ListLocalRoutesResult> {
+    const routes = GlobalRouteTable.getRoutes()
+    return { routes }
+  }
 
-    async listLocalRoutes(): Promise<ListLocalRoutesResult> {
-        const routes = GlobalRouteTable.getRoutes();
-        return { routes };
-    }
-
-    async listMetrics(): Promise<ListMetricsResult> {
-        const metrics = GlobalRouteTable.getMetrics();
-        return { metrics };
-    }
+  async listMetrics(): Promise<ListMetricsResult> {
+    const metrics = GlobalRouteTable.getMetrics()
+    return { metrics }
+  }
 }

--- a/packages/orchestrator/tests/session.unit.test.ts
+++ b/packages/orchestrator/tests/session.unit.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'bun:test'
+import { Session } from '../src/auth/session.js'
+
+describe('Session', () => {
+  describe('construction', () => {
+    it('should create session with auth context', () => {
+      const session = new Session({
+        auth: { userId: 'user-123', roles: ['admin'] },
+      })
+      expect(session.auth.userId).toBe('user-123')
+      expect(session.auth.roles).toEqual(['admin'])
+    })
+
+    it('should generate unique connectionId', () => {
+      const session1 = new Session({ auth: { userId: 'user-1' } })
+      const session2 = new Session({ auth: { userId: 'user-2' } })
+      expect(session1.connectionId).not.toBe(session2.connectionId)
+    })
+
+    it('should set connectedAt to current time', () => {
+      const before = new Date()
+      const session = new Session({ auth: { userId: 'user-123' } })
+      const after = new Date()
+
+      expect(session.connectedAt.getTime()).toBeGreaterThanOrEqual(before.getTime())
+      expect(session.connectedAt.getTime()).toBeLessThanOrEqual(after.getTime())
+    })
+
+    it('should set expiresAt when provided', () => {
+      const expiry = new Date(Date.now() + 3600000) // 1 hour from now
+      const session = new Session({
+        auth: { userId: 'user-123' },
+        expiresAt: expiry,
+      })
+      expect(session.expiresAt).toEqual(expiry)
+    })
+
+    it('should set expiresAt to null when not provided', () => {
+      const session = new Session({ auth: { userId: 'user-123' } })
+      expect(session.expiresAt).toBeNull()
+    })
+  })
+
+  describe('isExpired', () => {
+    it('should return false when no expiry is set', () => {
+      const session = new Session({ auth: { userId: 'user-123' } })
+      expect(session.isExpired()).toBe(false)
+    })
+
+    it('should return false when expiry is in the future', () => {
+      const session = new Session({
+        auth: { userId: 'user-123' },
+        expiresAt: new Date(Date.now() + 3600000), // 1 hour from now
+      })
+      expect(session.isExpired()).toBe(false)
+    })
+
+    it('should return true when expiry is in the past', () => {
+      const session = new Session({
+        auth: { userId: 'user-123' },
+        expiresAt: new Date(Date.now() - 1000), // 1 second ago
+      })
+      expect(session.isExpired()).toBe(true)
+    })
+
+    it('should return true when expiry is exactly now', () => {
+      const now = new Date()
+      const session = new Session({
+        auth: { userId: 'user-123' },
+        expiresAt: now,
+      })
+      // Session expires at exactly now, so it should be considered expired
+      expect(session.isExpired()).toBe(true)
+    })
+  })
+
+  describe('remainingMs', () => {
+    it('should return null when no expiry is set', () => {
+      const session = new Session({ auth: { userId: 'user-123' } })
+      expect(session.remainingMs()).toBeNull()
+    })
+
+    it('should return positive value when expiry is in future', () => {
+      const session = new Session({
+        auth: { userId: 'user-123' },
+        expiresAt: new Date(Date.now() + 60000), // 1 minute from now
+      })
+      const remaining = session.remainingMs()
+      expect(remaining).not.toBeNull()
+      expect(remaining!).toBeGreaterThan(0)
+      expect(remaining!).toBeLessThanOrEqual(60000)
+    })
+
+    it('should return 0 when expiry is in the past', () => {
+      const session = new Session({
+        auth: { userId: 'user-123' },
+        expiresAt: new Date(Date.now() - 1000), // 1 second ago
+      })
+      expect(session.remainingMs()).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
### TL;DR

Implement session-based authentication with role-based access control (RBAC) for the orchestrator service.

### What changed?

- Added a session-based authentication system that verifies JWT tokens at connection time
- Implemented role-based access control (RBAC) with predefined permissions for admin, operator, and viewer roles
- Created utility functions for token extraction, verification, and auth context parsing
- Added token expiration handling for long-lived WebSocket connections
- Updated the RPC server to create sessions at connection time and validate permissions for each action
- Added support for JWT audience validation via the `CATALYST_AUTH_AUDIENCE` environment variable

### How to test?

1. Set the required environment variables:
   ```
   CATALYST_AUTH_ENDPOINT=<auth-service-url>
   CATALYST_AUTH_AUDIENCE=<optional-audience-value>
   ```

2. Connect to the orchestrator with a valid JWT token in the Authorization header:
   ```
   Authorization: Bearer <jwt-token>
   ```

3. Test different roles by including appropriate role claims in your JWT:
   - `admin`: Has full access to all actions
   - `operator`: Can create, update, and delete data channels
   - `viewer`: Has no write permissions

### Why make this change?

This change improves security by implementing proper authentication and authorization:

1. Authentication happens once at connection time, creating a session with the user's identity and roles
2. Each subsequent action is checked against the user's roles to ensure they have permission
3. Token expiration is tracked to ensure that long-lived WebSocket connections don't bypass security
4. The RBAC system provides fine-grained control over which roles can perform which actions