### PR TITLE
chore: finishing out open

### DIFF
--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -1,117 +1,32 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
 import type {
     Action,
     AddDataChannelResult,
     ListLocalRoutesResult,
     ListMetricsResult
 } from '@catalyst/orchestrator';
-import { newWebSocketRpcSession } from 'capnweb';
-import { WebSocket } from 'ws';
-=======
-import { WebSocket } from 'ws';
 import { newWebSocketRpcSession, RpcPromise } from 'capnweb';
->>>>>>> 9d03721 (chore: implements progressive api for cli)
+import { WebSocket } from 'ws';
 
 // Polyfill Symbol.asyncDispose if necessary (TypeScript < 5.2 or older environments)
 // @ts-ignore
 Symbol.asyncDispose ??= Symbol('Symbol.asyncDispose');
 
-<<<<<<< HEAD
-export interface OrchestratorRpc {
-    applyAction(action: Action): Promise<AddDataChannelResult>;
-    listLocalRoutes(): Promise<ListLocalRoutesResult>;
-    listMetrics(): Promise<ListMetricsResult>;
-}
+export async function createClient(url: string = process.env.CATALYST_ORCHESTRATOR_URL || 'ws://localhost:4015/rpc'): Promise<PublicApi> {
+    const clientStub = newWebSocketRpcSession<PublicApi>(url);
 
-export class CliClient implements OrchestratorRpc, AsyncDisposable {
-    private ws: WebSocket | null = null;
-    private rpc: OrchestratorRpc;
-
-    constructor(url: string = 'ws://localhost:3000/rpc') {
-        const connectionUrl = process.env.CATALYST_ORCHESTRATOR_URL || url;
-
-        // Quick hack for global WebSocket in Node if not present
-        if (!globalThis.WebSocket) {
-            // @ts-ignore
-            globalThis.WebSocket = WebSocket;
-        }
-
-        let capturedWs: any = null;
-        // Proxy WebSocket constructor to capture the instance so we can close it later
-        const WebSocketProxy = new Proxy(WebSocket, {
-            construct(target, args) {
-                const instance = new (target as any)(...args);
-                capturedWs = instance;
-                return instance;
-            }
-        });
-
-        this.rpc = newWebSocketRpcSession<OrchestratorRpc>(connectionUrl, {
-            WebSocket: WebSocketProxy as any
-        });
-        this.ws = capturedWs;
-    }
-
-    async applyAction(action: Action): Promise<AddDataChannelResult> {
-        return this.rpc.applyAction(action);
-    }
-
-    async listLocalRoutes(): Promise<ListLocalRoutesResult> {
-        return this.rpc.listLocalRoutes();
-    }
-
-    async listMetrics(): Promise<ListMetricsResult> {
-        return this.rpc.listMetrics();
-    }
-
-    async [Symbol.asyncDispose]() {
-        if (this.ws) {
-            this.ws.close();
-        }
-    }
-}
-
-export async function createClient(url?: string): Promise<CliClient> {
-    return new CliClient(url);
-}
-
-export type RpcClient = CliClient;
-=======
-export async function createClient(url: string = 'ws://localhost:3000/rpc') {
-    // In Node, we need to provide a WebSocket implementation usually.
-    // However, capnweb 0.4.x might expect a browser-like WebSocket.
-    // Let's assume global WebSocket or pass it if the API supports it.
-=======
-import { newHttpBatchRpcSession, RpcPromise } from 'capnweb';
-
-export async function createClient(url: string = process.env.CATALYST_ORCHESTRATOR_URL || 'http://localhost:4015/rpc') {
-    // Ensure URL is http/https for batch RPC, not ws/wss
-    const connectionUrl = url.replace(/^ws/, 'http');
-
-    // newHttpBatchRpcSession returns a proxy that automatically batches calls
-    const clientStub = newHttpBatchRpcSession<PublicApi>(connectionUrl, {
-        fetch: fetch as any
-    } as any);
->>>>>>> 0f8156e (fix: rename from cli to management sdk)
-
-    return clientStub;
+    return clientStub as unknown as PublicApi;
 }
 
 export type RpcClient = RpcPromise<PublicApi>;
 
 export interface PublicApi {
-    connectionFromManagementSDK(): RpcPromise<ManagementScope>;
+    connectionFromManagementSDK(): Promise<ManagementScope>;
 }
 
 export interface ManagementScope {
-    applyAction(action: any): RpcPromise<any>;
-    listLocalRoutes(): RpcPromise<any>;
-    listMetrics(): RpcPromise<any>;
-    listPeers(): RpcPromise<any>;
+    applyAction(action: any): Promise<any>;
+    listLocalRoutes(): Promise<any>;
+    listMetrics(): Promise<any>;
+    listPeers(): Promise<any>;
+    deletePeer(peerId: string): Promise<any>;
 }
-<<<<<<< HEAD
-
->>>>>>> 9d03721 (chore: implements progressive api for cli)
-=======
->>>>>>> 0f8156e (fix: rename from cli to management sdk)

--- a/packages/cli/src/commands/metrics.ts
+++ b/packages/cli/src/commands/metrics.ts
@@ -7,14 +7,9 @@ import type { CliResult } from '../types.js';
 
 export async function fetchMetrics(): Promise<CliResult<any>> {
     try {
-<<<<<<< HEAD
-        await using root = await createClient();
-        const result = await root.listMetrics();
-=======
         const root = await createClient();
-        const api = root.connectionFromManagementSDK();
+        const api = await root.connectionFromManagementSDK();
         const result = await api.listMetrics();
->>>>>>> 9d03721 (chore: implements progressive api for cli)
         return { success: true, data: result };
     } catch (err: any) {
         return { success: false, error: err.message || 'Unknown error' };

--- a/packages/cli/src/commands/peer.ts
+++ b/packages/cli/src/commands/peer.ts
@@ -15,7 +15,7 @@ export const peerCommands = () => {
         .action(async (endpoint, options) => {
             try {
                 const client = await createClient();
-                const api = client.connectionFromManagementSDK();
+                const api = await client.connectionFromManagementSDK();
 
                 const result = await api.applyAction({
                     resource: 'internalBGPConfig',
@@ -47,7 +47,7 @@ export const peerCommands = () => {
         .action(async () => {
             try {
                 const client = await createClient();
-                const api = client.connectionFromManagementSDK();
+                const api = await client.connectionFromManagementSDK();
                 const result = await api.listPeers();
 
                 if (result.peers.length === 0) {
@@ -74,14 +74,8 @@ export const peerCommands = () => {
         .action(async (peerId) => {
             try {
                 const client = await createClient();
-                const api = client.connectionFromManagementSDK();
-                const result = await api.applyAction({
-                    resource: 'internalBGP',
-                    resourceAction: 'close',
-                    data: {
-                        peerId
-                    }
-                });
+                const api = await client.connectionFromManagementSDK();
+                const result = await api.deletePeer(peerId);
                 if (result.success) {
                     console.log(chalk.green(`Peer ${peerId} removed.`));
                     process.exit(0);

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -1,7 +1,6 @@
 import { Command } from 'commander';
 import { createClient } from '../client.js';
 import chalk from 'chalk';
-import type { ServiceProtocol } from '@catalyst/orchestrator';
 import type { CliResult } from '../types.js';
 
 
@@ -10,16 +9,10 @@ import { AddServiceInputSchema, ListServicesInputSchema, type AddServiceInput } 
 
 export async function addService(params: AddServiceInput): Promise<CliResult<void>> {
     try {
-<<<<<<< HEAD
-        await using root = await createClient(params.orchestratorUrl);
-=======
-        const root = await createClient();
-<<<<<<< HEAD
-        const api = root.connectionFromCli();
->>>>>>> 9d03721 (chore: implements progressive api for cli)
-=======
-        const api = root.connectionFromManagementSDK();
->>>>>>> 0f8156e (fix: rename from cli to management sdk)
+        const root = await createClient(params.orchestratorUrl);
+
+
+        const api = await root.connectionFromManagementSDK();
 
         const action = {
             resource: 'localRoute',
@@ -41,14 +34,9 @@ export async function addService(params: AddServiceInput): Promise<CliResult<voi
 
 export async function listServices(orchestratorUrl?: string): Promise<CliResult<any[]>> {
     try {
-<<<<<<< HEAD
-        await using root = await createClient(orchestratorUrl);
-        const result = await root.listLocalRoutes();
-=======
-        const root = await createClient();
-        const api = root.connectionFromManagementSDK();
+        const root = await createClient(orchestratorUrl);
+        const api = await root.connectionFromManagementSDK();
         const result = await api.listLocalRoutes();
->>>>>>> 9d03721 (chore: implements progressive api for cli)
         return { success: true, data: result.routes || [] };
     } catch (err: any) {
         return { success: false, error: err.message || 'Connection error' };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,14 +9,9 @@ const program = new Command();
 program
     .name('catalyst')
     .description('Catalyst Node CLI')
-<<<<<<< HEAD
     .version(process.env.VERSION || '0.0.0-dev')
-    .option('--orchestrator-url <url>', 'Orchestrator RPC URL', 'ws://localhost:3000/rpc')
+    .option('--orchestrator-url <url>', 'Orchestrator RPC URL', process.env.CATALYST_ORCHESTRATOR_URL || 'ws://localhost:3000/rpc')
     .option('--log-level <level>', 'Log level', 'info');
-=======
-    .version('0.0.1')
-    .option('-u, --orchestrator-url <url>', 'Orchestrator URL', 'http://localhost:3000');
->>>>>>> cc06185 (chore: peer to peer updates)
 
 program.addCommand(serviceCommands());
 program.addCommand(metricsCommands());

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -6,7 +6,7 @@ export type CliResult<T> =
     | { success: false; error: string };
 
 export const BaseCliConfigSchema = z.object({
-    orchestratorUrl: z.string().url().default('ws://localhost:3000/rpc'),
+    orchestratorUrl: z.string().url().default(process.env.CATALYST_ORCHESTRATOR_URL || 'ws://localhost:3000/rpc'),
     logLevel: z.enum(['debug', 'info', 'warn', 'error']).default('info')
 });
 export type BaseCliConfig = z.infer<typeof BaseCliConfigSchema>;

--- a/packages/cli/tests/metrics.unit.test.ts
+++ b/packages/cli/tests/metrics.unit.test.ts
@@ -6,8 +6,9 @@ const mockListMetrics = mock(() => Promise.resolve({ uptime: 100 }));
 mock.module('../src/client.js', () => {
     return {
         createClient: async () => ({
-            listMetrics: mockListMetrics,
-            [Symbol.asyncDispose]: async () => { }
+            connectionFromManagementSDK: async () => ({
+                listMetrics: mockListMetrics
+            })
         })
     };
 });

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -1,8 +1,14 @@
-
 import { Hono } from 'hono';
 import { upgradeWebSocket, websocket } from 'hono/bun';
 import { newRpcResponse } from '@hono/capnweb';
 import { OrchestratorRpcServer } from './rpc/server.js';
+
+// Schemas and Types Exports
+export * from './rpc/schema/index.js';
+export * from './rpc/schema/peering.js';
+export * from './rpc/schema/actions.js';
+export * from './rpc/schema/direct.js';
+
 const app = new Hono();
 const rpcServer = new OrchestratorRpcServer();
 
@@ -14,11 +20,15 @@ app.all('/rpc', (c) => {
 
 app.get('/health', (c) => c.text('OK'));
 
-const port = process.env.PORT || 4015;
-console.log(`Orchestrator running on port ${port}`);
+const port = Number(process.env.PORT) || 4015;
+
+if (import.meta.main) {
+    console.log(`Orchestrator running on port ${port}`);
+}
 
 export default {
     port,
+    hostname: '0.0.0.0',
     fetch: app.fetch,
     websocket,
 };

--- a/packages/orchestrator/src/plugins/implementations/gateway.ts
+++ b/packages/orchestrator/src/plugins/implementations/gateway.ts
@@ -51,6 +51,7 @@ export class GatewayIntegrationPlugin extends BasePlugin {
             console.error('[GatewayIntegrationPlugin] Failed to update gateway:', error);
             return {
                 success: false,
+                ctx: context,
                 error: {
                     pluginName: this.name,
                     message: `Gateway update failed: ${error.message}`,

--- a/packages/orchestrator/src/plugins/implementations/local-routing.ts
+++ b/packages/orchestrator/src/plugins/implementations/local-routing.ts
@@ -46,7 +46,7 @@ export class LocalRoutingTablePlugin extends BasePlugin {
             const data = action.data as z.infer<typeof ServiceDefinitionSchema>;
 
             // Logic: Distinguish by protocol
-            if (data.protocol === 'tcp:graphql' || data.protocol === 'tcp:gql') {
+            if (data.protocol === 'http:graphql' || data.protocol === 'http:gql') {
                 // Proxy Route
                 console.log(`[LocalRoutingTablePlugin] Adding PROXY route for ${data.name}`);
                 const { state: newState, id } = state.addProxiedRoute({
@@ -89,7 +89,7 @@ export class LocalRoutingTablePlugin extends BasePlugin {
         } else if (action.resourceAction === 'update') {
             const data = action.data as z.infer<typeof ServiceDefinitionSchema>;
 
-            if (data.protocol === 'tcp:graphql' || data.protocol === 'tcp:gql') {
+            if (data.protocol === 'http:graphql' || data.protocol === 'http:gql') {
                 // Proxy Route
                 const result = state.updateProxiedRoute({
                     name: data.name,
@@ -112,6 +112,7 @@ export class LocalRoutingTablePlugin extends BasePlugin {
                 } else {
                     return {
                         success: false,
+                        ctx: context,
                         error: {
                             pluginName: this.name,
                             message: `Proxy route not found for update: ${data.name}:${data.protocol}`
@@ -141,6 +142,7 @@ export class LocalRoutingTablePlugin extends BasePlugin {
                 } else {
                     return {
                         success: false,
+                        ctx: context,
                         error: {
                             pluginName: this.name,
                             message: `Internal route not found for update: ${data.name}:${data.protocol}`

--- a/packages/orchestrator/src/plugins/implementations/logger.ts
+++ b/packages/orchestrator/src/plugins/implementations/logger.ts
@@ -6,7 +6,7 @@ export class LoggerPlugin extends BasePlugin {
     name = 'LoggerPlugin';
 
     async apply(context: PluginContext): Promise<PluginResult> {
-        console.log(`[LoggerPlugin] Action: ${context.action.resource} / ${context.action.action}`);
+        console.log(`[LoggerPlugin] Action: ${context.action.resource} / ${context.action.resourceAction}`);
         if ('name' in context.action.data) {
             console.log(`[LoggerPlugin] Data: ${context.action.data.name}`);
         }

--- a/packages/orchestrator/src/plugins/pipeline.ts
+++ b/packages/orchestrator/src/plugins/pipeline.ts
@@ -23,6 +23,7 @@ export class PluginPipeline implements PluginInterface {
                 console.error(`[PluginPipeline] Error in plugin ${plugin.name}: ${error.message}`);
                 return {
                     success: false,
+                    ctx: context,
                     error: {
                         pluginName: plugin.name,
                         message: `Unexpected error: ${error.message}`,

--- a/packages/orchestrator/src/plugins/types.ts
+++ b/packages/orchestrator/src/plugins/types.ts
@@ -1,6 +1,7 @@
 
 import { z } from 'zod';
 import { ActionSchema } from '../rpc/schema/index.js';
+export { ActionSchema };
 import { RouteTable } from '../state/route-table.js';
 
 export const AuthContextSchema = z.object({
@@ -27,7 +28,7 @@ export interface PluginResult {
     };
 }
 
-export interface Plugin {
+export interface PluginInterface {
     name: string;
     apply(context: PluginContext): Promise<PluginResult>;
 }

--- a/packages/orchestrator/src/rpc/client.ts
+++ b/packages/orchestrator/src/rpc/client.ts
@@ -1,7 +1,13 @@
-import { newHttpBatchRpcSession } from 'capnweb';
+import { newHttpBatchRpcSession, newWebSocketRpcSession } from 'capnweb';
 import type { PublicIBGPScope } from './schema/peering.js';
 
-export function getPeerSession(endpoint: string, secret: string) {
-    const session = newHttpBatchRpcSession<PublicIBGPScope>(endpoint);
+export function getHttpPeerSession(endpoint: string, secret: string) {
+    const wsEndpoint = endpoint.replace(/^http/, 'ws');
+    const session = newWebSocketRpcSession<PublicIBGPScope>(wsEndpoint);
+    return session.connectToIBGPPeer(secret);
+}
+
+export function getWebSocketPeerSession(endpoint: string, secret: string) {
+    const session = newWebSocketRpcSession<PublicIBGPScope>(endpoint);
     return session.connectToIBGPPeer(secret);
 }

--- a/packages/orchestrator/src/rpc/schema/peering.ts
+++ b/packages/orchestrator/src/rpc/schema/peering.ts
@@ -139,12 +139,28 @@ export type IBGPProtocolOpen = z.infer<typeof IBGPProtocolOpenSchema>;
 export type IBGPProtocolClose = z.infer<typeof IBGPProtocolCloseSchema>;
 export type IBGPProtocolUpdate = z.infer<typeof IBGPProtocolUpdateSchema>;
 
+export const IBGPOpenResultSuccessSchema = z.object({
+    success: z.literal(true),
+    peerInfo: PeerInfoSchema
+});
+
+export const IBGPOpenResultFailureSchema = z.object({
+    success: z.literal(false),
+    error: z.string().optional()
+});
+
+export const IBGPOpenResultSchema = z.discriminatedUnion('success', [
+    IBGPOpenResultSuccessSchema,
+    IBGPOpenResultFailureSchema
+]);
+export type IBGPOpenResult = z.infer<typeof IBGPOpenResultSchema>;
+
 export interface IBGPScope {
-    open(peerInfo: PeerInfo): Promise<ApplyActionResult>;
+    open(peerInfo: PeerInfo): Promise<IBGPOpenResult>;
     update(peerInfo: PeerInfo, routes: UpdateMessage[]): Promise<ApplyActionResult>;
     close(peerInfo: PeerInfo): Promise<ApplyActionResult>;
 }
 
-export interface PeerApi {
+export interface PublicIBGPScope {
     connectToIBGPPeer(secret: string): IBGPScope;
 }

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -1,5 +1,6 @@
+import { ServiceProtocol } from './rpc/schema/direct.js';
 
-export type ServiceProtocol = 'tcp' | 'tcp:http' | 'tcp:graphql' | 'tcp:gql' | 'tcp:grpc' | 'udp';
+export { ServiceProtocol };
 
 export interface DataChannel {
     name: string;

--- a/packages/orchestrator/tests/composite.proxy.state.unit.test.ts
+++ b/packages/orchestrator/tests/composite.proxy.state.unit.test.ts
@@ -6,7 +6,7 @@ import { ServiceDefinition } from '../src/rpc/schema/index.js';
 describe('Proxy State - Composite Lifecycle', () => {
     const service: ServiceDefinition = {
         name: 'test-composite-proxy',
-        protocol: 'tcp:graphql',
+        protocol: 'http:graphql',
         endpoint: 'initial-endpoint',
         region: 'ap-south-1'
     };

--- a/packages/orchestrator/tests/config.ibgp.plugins.integration.test.ts
+++ b/packages/orchestrator/tests/config.ibgp.plugins.integration.test.ts
@@ -3,8 +3,16 @@ import { OrchestratorRpcServer } from '../src/rpc/server.js';
 import { IBGPConfigResource, IBGPConfigResourceAction } from '../src/rpc/schema/peering.js';
 
 mock.module('../src/rpc/client.js', () => ({
-    getPeerSession: () => ({
-        open: async () => ({ success: true }),
+    getHttpPeerSession: () => ({
+        open: async () => ({
+            success: true,
+            peerInfo: {
+                id: 'mock-peer-id',
+                as: 100,
+                endpoint: 'http://peer-a:3000/rpc', // Match the test case
+                domains: []
+            }
+        }),
         update: async () => ({ success: true }),
         close: async () => ({ success: true })
     })

--- a/packages/orchestrator/tests/config.ibgp.plugins.unit.test.ts
+++ b/packages/orchestrator/tests/config.ibgp.plugins.unit.test.ts
@@ -4,12 +4,30 @@ import { RouteTable } from '../src/state/route-table.js';
 import { PluginContext } from '../src/plugins/types.js';
 import { IBGPConfigResource, IBGPConfigResourceAction } from '../src/rpc/schema/peering.js';
 
-const mockSession = {
-    open: async () => ({ success: true }),
+const mockPeerInfo = {
+    id: 'mock-peer-id',
+    as: 100,
+    endpoint: 'http://mock-endpoint',
+    domains: []
+};
+
+const mockSessionBase = {
     update: async () => ({ success: true }),
     close: async () => ({ success: true })
 };
-const mockFactory = () => mockSession as any;
+
+const mockFactory = (endpoint: string) => ({
+    ...mockSessionBase,
+    open: async () => ({
+        success: true,
+        peerInfo: {
+            id: 'mock-peer-id',
+            as: 100,
+            endpoint: endpoint, // Return the endpoint requested
+            domains: []
+        }
+    })
+}) as any;
 
 
 describe('InternalBGPPlugin Config Unit Tests', () => {

--- a/packages/orchestrator/tests/create.proxy.state.unit.test.ts
+++ b/packages/orchestrator/tests/create.proxy.state.unit.test.ts
@@ -6,7 +6,7 @@ import { ServiceDefinition } from '../src/rpc/schema/index.js';
 describe('Proxy State - Create', () => {
     const service: ServiceDefinition = {
         name: 'test-create-proxy',
-        protocol: 'tcp:graphql',
+        protocol: 'http:graphql',
         endpoint: 'localhost:8081',
         region: 'us-east-1'
     };

--- a/packages/orchestrator/tests/delete.proxy.state.unit.test.ts
+++ b/packages/orchestrator/tests/delete.proxy.state.unit.test.ts
@@ -6,7 +6,7 @@ import { ServiceDefinition } from '../src/rpc/schema/index.js';
 describe('Proxy State - Delete', () => {
     const service: ServiceDefinition = {
         name: 'test-delete-proxy',
-        protocol: 'tcp:graphql',
+        protocol: 'http:graphql',
         endpoint: 'localhost:8083',
         region: 'eu-west-1'
     };

--- a/packages/orchestrator/tests/internal-bgp.plugin.unit.test.ts
+++ b/packages/orchestrator/tests/internal-bgp.plugin.unit.test.ts
@@ -3,8 +3,15 @@ import { InternalBGPPlugin } from '../src/plugins/implementations/Internal-bgp.j
 import { RouteTable } from '../src/state/route-table.js';
 import { PluginContext } from '../src/plugins/types.js';
 
+const mockPeerInfo = {
+    id: 'mock-peer-id',
+    as: 100,
+    endpoint: 'http://mock-endpoint',
+    domains: []
+};
+
 const mockSession = {
-    open: async () => ({ success: true }),
+    open: async () => ({ success: true, peerInfo: mockPeerInfo }),
     update: async () => ({ success: true }),
     close: async () => ({ success: true })
 };
@@ -14,13 +21,13 @@ const mockFactory = () => mockSession as any;
 describe('InternalBGPPlugin Unit Tests', () => {
 
     it('should add an internal route when receiving an "add" update', async () => {
-        const plugin = new InternalBGPPlugin();
+        const plugin = new InternalBGPPlugin(mockFactory);
         const initialState = new RouteTable();
 
         const route = {
             name: 'proxied-service',
             endpoint: 'http://remote:8080/rpc',
-            protocol: 'tcp:graphql' as any
+            protocol: 'http:graphql' as any
         };
 
         const context: PluginContext = {
@@ -53,14 +60,14 @@ describe('InternalBGPPlugin Unit Tests', () => {
     });
 
     it('should remove an internal route when receiving a "remove" update', async () => {
-        const plugin = new InternalBGPPlugin();
-        const routeId = 'proxied-service:tcp:graphql';
+        const plugin = new InternalBGPPlugin(mockFactory);
+        const routeId = 'proxied-service:http:graphql';
 
         // Seed state with the route
         const seedState = new RouteTable().addInternalRoute({
             name: 'proxied-service',
             endpoint: 'http://remote:8080/rpc',
-            protocol: 'tcp:graphql'
+            protocol: 'http:graphql'
         }, 'peer-b').state;
 
         expect(seedState.getInternalRoutes()).toHaveLength(1);

--- a/packages/orchestrator/tests/local.routing.plugin.unit.test.ts
+++ b/packages/orchestrator/tests/local.routing.plugin.unit.test.ts
@@ -14,12 +14,11 @@ describe('LocalRoutingTablePlugin Comprehensive Tests', () => {
         state = new RouteTable();
     });
 
-    // Helper to create context
-    const createCtx = (resource: string, resourceAction: string, data: any): PluginContext => ({
+    const createCtx = (resource: 'localRoute', resourceAction: 'create' | 'update' | 'delete', data: any): PluginContext => ({
         action: { resource, resourceAction, data },
         state,
         results: [],
-        authxContext: {} as any
+        authxContext: { userId: 'test', roles: [] }
     });
 
     describe('Create Actions', () => {
@@ -45,7 +44,7 @@ describe('LocalRoutingTablePlugin Comprehensive Tests', () => {
             const data: DataChannel = {
                 name: 'proxy-service-1',
                 endpoint: 'http://proxy.target',
-                protocol: 'tcp:graphql',
+                protocol: 'http:graphql',
                 region: 'us-west-1'
             };
             const ctx = createCtx('localRoute', 'create', data);
@@ -104,7 +103,7 @@ describe('LocalRoutingTablePlugin Comprehensive Tests', () => {
 
             expect(result.success).toBe(false);
             if (!result.success) { // Type guard
-                expect(result.error.message).toContain('Internal route not found');
+                expect(result.error?.message).toContain('Internal route not found');
             }
         });
 
@@ -113,7 +112,7 @@ describe('LocalRoutingTablePlugin Comprehensive Tests', () => {
             const initialData: DataChannel = {
                 name: 'proxy-service-update',
                 endpoint: 'http://old.proxy',
-                protocol: 'tcp:graphql'
+                protocol: 'http:graphql'
             };
             const { state: stateWithRoute } = state.addProxiedRoute(initialData);
             state = stateWithRoute;
@@ -122,7 +121,7 @@ describe('LocalRoutingTablePlugin Comprehensive Tests', () => {
             const updateData: DataChannel = {
                 name: 'proxy-service-update',
                 endpoint: 'http://new.proxy',
-                protocol: 'tcp:graphql'
+                protocol: 'http:graphql'
             };
             const ctx = createCtx('localRoute', 'update', updateData);
 

--- a/packages/orchestrator/tests/peering-e2e.test.ts
+++ b/packages/orchestrator/tests/peering-e2e.test.ts
@@ -96,7 +96,9 @@ describe('Peering E2E Lifecycle (Containerized)', () => {
             stderr: 'pipe',
             env: {
                 ...process.env,
-                'CATALYST_ORCHESTRATOR_URL': `ws://localhost:${targetPort}/rpc`
+                'CATALYST_ORCHESTRATOR_URL': `ws://127.0.0.1:${targetPort}/rpc`,
+                'NODE_ENV': 'test',
+                'DEBUG': '1'
             }
         });
 
@@ -106,7 +108,8 @@ describe('Peering E2E Lifecycle (Containerized)', () => {
 
         if (proc.exitCode !== 0) {
             console.error(`CLI Command Failed: ${args.join(' ')}\nError:`, error);
-            throw new Error(`CLI command failed: ${args.join(' ')}\nError: ${error}`);
+            console.log(`CLI Output:\n`, output);
+            throw new Error(`CLI command failed: ${args.join(' ')}\nError: ${error}\nOutput: ${output}`);
         }
         return output;
     };

--- a/packages/orchestrator/tests/peering-lifecycle.integration.test.ts
+++ b/packages/orchestrator/tests/peering-lifecycle.integration.test.ts
@@ -6,8 +6,16 @@ import { AuthorizedPeer } from '../src/rpc/schema/peering.js';
 import { mock } from 'bun:test';
 
 mock.module('../src/rpc/client.js', () => ({
-    getPeerSession: () => ({
-        open: async () => ({ success: true }),
+    getHttpPeerSession: () => ({
+        open: async () => ({
+            success: true,
+            peerInfo: {
+                id: 'mock-peer-id',
+                as: 100,
+                endpoint: 'http://mock-endpoint',
+                domains: []
+            }
+        }),
         update: async () => ({ success: true }),
         close: async () => ({ success: true })
     })

--- a/packages/orchestrator/tests/pipeline.unit.test.ts
+++ b/packages/orchestrator/tests/pipeline.unit.test.ts
@@ -23,7 +23,8 @@ describe('PluginPipeline', () => {
         const result = await pipeline.apply({
             action: {} as any,
             state: initialState,
-            authxContext: {}
+            authxContext: { userId: 'test', roles: [] },
+            results: []
         });
 
         if (!result.success) {

--- a/packages/orchestrator/tests/rpc.test.ts
+++ b/packages/orchestrator/tests/rpc.test.ts
@@ -47,7 +47,7 @@ describe('Orchestrator RPC', () => {
         const cli = rpc.connectionFromManagementSDK();
         const result = await cli.applyAction(action);
         expect(result.success).toBe(true);
-        expect(result.results[0].id).toBe('test-service:tcp:graphql');
+        expect(result.results[0].id).toBe('test-service:http:graphql');
     });
 
     it('should list local routes', async () => {
@@ -55,7 +55,7 @@ describe('Orchestrator RPC', () => {
         const result = await cli.listLocalRoutes();
         expect(result.routes).toBeInstanceOf(Array);
         expect(result.routes.length).toBeGreaterThan(0);
-        const route = result.routes.find((r: any) => r.id === 'test-service:tcp:graphql');
+        const route = result.routes.find((r: any) => r.id === 'test-service:http:graphql');
         expect(route).toBeDefined();
         expect(route.service.name).toBe('test-service');
     });
@@ -64,7 +64,7 @@ describe('Orchestrator RPC', () => {
         const cli = rpc.connectionFromManagementSDK();
         const result = await cli.listMetrics();
         expect(result.metrics).toBeInstanceOf(Array);
-        const metric = result.metrics.find((m: any) => m.id === 'test-service:tcp:graphql');
+        const metric = result.metrics.find((m: any) => m.id === 'test-service:http:graphql');
         expect(metric).toBeDefined();
         expect(metric.connectionCount).toBe(0);
     });


### PR DESCRIPTION
### TL;DR

Fixed RPC promise handling in the orchestrator and CLI by properly awaiting connections and updating type definitions.

### What changed?

- Updated the client-side code to properly await `connectionFromManagementSDK()` calls
- Modified return type definitions in the client interface from `RpcPromise<T>` to `Promise<T>`
- Enhanced the iBGP peer handshake process to return peer information during connection
- Added proper error context to plugin results
- Implemented WebSocket peer session support alongside HTTP sessions
- Fixed type definitions throughout the codebase for better type safety

### How to test?

1. Run the CLI commands that interact with the orchestrator:
   ```
   catalyst metrics
   catalyst peer list
   catalyst service list
   ```

2. Test peer connections between orchestrator instances:
   ```
   catalyst peer add http://other-node:4015/rpc
   ```

3. Verify the WebSocket connection works by connecting to an orchestrator using a WebSocket client

### Why make this change?

The previous implementation was using RPC promises incorrectly, which could lead to race conditions and unexpected behavior. By properly awaiting connections and updating type definitions, we ensure that RPC calls are handled correctly and in the expected order. The enhanced peer handshake process also improves reliability by providing more information during the connection process, making debugging easier and connections more robust.