### PR TITLE
fix: peering schema is better and confguration items work

### DIFF
--- a/packages/cli/src/commands/peer.ts
+++ b/packages/cli/src/commands/peer.ts
@@ -17,7 +17,7 @@ export const peerCommands = () => {
                 const api = client.connectionFromManagementSDK();
 
                 const result = await api.applyAction({
-                    resource: 'internalPeerConfig',
+                    resource: 'internalBGPConfig',
                     resourceAction: 'create',
                     data: {
                         endpoint,
@@ -75,7 +75,7 @@ export const peerCommands = () => {
                 const client = await createClient();
                 const api = client.connectionFromManagementSDK();
                 const result = await api.applyAction({
-                    resource: 'internalPeerSession',
+                    resource: 'internalBGP',
                     resourceAction: 'close',
                     data: {
                         peerId

--- a/packages/orchestrator/src/plugins/implementations/Internal-bgp.ts
+++ b/packages/orchestrator/src/plugins/implementations/Internal-bgp.ts
@@ -1,9 +1,23 @@
-import { Action } from '../../rpc/schema/actions.js';
+
 import { BasePlugin } from '../../plugins/base.js';
 import { PluginContext, PluginResult } from '../../plugins/types.js';
-import { z } from 'zod';
 import { newHttpBatchRpcSession } from 'capnweb';
 import { getConfig } from '../../config.js';
+import {
+    IBGPConfigCreatePeerSchema,
+    IBGPConfigUpdatePeerSchema,
+    IBGPConfigDeletePeerSchema,
+    IBGPProtocolOpenSchema,
+    IBGPProtocolCloseSchema,
+    IBGPProtocolUpdateSchema,
+    IBGPProtocolKeepAliveSchema,
+    IBGPConfigResource,
+    IBGPConfigResourceAction,
+    IBGPProtocolResource,
+    IBGPProtocolResourceAction,
+    PeerInfo
+} from '../../rpc/schema/peering.js';
+import { LocalRoutingCreateActionSchema, LocalRoutingDeleteActionSchema } from './local-routing.js';
 
 export class InternalBGPPlugin extends BasePlugin {
     name = 'InternalBGPPlugin';
@@ -11,32 +25,54 @@ export class InternalBGPPlugin extends BasePlugin {
     async apply(context: PluginContext): Promise<PluginResult> {
         const { action } = context;
 
-        if (action.resource === 'internalPeerConfig' && action.resourceAction === 'create') {
-            return this.handleCreatePeer(context);
-        }
+        switch (action.resource) {
+            case IBGPConfigResource.value:
+                switch (action.resourceAction) {
+                    case IBGPConfigResourceAction.enum.create:
+                        return this.handleCreatePeer(context);
+                    case IBGPConfigResourceAction.enum.delete:
+                        return this.handleDeletePeer(context);
+                    case IBGPConfigResourceAction.enum.update:
+                        return this.handleUpdatePeer(context);
+                }
+                break;
 
-        if (action.resource === 'internalPeerSession' && action.resourceAction === 'open') {
-            return this.handleOpenPeer(context);
-        }
+            case IBGPProtocolResource.value:
+                switch (action.resourceAction) {
+                    case IBGPProtocolResourceAction.enum.open:
+                        return this.handleOpenPeer(context);
+                    case IBGPProtocolResourceAction.enum.close:
+                        return this.handleClosePeer(context);
+                    case IBGPProtocolResourceAction.enum.update:
+                        return this.handleProtocolUpdate(context);
+                    case IBGPProtocolResourceAction.enum.keepAlive:
+                        return this.handleKeepAlive(context);
+                }
+                break;
 
-        if (action.resource === 'internalPeerSession' && action.resourceAction === 'close') {
-            return this.handleClosePeer(context);
-        }
-
-        if (action.resource === 'internalBGPRoute' && action.resourceAction === 'update') {
-            return this.handleRouteUpdate(context);
-        }
-
-        if (action.resource === 'localRoute' && (action.resourceAction === 'create' || action.resourceAction === 'delete')) {
-            return this.broadcastRouteUpdate(context);
+            case 'localRoute':
+                if (action.resourceAction === 'create' || action.resourceAction === 'delete') {
+                    return this.broadcastRouteUpdate(context);
+                }
+                break;
         }
 
         return { success: true, ctx: context };
     }
 
     private async handleCreatePeer(context: PluginContext): Promise<PluginResult> {
-        const { data } = context.action;
-        const { endpoint } = data;
+        const { action } = context;
+        const result = IBGPConfigCreatePeerSchema.safeParse(action);
+        if (!result.success) return {
+            success: false,
+            error: {
+                pluginName: this.name,
+                message: 'Error parsing message for iBGP create peer action',
+                error: result.error
+            }
+        };
+
+        const { endpoint } = result.data.data;
 
         const existingPeers = context.state.getPeers();
         if (existingPeers.some(p => p.endpoint === endpoint)) {
@@ -66,9 +102,74 @@ export class InternalBGPPlugin extends BasePlugin {
         return { success: true, ctx: context };
     }
 
+    private async handleUpdatePeer(context: PluginContext): Promise<PluginResult> {
+        const { action } = context;
+        const result = IBGPConfigUpdatePeerSchema.safeParse(action);
+        if (!result.success) return {
+            success: false,
+            error: {
+                pluginName: this.name,
+                message: 'Error parsing message for iBGP update peer action',
+                error: result.error
+            }
+        };
+
+        const { peerId, endpoint } = result.data.data;
+        const peer = context.state.getPeer(peerId);
+        if (!peer) {
+            return {
+                success: false,
+                error: { pluginName: this.name, message: `Peer ${peerId} not found for update` }
+            };
+        }
+
+        console.log(`[InternalAS] Updating peer ${peerId} to ${endpoint}`);
+
+        const updatedPeer = {
+            ...peer,
+            endpoint
+        };
+
+        const { state: newState } = context.state.addPeer(updatedPeer); // addPeer handles overwrite
+        context.state = newState;
+
+        return { success: true, ctx: context };
+    }
+
+    private async handleDeletePeer(context: PluginContext): Promise<PluginResult> {
+        const { action } = context;
+        const result = IBGPConfigDeletePeerSchema.safeParse(action);
+        if (!result.success) return {
+            success: false,
+            error: {
+                pluginName: this.name,
+                message: 'Error parsing message for iBGP delete peer action',
+                error: result.error
+            }
+        };
+
+        const { peerId } = result.data.data;
+        console.log(`[InternalAS] Deleting peer ${peerId}`);
+
+        const newState = context.state.removePeer(peerId);
+        context.state = newState;
+
+        return { success: true, ctx: context };
+    }
+
     private async handleOpenPeer(context: PluginContext): Promise<PluginResult> {
-        const { data } = context.action;
-        const { peerInfo } = data;
+        const { action } = context;
+        const result = IBGPProtocolOpenSchema.safeParse(action);
+        if (!result.success) return {
+            success: false,
+            error: {
+                pluginName: this.name,
+                message: 'Error parsing message for iBGP open protocol action',
+                error: result.error
+            }
+        };
+
+        const { peerInfo } = result.data.data;
 
         console.log(`[InternalAS] Handling OPEN request from ${peerInfo.id}`);
 
@@ -109,6 +210,76 @@ export class InternalBGPPlugin extends BasePlugin {
         return { success: true, ctx: context };
     }
 
+    private async handleClosePeer(context: PluginContext): Promise<PluginResult> {
+        const { action } = context;
+        const result = IBGPProtocolCloseSchema.safeParse(action);
+        if (!result.success) return {
+            success: false,
+            error: {
+                pluginName: this.name,
+                message: 'Error parsing message for iBGP close protocol action',
+                error: result.error
+            }
+        };
+
+        const { peerInfo } = result.data.data;
+        console.log(`[InternalAS] Handling CLOSE request for ${peerInfo.id}`);
+
+        const newState = context.state.removePeer(peerInfo.id);
+        context.state = newState;
+        return { success: true, ctx: context };
+    }
+
+    private async handleKeepAlive(context: PluginContext): Promise<PluginResult> {
+        const { action } = context;
+        const result = IBGPProtocolKeepAliveSchema.safeParse(action);
+        if (!result.success) return {
+            success: false,
+            error: {
+                pluginName: this.name,
+                message: 'Error parsing message for iBGP keepalive protocol action',
+                error: result.error
+            }
+        };
+
+        // For now, keepalive just updates the last seen time in orchestration state if we had one
+        // but we don't currently track "lastSeen" in the AuthorizedPeer record.
+        return { success: true, ctx: context };
+    }
+
+    private async handleProtocolUpdate(context: PluginContext): Promise<PluginResult> {
+        const { action } = context;
+        const result = IBGPProtocolUpdateSchema.safeParse(action);
+        if (!result.success) return {
+            success: false,
+            error: {
+                pluginName: this.name,
+                message: 'Error parsing message for iBGP update protocol action',
+                error: result.error
+            }
+        };
+
+        const { peerInfo, updateMessages } = result.data.data;
+        const sourcePeerId = peerInfo.id;
+
+        console.log(`[InternalAS] Handling BGP UPDATE session from ${sourcePeerId} with ${updateMessages.length} messages`);
+
+        let newState = context.state;
+        for (const msg of updateMessages) {
+            if (msg.type === 'add') {
+                const res = newState.addInternalRoute(msg.route, sourcePeerId);
+                newState = res.state;
+            } else if (msg.type === 'remove') {
+                newState = newState.removeRoute(msg.routeId);
+            }
+        }
+
+        console.log(`[InternalAS] Route table updated. Total routes: ${newState.getRoutes().length}`);
+
+        context.state = newState;
+        return { success: true, ctx: context };
+    }
+
     private async syncExistingRoutesToPeer(context: PluginContext, peerId: string): Promise<void> {
         const start = Date.now();
         const peer = context.state.getPeer(peerId);
@@ -120,33 +291,28 @@ export class InternalBGPPlugin extends BasePlugin {
         try {
             const config = getConfig();
             const sharedSecret = config.peering.secret;
-            const myPeerInfo = {
+            const myPeerInfo: PeerInfo = {
                 id: config.peering.localId || 'unknown',
                 as: config.peering.as,
                 domains: config.peering.domains,
                 services: [],
-                endpoint: config.peering.endpoint || null
+                endpoint: config.peering.endpoint || 'unknown'
             };
 
             const session: any = newHttpBatchRpcSession(peer.endpoint);
             const ibgpScope = session.connectionFromIBGPPeer(sharedSecret);
 
             // Always start with OPEN to ensure bidirectional handshake
-            // Don't await it here, let it batch with updates for stateless RPC to work
             const openPromise = ibgpScope.open(myPeerInfo);
 
             if (routes.length > 0) {
-                let lastPromise: Promise<any> | null = null;
-                for (const route of routes) {
-                    console.log(`[InternalAS] --> Syncing ${route.service.name} to ${peerId}`);
-                    lastPromise = ibgpScope.update({
-                        type: 'add',
-                        route: route.service
-                    });
-                }
-                // Await the last one to flush everything
-                if (lastPromise) await lastPromise;
-                else await openPromise;
+                const updates = routes.map(route => ({
+                    type: 'add' as const,
+                    route: route.service
+                }));
+
+                await ibgpScope.update(myPeerInfo, updates);
+                await openPromise;
             } else {
                 await openPromise;
             }
@@ -164,75 +330,51 @@ export class InternalBGPPlugin extends BasePlugin {
         try {
             const config = getConfig();
             const sharedSecret = config.peering.secret;
-            const myPeerInfo = {
+            const myPeerInfo: PeerInfo = {
                 id: config.peering.localId || 'unknown',
                 as: config.peering.as,
                 domains: config.peering.domains,
                 services: [],
-                endpoint: config.peering.endpoint || null
+                endpoint: config.peering.endpoint || 'unknown'
             };
 
             const session: any = newHttpBatchRpcSession(peer.endpoint);
             const ibgpScope = session.connectionFromIBGPPeer(sharedSecret);
             // Batch open and update together
             ibgpScope.open(myPeerInfo);
-            await ibgpScope.update(updateMsg);
+            await ibgpScope.update(myPeerInfo, [updateMsg]);
         } catch (e: any) {
             console.error(`[InternalAS] Failed to send update to peer ${peerId} at ${peer.endpoint}:`, e.message);
         }
     }
 
-    private async handleClosePeer(context: PluginContext): Promise<PluginResult> {
-        const { data } = context.action;
-        const { peerId, skipNotify } = data;
-        console.log(`[InternalAS] Handling CLOSE request for ${peerId}`);
-
-        if (!skipNotify) {
-            await this.notifyPeerClose(context, peerId);
-        }
-
-        const newState = context.state.removePeer(peerId);
-        context.state = newState;
-        return { success: true, ctx: context };
-    }
-
-    private async notifyPeerClose(context: PluginContext, peerId: string): Promise<void> {
-        const peer = context.state.getPeer(peerId);
-        if (!peer || !peer.endpoint || peer.endpoint === 'unknown') return;
-
-        try {
-            console.log(`[InternalAS] Notifying peer ${peerId} of closure at ${peer.endpoint}`);
-            const config = getConfig();
-            const sharedSecret = config.peering.secret;
-            const myPeerInfo = {
-                id: config.peering.localId || 'unknown',
-                as: config.peering.as,
-                domains: config.peering.domains,
-                services: [],
-                endpoint: config.peering.endpoint || null
-            };
-
-            const session: any = newHttpBatchRpcSession(peer.endpoint);
-            const ibgpScope = session.connectionFromIBGPPeer(sharedSecret);
-            await ibgpScope.open(myPeerInfo);
-            await ibgpScope.close();
-            console.log(`[InternalAS] Successfully notified peer ${peerId} of closure.`);
-        } catch (e: any) {
-            console.error(`[InternalAS] Failed to notify peer ${peerId} of closure:`, e.message);
-        }
-    }
-
     private async broadcastRouteUpdate(context: PluginContext): Promise<PluginResult> {
         const { action } = context;
-        const updateType = action.resourceAction === 'create' ? 'add' : 'remove';
+
+        let updateType: 'add' | 'remove';
+        let routeData: any;
+        let routeId: string | undefined;
+
+        if (action.resourceAction === 'create') {
+            const result = LocalRoutingCreateActionSchema.safeParse(action);
+            if (!result.success) return { success: true, ctx: context };
+            updateType = 'add';
+            routeData = result.data.data;
+        } else {
+            const result = LocalRoutingDeleteActionSchema.safeParse(action);
+            if (!result.success) return { success: true, ctx: context };
+            updateType = 'remove';
+            routeId = result.data.data.id;
+        }
+
         let updateMsg: any = {
             type: updateType
         };
 
         if (updateType === 'add') {
-            updateMsg.route = action.data;
+            updateMsg.route = routeData;
         } else {
-            updateMsg.routeId = action.data.id;
+            updateMsg.routeId = routeId;
         }
 
         const peers = context.state.getPeers();
@@ -243,80 +385,4 @@ export class InternalBGPPlugin extends BasePlugin {
         await Promise.all(promises);
         return { success: true, ctx: context };
     }
-
-    private async handleRouteUpdate(context: PluginContext): Promise<PluginResult> {
-        const { data } = context.action;
-        const { type, route, routeId } = data;
-        const sourcePeerId = data.sourcePeerId || 'unknown';
-
-        console.log(`[InternalAS] Handling BGP UPDATE: ${type} ${route?.name || routeId} from ${sourcePeerId}`);
-
-        let newState = context.state;
-        if (type === 'add' && route) {
-            const res = newState.addInternalRoute(route, sourcePeerId);
-            newState = res.state;
-        } else if (type === 'remove' && routeId) {
-            newState = newState.removeRoute(routeId);
-        }
-
-        console.log(`[InternalAS] Route table updated. Total routes: ${newState.getRoutes().length}`);
-
-        context.state = newState;
-        return { success: true, ctx: context };
-    }
 }
-
-export const InternalPeerConfigCreateSchema = z.object({
-    resource: z.literal('internalPeerConfig'),
-    resourceAction: z.literal('create'),
-    data: z.object({
-        endpoint: z.string(),
-        secret: z.string()
-    })
-});
-
-export const InternalPeerSessionOpenSchema = z.object({
-    resource: z.literal('internalPeerSession'),
-    resourceAction: z.literal('open'),
-    data: z.object({
-        peerInfo: z.any(),
-        clientStub: z.any(),
-        direction: z.enum(['inbound', 'outbound']).optional()
-    })
-});
-
-export const InternalPeerSessionCloseSchema = z.object({
-    resource: z.literal('internalPeerSession'),
-    resourceAction: z.literal('close'),
-    data: z.object({
-        peerId: z.string(),
-        skipNotify: z.boolean().optional()
-    })
-});
-
-export const InternalPeerSessionKeepAliveSchema = z.object({
-    resource: z.literal('internalPeerSession'),
-    resourceAction: z.literal('keepAlive'),
-    data: z.object({
-        peerId: z.string()
-    })
-});
-
-export const InternalBGPRouteUpdateSchema = z.object({
-    resource: z.literal('internalBGPRoute'),
-    resourceAction: z.literal('update'),
-    data: z.object({
-        type: z.union([z.literal('add'), z.literal('remove')]),
-        route: z.any().optional(),
-        routeId: z.string().optional(),
-        sourcePeerId: z.string().optional()
-    })
-});
-
-export const InternalPeeringActionsSchema = z.union([
-    InternalPeerConfigCreateSchema,
-    InternalPeerSessionOpenSchema,
-    InternalPeerSessionCloseSchema,
-    InternalPeerSessionKeepAliveSchema,
-    InternalBGPRouteUpdateSchema
-]);

--- a/packages/orchestrator/src/plugins/types.ts
+++ b/packages/orchestrator/src/plugins/types.ts
@@ -1,48 +1,33 @@
+
 import { z } from 'zod';
 import { ActionSchema } from '../rpc/schema/index.js';
-export { ActionSchema };
 import { RouteTable } from '../state/route-table.js';
 
 export const AuthContextSchema = z.object({
-    userId: z.string().optional(),
-    orgId: z.string().optional(),
-    roles: z.array(z.string()).optional(),
+    userId: z.string(),
+    roles: z.array(z.string()),
 });
 export type AuthContext = z.infer<typeof AuthContextSchema>;
 
-export interface BaseAction<Resource extends string, Action extends string, Data> {
-    resource: Resource;
-    resourceAction: Action;
-    data: Data;
-}
-
-export type OrchestratorAction = BaseAction<string, string, any>;
-
 export const PluginContextSchema = z.object({
-    action: z.custom<OrchestratorAction>(),
+    action: ActionSchema,
     state: z.instanceof(RouteTable),
     authxContext: AuthContextSchema,
     results: z.array(z.any()).default([]),
 });
 export type PluginContext = z.infer<typeof PluginContextSchema>;
 
-export const PluginResultSchema = z.discriminatedUnion('success', [
-    z.object({
-        success: z.literal(true),
-        ctx: PluginContextSchema,
-    }),
-    z.object({
-        success: z.literal(false),
-        error: z.object({
-            pluginName: z.string(),
-            message: z.string(),
-            error: z.any().optional(),
-        }),
-    }),
-]);
-export type PluginResult = z.infer<typeof PluginResultSchema>;
+export interface PluginResult {
+    success: boolean;
+    ctx: PluginContext;
+    error?: {
+        pluginName: string;
+        message: string;
+        error?: any;
+    };
+}
 
-export interface PluginInterface {
+export interface Plugin {
     name: string;
     apply(context: PluginContext): Promise<PluginResult>;
 }

--- a/packages/orchestrator/src/rpc/schema/actions.ts
+++ b/packages/orchestrator/src/rpc/schema/actions.ts
@@ -3,17 +3,22 @@ import { z } from 'zod';
 
 
 import { LocalRoutingActionsSchema } from '../../plugins/implementations/local-routing.js';
-import { InternalPeeringActionsSchema } from '../../plugins/implementations/Internal-bgp.js';
+import { IBGPConfigSchema, IBGPProtocolSchema } from './peering.js';
 
 export const ActionSchema = z.union([
     LocalRoutingActionsSchema,
-    InternalPeeringActionsSchema
+    IBGPProtocolSchema,
+    IBGPConfigSchema
 ]);
 export type Action = z.infer<typeof ActionSchema>;
 
-export const ActionResultSchema = z.object({
-    success: z.boolean(),
-    id: z.string().optional(),
-    error: z.string().optional(),
-});
+export const ActionResultSchema = z.discriminatedUnion("success", [
+    z.object({
+        success: z.literal(true),
+    }),
+    z.object({
+        success: z.literal(false),
+        error: z.string(),
+    })
+]);
 export type ActionResult = z.infer<typeof ActionResultSchema>;

--- a/packages/orchestrator/src/rpc/schema/peering.ts
+++ b/packages/orchestrator/src/rpc/schema/peering.ts
@@ -2,6 +2,7 @@
 import { z } from 'zod';
 import { ServiceDefinitionSchema } from './direct.js';
 
+// --- iBGP Route Table ---
 export const AuthorizedPeerSchema = z.object({
     id: z.string(),
     as: z.number(),
@@ -18,15 +19,123 @@ export const PeerInfoSchema = z.object({
 });
 export type PeerInfo = z.infer<typeof PeerInfoSchema>;
 
-export const UpdateMessageSchema = z.object({
-    type: z.union([z.literal('add'), z.literal('remove')]),
-    route: ServiceDefinitionSchema.optional(),
-    routeId: z.string().optional(),
-    path: z.array(z.string()).optional() // BGP AS Path (using Peer IDs for internal peering)
+export const UpdateMesssageAddSchema = z.object({
+    type: z.literal('add'),
+    route: ServiceDefinitionSchema,
 });
+
+export const UpdateMesssageRemoveSchema = z.object({
+    type: z.literal('remove'),
+    routeId: z.string(),
+});
+
+export const UpdateMessageSchema = z.discriminatedUnion('type', [
+    UpdateMesssageAddSchema,
+    UpdateMesssageRemoveSchema
+]);
+
 export type UpdateMessage = z.infer<typeof UpdateMessageSchema>;
 
 export const ListPeersResultSchema = z.object({
     peers: z.array(AuthorizedPeerSchema)
 });
 export type ListPeersResult = z.infer<typeof ListPeersResultSchema>;
+
+// --- iBGP Peering Actions ---
+export const IBGPConfigResource = z.literal('internalBGPConfig');
+export const IBGPConfigResourceAction = z.enum([
+    'create',
+    'update',
+    'delete'
+]);
+
+export const IBGPConfigCreatePeerSchema = z.object({
+    resource: IBGPConfigResource,
+    resourceAction: z.literal(IBGPConfigResourceAction.enum.create),
+    data: z.object({
+        endpoint: z.string(),
+        secret: z.string()
+    })
+});
+
+export const IBGPConfigUpdatePeerSchema = z.object({
+    resource: IBGPConfigResource,
+    resourceAction: z.literal(IBGPConfigResourceAction.enum.update),
+    data: z.object({
+        peerId: z.string(),
+        endpoint: z.string(),
+        secret: z.string()
+    })
+});
+
+export const IBGPConfigDeletePeerSchema = z.object({
+    resource: IBGPConfigResource,
+    resourceAction: z.literal(IBGPConfigResourceAction.enum.delete),
+    data: z.object({
+        peerId: z.string()
+    })
+});
+
+export const IBGPConfigSchema = z.discriminatedUnion('resourceAction', [
+    IBGPConfigCreatePeerSchema,
+    IBGPConfigUpdatePeerSchema,
+    IBGPConfigDeletePeerSchema
+]);
+
+export type IBGPConfig = z.infer<typeof IBGPConfigSchema>;
+
+
+export const IBGPProtocolResource = z.literal('internalBGP');
+export const IBGPProtocolResourceAction = z.enum([
+    'open',
+    'close',
+    'keepAlive',
+    'update'
+]);
+
+
+export const IBGPProtocolOpenSchema = z.object({
+    resource: IBGPProtocolResource,
+    resourceAction: z.literal(IBGPProtocolResourceAction.enum.open),
+    data: z.object({
+        peerInfo: PeerInfoSchema,
+    })
+});
+
+export const IBGPProtocolCloseSchema = z.object({
+    resource: IBGPProtocolResource,
+    resourceAction: z.literal(IBGPProtocolResourceAction.enum.close),
+    data: z.object({
+        peerInfo: PeerInfoSchema.omit({ domains: true }),
+    })
+});
+
+export const IBGPProtocolKeepAliveSchema = z.object({
+    resource: IBGPProtocolResource,
+    resourceAction: z.literal(IBGPProtocolResourceAction.enum.keepAlive),
+    data: z.object({
+        peerInfo: PeerInfoSchema.omit({ domains: true }),
+    })
+});
+
+export const IBGPProtocolUpdateSchema = z.object({
+    resource: IBGPProtocolResource,
+    resourceAction: z.literal(IBGPProtocolResourceAction.enum.update),
+    data: z.object({
+        peerInfo: PeerInfoSchema,
+        updateMessages: z.array(UpdateMessageSchema),
+    })
+});
+
+export const IBGPProtocolSchema = z.discriminatedUnion('resourceAction', [
+    IBGPProtocolOpenSchema,
+    IBGPProtocolCloseSchema,
+    IBGPProtocolKeepAliveSchema,
+    IBGPProtocolUpdateSchema
+]);
+
+export type IBGPProtocol = z.infer<typeof IBGPProtocolSchema>;
+export type IBGPProtocolOpen = z.infer<typeof IBGPProtocolOpenSchema>;
+export type IBGPProtocolClose = z.infer<typeof IBGPProtocolCloseSchema>;
+export type IBGPProtocolKeepAlive = z.infer<typeof IBGPProtocolKeepAliveSchema>;
+export type IBGPProtocolUpdate = z.infer<typeof IBGPProtocolUpdateSchema>;

--- a/packages/orchestrator/tests/config.ibgp.plugins.integration.test.ts
+++ b/packages/orchestrator/tests/config.ibgp.plugins.integration.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'bun:test';
+import { OrchestratorRpcServer } from '../src/rpc/server.js';
+import { IBGPConfigResource, IBGPConfigResourceAction } from '../src/rpc/schema/peering.js';
+
+describe('iBGP Config Integration Tests', () => {
+
+    it('should create a peer via applyAction', async () => {
+        const server = new OrchestratorRpcServer();
+        const endpoint = 'http://peer-a:3000/rpc';
+
+        const action = {
+            resource: IBGPConfigResource.value,
+            resourceAction: IBGPConfigResourceAction.enum.create,
+            data: {
+                endpoint,
+                secret: 'valid-secret'
+            }
+        };
+
+        const result = await server.applyAction(action as any);
+        expect(result.success).toBe(true);
+
+        const peersResult = await server.listPeers();
+        expect(peersResult.peers).toHaveLength(1);
+        expect(peersResult.peers[0].endpoint).toBe(endpoint);
+    });
+
+    it('should update a peer via applyAction', async () => {
+        const server = new OrchestratorRpcServer();
+        const initialEndpoint = 'http://peer-old:3000/rpc';
+        const newEndpoint = 'http://peer-new:3000/rpc';
+
+        // 1. Create peer
+        await server.applyAction({
+            resource: IBGPConfigResource.value,
+            resourceAction: IBGPConfigResourceAction.enum.create,
+            data: {
+                endpoint: initialEndpoint,
+                secret: 'valid-secret'
+            }
+        } as any);
+
+        const peersResult = await server.listPeers();
+        const peerId = peersResult.peers[0].id;
+
+        // 2. Update peer
+        const updateAction = {
+            resource: IBGPConfigResource.value,
+            resourceAction: IBGPConfigResourceAction.enum.update,
+            data: {
+                peerId,
+                endpoint: newEndpoint,
+                secret: 'new-secret'
+            }
+        };
+
+        const updateResult = await server.applyAction(updateAction as any);
+        expect(updateResult.success).toBe(true);
+
+        const updatedPeersResult = await server.listPeers();
+        expect(updatedPeersResult.peers[0].endpoint).toBe(newEndpoint);
+    });
+
+    it('should delete a peer via applyAction', async () => {
+        const server = new OrchestratorRpcServer();
+        const endpoint = 'http://peer-to-delete:3000/rpc';
+
+        // 1. Create peer
+        await server.applyAction({
+            resource: IBGPConfigResource.value,
+            resourceAction: IBGPConfigResourceAction.enum.create,
+            data: {
+                endpoint,
+                secret: 'valid-secret'
+            }
+        } as any);
+
+        const peersResult = await server.listPeers();
+        const peerId = peersResult.peers[0].id;
+
+        // 2. Delete peer
+        const deleteAction = {
+            resource: IBGPConfigResource.value,
+            resourceAction: IBGPConfigResourceAction.enum.delete,
+            data: {
+                peerId
+            }
+        };
+
+        const deleteResult = await server.applyAction(deleteAction as any);
+        expect(deleteResult.success).toBe(true);
+
+        const finalPeersResult = await server.listPeers();
+        expect(finalPeersResult.peers).toHaveLength(0);
+    });
+});

--- a/packages/orchestrator/tests/config.ibgp.plugins.unit.test.ts
+++ b/packages/orchestrator/tests/config.ibgp.plugins.unit.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'bun:test';
+import { InternalBGPPlugin } from '../src/plugins/implementations/Internal-bgp.js';
+import { RouteTable } from '../src/state/route-table.js';
+import { PluginContext } from '../src/plugins/types.js';
+import { IBGPConfigResource, IBGPConfigResourceAction } from '../src/rpc/schema/peering.js';
+
+describe('InternalBGPPlugin Config Unit Tests', () => {
+
+    it('should handle create peer action', async () => {
+        const plugin = new InternalBGPPlugin();
+        const initialState = new RouteTable();
+
+        const context: PluginContext = {
+            action: {
+                resource: IBGPConfigResource.value,
+                resourceAction: IBGPConfigResourceAction.enum.create,
+                data: {
+                    endpoint: 'http://peer-a:3000/rpc',
+                    secret: 'peer-secret'
+                }
+            },
+            state: initialState,
+            results: [],
+            authxContext: {} as any
+        };
+
+        const result = await plugin.apply(context);
+        expect(result.success).toBe(true);
+        if (!result.success) throw new Error('Plugin failed');
+
+        const peers = result.ctx.state.getPeers();
+        expect(peers).toHaveLength(1);
+        expect(peers[0].endpoint).toBe('http://peer-a:3000/rpc');
+    });
+
+    it('should handle update peer action', async () => {
+        const plugin = new InternalBGPPlugin();
+        const endpoint = 'http://peer-old:3000/rpc';
+        const peerId = 'peer-http---peer-old-3000-rpc';
+
+        const stateWithPeer = new RouteTable().addPeer({
+            id: peerId,
+            as: 0,
+            endpoint: endpoint,
+            domains: []
+        }).state;
+
+        const context: PluginContext = {
+            action: {
+                resource: IBGPConfigResource.value,
+                resourceAction: IBGPConfigResourceAction.enum.update,
+                data: {
+                    peerId: peerId,
+                    endpoint: 'http://peer-new:3000/rpc',
+                    secret: 'new-secret'
+                }
+            },
+            state: stateWithPeer,
+            results: [],
+            authxContext: {} as any
+        };
+
+        const result = await plugin.apply(context);
+        expect(result.success).toBe(true);
+        if (!result.success) throw new Error('Plugin failed');
+
+        const updatedPeer = result.ctx.state.getPeer(peerId);
+        expect(updatedPeer?.endpoint).toBe('http://peer-new:3000/rpc');
+    });
+
+    it('should handle delete peer action', async () => {
+        const plugin = new InternalBGPPlugin();
+        const peerId = 'peer-to-delete';
+
+        const stateWithPeer = new RouteTable().addPeer({
+            id: peerId,
+            as: 100,
+            endpoint: 'http://peer-to-delete:3000/rpc',
+            domains: []
+        }).state;
+
+        const context: PluginContext = {
+            action: {
+                resource: IBGPConfigResource.value,
+                resourceAction: IBGPConfigResourceAction.enum.delete,
+                data: {
+                    peerId: peerId
+                }
+            },
+            state: stateWithPeer,
+            results: [],
+            authxContext: {} as any
+        };
+
+        const result = await plugin.apply(context);
+        expect(result.success).toBe(true);
+        if (!result.success) throw new Error('Plugin failed');
+
+        const peers = result.ctx.state.getPeers();
+        expect(peers).toHaveLength(0);
+    });
+});

--- a/packages/orchestrator/tests/internal-bgp.plugin.unit.test.ts
+++ b/packages/orchestrator/tests/internal-bgp.plugin.unit.test.ts
@@ -12,17 +12,21 @@ describe('InternalBGPPlugin Unit Tests', () => {
         const route = {
             name: 'proxied-service',
             endpoint: 'http://remote:8080/rpc',
-            protocol: 'tcp:graphql'
+            protocol: 'tcp:graphql' as any
         };
 
         const context: PluginContext = {
             action: {
-                resource: 'internalBGPRoute',
+                resource: 'internalBGP',
                 resourceAction: 'update',
                 data: {
-                    type: 'add',
-                    route,
-                    sourcePeerId: 'peer-b'
+                    peerInfo: { id: 'peer-b', as: 100, endpoint: 'http://peer-b:3000/rpc', domains: [] },
+                    updateMessages: [
+                        {
+                            type: 'add',
+                            route
+                        }
+                    ]
                 }
             },
             state: initialState,
@@ -55,11 +59,16 @@ describe('InternalBGPPlugin Unit Tests', () => {
 
         const context: PluginContext = {
             action: {
-                resource: 'internalBGPRoute',
+                resource: 'internalBGP',
                 resourceAction: 'update',
                 data: {
-                    type: 'remove',
-                    routeId
+                    peerInfo: { id: 'peer-b', as: 100, endpoint: 'http://peer-b:3000/rpc', domains: [] },
+                    updateMessages: [
+                        {
+                            type: 'remove',
+                            routeId
+                        }
+                    ]
                 }
             },
             state: seedState,
@@ -98,7 +107,7 @@ describe('InternalBGPPlugin Unit Tests', () => {
                 data: {
                     name: 'local-service',
                     endpoint: 'http://localhost:8080',
-                    protocol: 'tcp'
+                    protocol: 'tcp' as any
                 }
             } as any,
             state: stateWithPeer,
@@ -137,11 +146,10 @@ describe('InternalBGPPlugin Unit Tests', () => {
 
         const context: PluginContext = {
             action: {
-                resource: 'internalPeerSession',
+                resource: 'internalBGP',
                 resourceAction: 'close',
                 data: {
-                    peerId,
-                    skipNotify: true // Skip network call in unit test
+                    peerInfo: { id: peerId, as: 100, endpoint: 'http://peer-b:3000/rpc' }
                 }
             },
             state: seededState,
@@ -182,11 +190,10 @@ describe('InternalBGPPlugin Unit Tests', () => {
 
         const context: PluginContext = {
             action: {
-                resource: 'internalPeerSession',
+                resource: 'internalBGP',
                 resourceAction: 'open',
                 data: {
-                    peerInfo,
-                    direction: 'inbound'
+                    peerInfo
                 }
             },
             state,

--- a/packages/orchestrator/tests/internal-peering.plugin.integration.test.ts
+++ b/packages/orchestrator/tests/internal-peering.plugin.integration.test.ts
@@ -10,12 +10,10 @@ describe('Internal Peering Integration', () => {
         const plugin = new InternalBGPPlugin();
         const context: PluginContext = {
             action: {
-                resource: 'internalPeerSession',
+                resource: 'internalBGP',
                 resourceAction: 'open',
                 data: {
-                    peerInfo: { id: 'remote-1', as: 200 },
-                    clientStub: {},
-                    direction: 'inbound'
+                    peerInfo: { id: 'remote-1', as: 200, endpoint: 'http://remote-1:3000/rpc', domains: [] }
                 }
             },
             state: new RouteTable(),
@@ -53,9 +51,11 @@ describe('Internal Peering Integration', () => {
 
         const context: PluginContext = {
             action: {
-                resource: 'internalPeerSession',
+                resource: 'internalBGP',
                 resourceAction: 'close',
-                data: { peerId: 'remote-exit' }
+                data: {
+                    peerInfo: { id: 'remote-exit', as: 300, endpoint: 'ws://host' }
+                }
             },
             state,
             results: [],


### PR DESCRIPTION
### TL;DR

Refactored the internal BGP implementation to use a more structured schema-based approach with clear resource types and actions.

### What changed?

- Renamed resources from `internalPeerConfig` to `internalBGPConfig` and `internalPeerSession` to `internalBGP` for consistency
- Restructured the BGP plugin to use a switch-case pattern for handling different resource actions
- Added proper schema validation for all BGP-related actions using Zod
- Moved schema definitions from the plugin file to a dedicated peering schema file
- Added support for new actions: update peer, delete peer, and keep-alive
- Improved error handling with more descriptive error messages
- Updated the RPC server to match the new protocol structure
- Added comprehensive unit and integration tests for the new functionality

### How to test?

1. Test peer configuration:
   ```
   cli peer add --endpoint http://peer:3000/rpc --secret your-secret
   ```

2. Test peer session management:
   ```
   cli peer close --peer-id peer-id
   ```

3. Run the new unit and integration tests:
   ```
   cd packages/orchestrator
   bun test
   ```

### Why make this change?

This refactoring improves the internal BGP implementation by:

1. Making the code more maintainable with clear resource types and actions
2. Adding proper schema validation to ensure data integrity
3. Providing better error handling and reporting
4. Supporting additional peer management operations (update, delete)
5. Improving the protocol structure to be more consistent with BGP standards
6. Adding comprehensive test coverage to ensure reliability

The changes make the codebase more robust and easier to extend with new features in the future.