### PR TITLE
chore: more peering management fixes

### DIFF
--- a/packages/cli/src/commands/peer.ts
+++ b/packages/cli/src/commands/peer.ts
@@ -11,6 +11,7 @@ export const peerCommands = () => {
         .description('Add a new peer connection')
         .argument('<endpoint>', 'WebSocket endpoint of the peer (e.g., ws://localhost:3000/rpc)')
         .requiredOption('--secret <secret>', 'Shared secret for authentication')
+        .option('--domains <domains>', 'Comma-separated list of domains')
         .action(async (endpoint, options) => {
             try {
                 const client = await createClient();
@@ -21,7 +22,7 @@ export const peerCommands = () => {
                     resourceAction: 'create',
                     data: {
                         endpoint,
-                        secret: options.secret
+                        domains: options.domains ? options.domains.split(',').map((d: string) => d.trim()) : []
                     }
                 });
 

--- a/packages/orchestrator/src/config.ts
+++ b/packages/orchestrator/src/config.ts
@@ -1,17 +1,17 @@
-
 import { z } from 'zod';
+import os from 'os';
 
 export const OrchestratorConfigSchema = z.object({
     gqlGatewayConfig: z.object({
         endpoint: z.string().url(),
     }).optional(),
-    peering: z.object({
+    as: z.number().default(0),
+    ibgp: z.object({
         localId: z.string().optional(),
         endpoint: z.string().url().optional(),
-        as: z.number().default(0),
         domains: z.array(z.string()).default([]),
         secret: z.string().default('valid-secret'),
-    }).default({ as: 0, domains: [], secret: 'valid-secret' }),
+    }).default({ domains: [], secret: 'valid-secret' }),
     port: z.number().default(3000),
 });
 
@@ -28,10 +28,10 @@ export function getConfig(): OrchestratorConfig {
 
     const config: any = {
         port,
-        peering: {
-            as: peeringAs ? parseInt(peeringAs) : 0,
+        as: peeringAs ? parseInt(peeringAs) : 0,
+        ibgp: {
             domains: peeringDomains ? peeringDomains.split(',').map(d => d.trim()) : [],
-            localId: peeringNodeId,
+            localId: peeringNodeId || os.hostname(),
             endpoint: peeringEndpoint,
             secret: peeringSecret || 'valid-secret'
         }

--- a/packages/orchestrator/src/rpc/schema/peering.ts
+++ b/packages/orchestrator/src/rpc/schema/peering.ts
@@ -1,6 +1,6 @@
-
 import { z } from 'zod';
 import { ServiceDefinitionSchema } from './direct.js';
+import { ApplyActionResult } from './index.js';
 
 // --- iBGP Route Table ---
 export const AuthorizedPeerSchema = z.object({
@@ -54,7 +54,7 @@ export const IBGPConfigCreatePeerSchema = z.object({
     resourceAction: z.literal(IBGPConfigResourceAction.enum.create),
     data: z.object({
         endpoint: z.string(),
-        secret: z.string()
+        domains: z.array(z.string()).optional()
     })
 });
 
@@ -64,7 +64,7 @@ export const IBGPConfigUpdatePeerSchema = z.object({
     data: z.object({
         peerId: z.string(),
         endpoint: z.string(),
-        secret: z.string()
+        domains: z.array(z.string()).optional()
     })
 });
 
@@ -137,5 +137,14 @@ export const IBGPProtocolSchema = z.discriminatedUnion('resourceAction', [
 export type IBGPProtocol = z.infer<typeof IBGPProtocolSchema>;
 export type IBGPProtocolOpen = z.infer<typeof IBGPProtocolOpenSchema>;
 export type IBGPProtocolClose = z.infer<typeof IBGPProtocolCloseSchema>;
-export type IBGPProtocolKeepAlive = z.infer<typeof IBGPProtocolKeepAliveSchema>;
 export type IBGPProtocolUpdate = z.infer<typeof IBGPProtocolUpdateSchema>;
+
+export interface IBGPScope {
+    open(peerInfo: PeerInfo): Promise<ApplyActionResult>;
+    update(peerInfo: PeerInfo, routes: UpdateMessage[]): Promise<ApplyActionResult>;
+    close(peerInfo: PeerInfo): Promise<ApplyActionResult>;
+}
+
+export interface PeerApi {
+    connectToIBGPPeer(secret: string): IBGPScope;
+}

--- a/packages/orchestrator/tests/config.ibgp.plugins.integration.test.ts
+++ b/packages/orchestrator/tests/config.ibgp.plugins.integration.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, mock } from 'bun:test';
 import { OrchestratorRpcServer } from '../src/rpc/server.js';
 import { IBGPConfigResource, IBGPConfigResourceAction } from '../src/rpc/schema/peering.js';
+
+mock.module('capnweb', () => ({
+    newHttpBatchRpcSession: () => ({
+        connectToIBGPPeer: () => ({
+            open: async () => ({ success: true }),
+            update: async () => ({ success: true })
+        })
+    })
+}));
 
 describe('iBGP Config Integration Tests', () => {
 
@@ -12,8 +21,7 @@ describe('iBGP Config Integration Tests', () => {
             resource: IBGPConfigResource.value,
             resourceAction: IBGPConfigResourceAction.enum.create,
             data: {
-                endpoint,
-                secret: 'valid-secret'
+                endpoint
             }
         };
 
@@ -35,8 +43,7 @@ describe('iBGP Config Integration Tests', () => {
             resource: IBGPConfigResource.value,
             resourceAction: IBGPConfigResourceAction.enum.create,
             data: {
-                endpoint: initialEndpoint,
-                secret: 'valid-secret'
+                endpoint: initialEndpoint
             }
         } as any);
 
@@ -49,8 +56,7 @@ describe('iBGP Config Integration Tests', () => {
             resourceAction: IBGPConfigResourceAction.enum.update,
             data: {
                 peerId,
-                endpoint: newEndpoint,
-                secret: 'new-secret'
+                endpoint: newEndpoint
             }
         };
 
@@ -70,8 +76,7 @@ describe('iBGP Config Integration Tests', () => {
             resource: IBGPConfigResource.value,
             resourceAction: IBGPConfigResourceAction.enum.create,
             data: {
-                endpoint,
-                secret: 'valid-secret'
+                endpoint
             }
         } as any);
 

--- a/packages/orchestrator/tests/config.ibgp.plugins.unit.test.ts
+++ b/packages/orchestrator/tests/config.ibgp.plugins.unit.test.ts
@@ -1,8 +1,17 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, mock } from 'bun:test';
 import { InternalBGPPlugin } from '../src/plugins/implementations/Internal-bgp.js';
 import { RouteTable } from '../src/state/route-table.js';
 import { PluginContext } from '../src/plugins/types.js';
 import { IBGPConfigResource, IBGPConfigResourceAction } from '../src/rpc/schema/peering.js';
+
+mock.module('capnweb', () => ({
+    newHttpBatchRpcSession: () => ({
+        connectToIBGPPeer: () => ({
+            open: async () => ({ success: true }),
+            update: async () => ({ success: true })
+        })
+    })
+}));
 
 describe('InternalBGPPlugin Config Unit Tests', () => {
 
@@ -15,8 +24,7 @@ describe('InternalBGPPlugin Config Unit Tests', () => {
                 resource: IBGPConfigResource.value,
                 resourceAction: IBGPConfigResourceAction.enum.create,
                 data: {
-                    endpoint: 'http://peer-a:3000/rpc',
-                    secret: 'peer-secret'
+                    endpoint: 'http://peer-a:3000/rpc'
                 }
             },
             state: initialState,
@@ -51,8 +59,7 @@ describe('InternalBGPPlugin Config Unit Tests', () => {
                 resourceAction: IBGPConfigResourceAction.enum.update,
                 data: {
                     peerId: peerId,
-                    endpoint: 'http://peer-new:3000/rpc',
-                    secret: 'new-secret'
+                    endpoint: 'http://peer-new:3000/rpc'
                 }
             },
             state: stateWithPeer,

--- a/packages/orchestrator/tests/internal-bgp.plugin.unit.test.ts
+++ b/packages/orchestrator/tests/internal-bgp.plugin.unit.test.ts
@@ -3,6 +3,15 @@ import { InternalBGPPlugin } from '../src/plugins/implementations/Internal-bgp.j
 import { RouteTable } from '../src/state/route-table.js';
 import { PluginContext } from '../src/plugins/types.js';
 
+mock.module('capnweb', () => ({
+    newHttpBatchRpcSession: () => ({
+        connectToIBGPPeer: () => ({
+            open: async () => ({ success: true }),
+            update: async () => ({ success: true })
+        })
+    })
+}));
+
 describe('InternalBGPPlugin Unit Tests', () => {
 
     it('should add an internal route when receiving an "add" update', async () => {


### PR DESCRIPTION
### TL;DR

Refactored the iBGP peering system to improve peer handshaking, configuration, and domain management.

### What changed?

- Restructured configuration by moving `as` to the top level and renaming `peering` to `ibgp`
- Added support for specifying domains when adding peers via CLI with a new `--domains` option
- Improved peer handshaking process to verify connectivity before adding peers to state
- Renamed RPC methods for clarity (`connectionFromIBGPPeer` → `connectToIBGPPeer`)
- Renamed handler methods to better reflect their purpose and functionality
- Enhanced error handling during peer synchronization
- Added proper hostname detection using `os.hostname()` as fallback for peer ID
- Moved `IBGPScope` interface to the schema file for better organization
- Updated tests to accommodate the new peer handshaking flow

### How to test?

1. Add a peer with domains:
   ```
   cli peer add ws://localhost:3000/rpc --secret your-secret --domains example.com,test.com
   ```

2. Configure an orchestrator with AS number and domains:
   ```
   PEERING_AS=65001 PEERING_DOMAINS=example.com,test.com node orchestrator
   ```

3. Verify peers connect and exchange routes properly between instances

### Why make this change?

This refactoring improves the iBGP peering system by:

1. Making the configuration more intuitive with AS numbers at the top level
2. Adding proper domain support for more granular route filtering
3. Implementing proper handshaking to ensure peers are valid before adding them
4. Improving error handling to make troubleshooting easier
5. Making the code more maintainable with better naming conventions