### PR TITLE
chore: finishing ibgp management

### DIFF
--- a/packages/orchestrator/src/rpc/client.ts
+++ b/packages/orchestrator/src/rpc/client.ts
@@ -1,0 +1,7 @@
+import { newHttpBatchRpcSession } from 'capnweb';
+import type { PeerApi } from './schema/peering.js';
+
+export function getPeerSession(endpoint: string, secret: string) {
+    const session = newHttpBatchRpcSession<PeerApi>(endpoint);
+    return session.connectToIBGPPeer(secret);
+}

--- a/packages/orchestrator/tests/config.ibgp.plugins.integration.test.ts
+++ b/packages/orchestrator/tests/config.ibgp.plugins.integration.test.ts
@@ -2,12 +2,11 @@ import { describe, it, expect, mock } from 'bun:test';
 import { OrchestratorRpcServer } from '../src/rpc/server.js';
 import { IBGPConfigResource, IBGPConfigResourceAction } from '../src/rpc/schema/peering.js';
 
-mock.module('capnweb', () => ({
-    newHttpBatchRpcSession: () => ({
-        connectToIBGPPeer: () => ({
-            open: async () => ({ success: true }),
-            update: async () => ({ success: true })
-        })
+mock.module('../src/rpc/client.js', () => ({
+    getPeerSession: () => ({
+        open: async () => ({ success: true }),
+        update: async () => ({ success: true }),
+        close: async () => ({ success: true })
     })
 }));
 

--- a/packages/orchestrator/tests/config.ibgp.plugins.unit.test.ts
+++ b/packages/orchestrator/tests/config.ibgp.plugins.unit.test.ts
@@ -4,19 +4,18 @@ import { RouteTable } from '../src/state/route-table.js';
 import { PluginContext } from '../src/plugins/types.js';
 import { IBGPConfigResource, IBGPConfigResourceAction } from '../src/rpc/schema/peering.js';
 
-mock.module('capnweb', () => ({
-    newHttpBatchRpcSession: () => ({
-        connectToIBGPPeer: () => ({
-            open: async () => ({ success: true }),
-            update: async () => ({ success: true })
-        })
-    })
-}));
+const mockSession = {
+    open: async () => ({ success: true }),
+    update: async () => ({ success: true }),
+    close: async () => ({ success: true })
+};
+const mockFactory = () => mockSession as any;
+
 
 describe('InternalBGPPlugin Config Unit Tests', () => {
 
     it('should handle create peer action', async () => {
-        const plugin = new InternalBGPPlugin();
+        const plugin = new InternalBGPPlugin(mockFactory);
         const initialState = new RouteTable();
 
         const context: PluginContext = {
@@ -42,7 +41,7 @@ describe('InternalBGPPlugin Config Unit Tests', () => {
     });
 
     it('should handle update peer action', async () => {
-        const plugin = new InternalBGPPlugin();
+        const plugin = new InternalBGPPlugin(mockFactory);
         const endpoint = 'http://peer-old:3000/rpc';
         const peerId = 'peer-http---peer-old-3000-rpc';
 
@@ -76,7 +75,7 @@ describe('InternalBGPPlugin Config Unit Tests', () => {
     });
 
     it('should handle delete peer action', async () => {
-        const plugin = new InternalBGPPlugin();
+        const plugin = new InternalBGPPlugin(mockFactory);
         const peerId = 'peer-to-delete';
 
         const stateWithPeer = new RouteTable().addPeer({

--- a/packages/orchestrator/tests/internal-bgp.plugin.unit.test.ts
+++ b/packages/orchestrator/tests/internal-bgp.plugin.unit.test.ts
@@ -3,14 +3,13 @@ import { InternalBGPPlugin } from '../src/plugins/implementations/Internal-bgp.j
 import { RouteTable } from '../src/state/route-table.js';
 import { PluginContext } from '../src/plugins/types.js';
 
-mock.module('capnweb', () => ({
-    newHttpBatchRpcSession: () => ({
-        connectToIBGPPeer: () => ({
-            open: async () => ({ success: true }),
-            update: async () => ({ success: true })
-        })
-    })
-}));
+const mockSession = {
+    open: async () => ({ success: true }),
+    update: async () => ({ success: true }),
+    close: async () => ({ success: true })
+};
+const mockFactory = () => mockSession as any;
+
 
 describe('InternalBGPPlugin Unit Tests', () => {
 
@@ -94,8 +93,8 @@ describe('InternalBGPPlugin Unit Tests', () => {
     });
 
     it('should trigger broadcast when a local route is created', async () => {
-        const plugin = new InternalBGPPlugin();
-
+        const plugin = new InternalBGPPlugin(mockFactory);
+        const initialState = new RouteTable()
         // Mock the internal broadcast logic if possible, 
         // but since it's a private method and uses dynamic imports, 
         // we can test it by seeding peers and checking if it runs without error 
@@ -133,7 +132,7 @@ describe('InternalBGPPlugin Unit Tests', () => {
     });
 
     it('should remove a peer and its routes when receiving a "close" action', async () => {
-        const plugin = new InternalBGPPlugin();
+        const plugin = new InternalBGPPlugin(mockFactory);
         const peerId = 'peer-b';
 
         // 1. Seed state with a peer and a route from that peer
@@ -175,8 +174,8 @@ describe('InternalBGPPlugin Unit Tests', () => {
     });
 
     it('should send existing routes to a new peer during OPEN', async () => {
-        const plugin = new InternalBGPPlugin();
-
+        const plugin = new InternalBGPPlugin(mockFactory);
+        const peerId = 'new-peer';
         // 1. Seed state with some routes
         let state = new RouteTable().addInternalRoute({
             name: 'existing-service-1',

--- a/packages/orchestrator/tests/peering-lifecycle.integration.test.ts
+++ b/packages/orchestrator/tests/peering-lifecycle.integration.test.ts
@@ -3,6 +3,15 @@ import { describe, it, expect } from 'bun:test';
 import { OrchestratorRpcServer } from '../src/rpc/server.js';
 import { RouteTable } from '../src/state/route-table.js';
 import { AuthorizedPeer } from '../src/rpc/schema/peering.js';
+import { mock } from 'bun:test';
+
+mock.module('../src/rpc/client.js', () => ({
+    getPeerSession: () => ({
+        open: async () => ({ success: true }),
+        update: async () => ({ success: true }),
+        close: async () => ({ success: true })
+    })
+}));
 
 describe('Peering Status & Lifecycle (Mocked)', () => {
 


### PR DESCRIPTION
### TL;DR

Refactored the Internal BGP plugin to improve peer session management with proper connection lifecycle handling.

### What changed?

- Created a dedicated `getPeerSession` function in a new `rpc/client.ts` file to centralize peer session creation
- Refactored the `InternalBGPPlugin` to use dependency injection for session creation, making it more testable
- Implemented proper connection lifecycle management:
  - Added explicit connection closing when updating or removing peers
  - Improved handshake and synchronization processes between peers
  - Added bidirectional synchronization during peer registration
- Added a `getMyPeerInfo` helper method to reduce code duplication
- Updated tests to use the new session factory pattern

### How to test?

1. Create a new BGP peer and verify the connection is properly established
2. Update a peer's endpoint and verify the old connection is closed and a new one is opened
3. Delete a peer and verify the connection is properly closed
4. Test route synchronization between peers to ensure routes are properly propagated

### Why make this change?

The previous implementation lacked proper connection lifecycle management, which could lead to stale connections and inconsistent route synchronization between peers. This refactoring ensures connections are properly established, maintained, and closed, improving the reliability of the BGP peering system.