### PR TITLE
fix: container build issues

### DIFF
--- a/packages/cli/tests/service.integration.test.ts
+++ b/packages/cli/tests/service.integration.test.ts
@@ -29,24 +29,24 @@ describe('CLI E2E with Containers', () => {
         console.log('Building Docker images...');
 
         const buildBooks = async () => {
-            await Bun.spawn(['docker', 'build', '-t', 'books-service:test', '-f', 'Dockerfile.books', '.'], {
-                cwd: examplesDir,
+            await Bun.spawn(['docker', 'build', '-t', 'books-service:test', '-f', 'packages/examples/Dockerfile.books', '.'], {
+                cwd: repoRoot,
                 stdout: 'ignore',
                 stderr: 'inherit'
             }).exited;
         };
 
         const buildMovies = async () => {
-            await Bun.spawn(['docker', 'build', '-t', 'movies-service:test', '-f', 'Dockerfile.movies', '.'], {
-                cwd: examplesDir,
+            await Bun.spawn(['docker', 'build', '-t', 'movies-service:test', '-f', 'packages/examples/Dockerfile.movies', '.'], {
+                cwd: repoRoot,
                 stdout: 'ignore',
                 stderr: 'inherit'
             }).exited;
         };
 
         const buildGateway = async () => {
-            await Bun.spawn(['docker', 'build', '-t', 'gateway-service:test', '.'], {
-                cwd: gatewayDir,
+            await Bun.spawn(['docker', 'build', '-t', 'gateway-service:test', '-f', 'packages/gateway/Dockerfile', '.'], {
+                cwd: repoRoot,
                 stdout: 'ignore',
                 stderr: 'inherit'
             }).exited;
@@ -54,8 +54,8 @@ describe('CLI E2E with Containers', () => {
 
         // We build orchestrator manually instead of using existing image to ensure fresh code
         const buildOrchestrator = async () => {
-            await Bun.spawn(['docker', 'build', '-t', 'orchestrator-service:test', '.'], {
-                cwd: orchestratorDir,
+            await Bun.spawn(['docker', 'build', '-t', 'orchestrator-service:test', '-f', 'packages/orchestrator/Dockerfile', '.'], {
+                cwd: repoRoot,
                 stdout: 'ignore',
                 stderr: 'inherit'
             }).exited;

--- a/packages/gateway/tests/container.gateway.test.ts
+++ b/packages/gateway/tests/container.gateway.test.ts
@@ -18,14 +18,13 @@ describe('Gateway Container Integration', () => {
 
     beforeAll(async () => {
         network = await new Network().start();
-        const examplesDir = path.resolve(__dirname, '../../examples');
-        const gatewayDir = path.resolve(__dirname, '..');
+        const repoRoot = path.resolve(__dirname, '../../..');
 
         // 1. Build & Start Books (Background)
         const startBooks = async () => {
             const imageName = 'books-service:test';
-            await Bun.spawn(['docker', 'build', '-t', imageName, '-f', 'Dockerfile.books', '.'], {
-                cwd: examplesDir, stdout: 'ignore', stderr: 'inherit'
+            await Bun.spawn(['docker', 'build', '-t', imageName, '-f', 'packages/examples/Dockerfile.books', '.'], {
+                cwd: repoRoot, stdout: 'ignore', stderr: 'inherit'
             }).exited;
 
             booksContainer = await new GenericContainer(imageName)
@@ -39,8 +38,8 @@ describe('Gateway Container Integration', () => {
         // 2. Build & Start Movies (Background)
         const startMovies = async () => {
             const imageName = 'movies-service:test';
-            await Bun.spawn(['docker', 'build', '-t', imageName, '-f', 'Dockerfile.movies', '.'], {
-                cwd: examplesDir, stdout: 'ignore', stderr: 'inherit'
+            await Bun.spawn(['docker', 'build', '-t', imageName, '-f', 'packages/examples/Dockerfile.movies', '.'], {
+                cwd: repoRoot, stdout: 'ignore', stderr: 'inherit'
             }).exited;
 
             moviesContainer = await new GenericContainer(imageName)
@@ -54,8 +53,8 @@ describe('Gateway Container Integration', () => {
         // 3. Build & Start Gateway (Background)
         const startGateway = async () => {
             const imageName = 'gateway-service:test';
-            await Bun.spawn(['docker', 'build', '-t', imageName, '.'], {
-                cwd: gatewayDir, stdout: 'ignore', stderr: 'inherit'
+            await Bun.spawn(['docker', 'build', '-t', imageName, '-f', 'packages/gateway/Dockerfile', '.'], {
+                cwd: repoRoot, stdout: 'ignore', stderr: 'inherit'
             }).exited;
 
             gatewayContainer = await new GenericContainer(imageName)


### PR DESCRIPTION
### TL;DR

Fixed Docker build paths in integration tests to use repository root as the build context.

### What changed?

Updated Docker build commands in integration tests to:
- Use the repository root as the build context (`cwd: repoRoot`)
- Specify full paths to Dockerfiles relative to the repo root (e.g., `packages/examples/Dockerfile.books`)
- Added explicit `-f` flags for Dockerfile paths where they were missing

This change affects both the CLI integration tests and Gateway container tests.

### How to test?

Run the integration tests to verify Docker builds work correctly:
```bash
cd packages/cli
bun test service.integration.test.ts

cd packages/gateway
bun test container.gateway.test.ts
```

### Why make this change?

Using the repository root as the build context ensures Docker has access to all necessary files during the build process, regardless of where the test is executed from. This approach is more reliable and consistent, especially when dealing with monorepo structures where dependencies might span across multiple packages.