### PR TITLE
chore: mangement api for all ibgp actions

### DIFF
--- a/packages/orchestrator/src/rpc/client.ts
+++ b/packages/orchestrator/src/rpc/client.ts
@@ -1,7 +1,7 @@
 import { newHttpBatchRpcSession } from 'capnweb';
-import type { PeerApi } from './schema/peering.js';
+import type { PublicIBGPScope } from './schema/peering.js';
 
 export function getPeerSession(endpoint: string, secret: string) {
-    const session = newHttpBatchRpcSession<PeerApi>(endpoint);
+    const session = newHttpBatchRpcSession<PublicIBGPScope>(endpoint);
     return session.connectToIBGPPeer(secret);
 }


### PR DESCRIPTION
### TL;DR

Added peer management methods to the RPC server and updated type references.

### What changed?

- Renamed `PeerApi` to `PublicIBGPScope` in the client.ts file for better type clarity
- Added three new methods to the OrchestratorRpcServer class:
  - `createPeer`: Creates a new peer with specified endpoint and optional domains
  - `updatePeer`: Updates an existing peer's endpoint and domains
  - `deletePeer`: Removes a peer by ID
- Added these methods to the ManagementScope interface
- Imported additional types from the peering schema (IBGPConfigResource, IBGPConfigResourceAction)

### How to test?

1. Test creating a new peer:
   ```typescript
   const result = await managementScope.createPeer("https://peer-endpoint.example.com", ["domain1.com", "domain2.com"]);
   ```

2. Test updating an existing peer:
   ```typescript
   const result = await managementScope.updatePeer("peer-id-123", "https://updated-endpoint.example.com", ["domain3.com"]);
   ```

3. Test deleting a peer:
   ```typescript
   const result = await managementScope.deletePeer("peer-id-123");
   ```

### Why make this change?

This change enhances the RPC interface to provide programmatic management of peers, allowing for the creation, updating, and deletion of peers through the API. This improves the orchestrator's functionality by enabling dynamic peer configuration without requiring manual intervention.