### PR TITLE
chore: multi peer propogation no translation

### DIFF
--- a/packages/orchestrator/tests/topology.e2e.test.ts
+++ b/packages/orchestrator/tests/topology.e2e.test.ts
@@ -1,0 +1,220 @@
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { GenericContainer, Wait, StartedTestContainer, Network, StartedNetwork } from 'testcontainers';
+import path from 'path';
+import { newHttpBatchRpcSession } from 'capnweb';
+import type { PublicApi } from '../../cli/src/client.js';
+
+describe('Topology E2E: Star (A center, B & C leaves)', () => {
+    const TIMEOUT = 300000; // 5 minutes
+
+    let network: StartedNetwork;
+    let peerA: StartedTestContainer;
+    let peerB: StartedTestContainer;
+    let peerC: StartedTestContainer;
+
+    let portA: number;
+    let portB: number;
+    let portC: number;
+
+    const imageName = 'catalyst-node:e2e-topology';
+
+    // Resolve Repo Root correctly
+    const repoRoot = path.resolve(__dirname, '../../../');
+
+    beforeAll(async () => {
+        // 1. Build Image
+        console.log('Building Docker image...');
+        const buildProc = Bun.spawn(['docker', 'build', '-f', 'packages/orchestrator/Dockerfile', '-t', imageName, '.'], {
+            cwd: repoRoot,
+            stdout: 'inherit',
+            stderr: 'inherit'
+        });
+        await buildProc.exited;
+
+        if (buildProc.exitCode !== 0) {
+            throw new Error('Docker build failed');
+        }
+
+        // 2. Create Network
+        network = await new Network().start();
+
+        // 3. Start Peer A (Center)
+        peerA = await new GenericContainer(imageName)
+            .withNetwork(network)
+            .withNetworkAliases('peer-a')
+            .withExposedPorts(3000)
+            .withEnvironment({
+                'PORT': '3000',
+                'CATALYST_AS': '100',
+                'CATALYST_NODE_ID': 'peer-a',
+                'CATALYST_PEERING_ENDPOINT': 'http://peer-a:3000/rpc'
+            })
+            .withWaitStrategy(Wait.forHttp('/health', 3000))
+            .start();
+
+        portA = peerA.getMappedPort(3000);
+        console.log(`Peer A started on port ${portA}`);
+
+        // 4. Start Peer B (Leaf)
+        peerB = await new GenericContainer(imageName)
+            .withNetwork(network)
+            .withNetworkAliases('peer-b')
+            .withExposedPorts(3000)
+            .withEnvironment({
+                'PORT': '3000',
+                'CATALYST_AS': '200',
+                'CATALYST_NODE_ID': 'peer-b',
+                'CATALYST_PEERING_ENDPOINT': 'http://peer-b:3000/rpc'
+            })
+            .withWaitStrategy(Wait.forHttp('/health', 3000))
+            .start();
+
+        portB = peerB.getMappedPort(3000);
+        console.log(`Peer B started on port ${portB}`);
+
+        // 5. Start Peer C (Leaf)
+        peerC = await new GenericContainer(imageName)
+            .withNetwork(network)
+            .withNetworkAliases('peer-c')
+            .withExposedPorts(3000)
+            .withEnvironment({
+                'PORT': '3000',
+                'CATALYST_AS': '300',
+                'CATALYST_NODE_ID': 'peer-c',
+                'CATALYST_PEERING_ENDPOINT': 'http://peer-c:3000/rpc'
+            })
+            .withWaitStrategy(Wait.forHttp('/health', 3000))
+            .start();
+
+        portC = peerC.getMappedPort(3000);
+        console.log(`Peer C started on port ${portC}`);
+
+        // Stream logs for debugging
+        (await peerA.logs()).pipe(process.stdout);
+        (await peerB.logs()).pipe(process.stdout);
+        (await peerC.logs()).pipe(process.stdout);
+
+    }, TIMEOUT);
+
+    afterAll(async () => {
+        if (peerA) await peerA.stop();
+        if (peerB) await peerB.stop();
+        if (peerC) await peerC.stop();
+        if (network) await network.stop();
+    });
+
+    const getClient = (port: number) => {
+        const url = `http://127.0.0.1:${port}/rpc`;
+        return newHttpBatchRpcSession<PublicApi>(url, {
+            fetch: fetch as any
+        } as any);
+    };
+
+    const runOp = async <T>(port: number, operation: (mgmt: any) => Promise<T>): Promise<T> => {
+        const client = getClient(port);
+        const mgmt = client.connectionFromManagementSDK(); // Pipelined
+        return operation(mgmt);
+    };
+
+    it('should propagate route from A to B and C', async () => {
+        // 1. Connect A -> B
+        await runOp(portA, mgmt => mgmt.applyAction({
+            resource: 'internalBGPConfig',
+            resourceAction: 'create',
+            data: {
+                endpoint: 'http://peer-b:3000/rpc',
+                domains: ['valid-secret']
+            }
+        }));
+
+        // 2. Connect A -> C
+        await runOp(portA, mgmt => mgmt.applyAction({
+            resource: 'internalBGPConfig',
+            resourceAction: 'create',
+            data: {
+                endpoint: 'http://peer-c:3000/rpc',
+                domains: ['valid-secret']
+            }
+        }));
+
+        // WaitFor connections (check peers on A)
+        let peersConnected = false;
+        for (let i = 0; i < 60; i++) {
+            await new Promise(r => setTimeout(r, 1000));
+            try {
+                const peers = await runOp(portA, async mgmt => {
+                    const res = await mgmt.listPeers();
+                    return res.peers || [];
+                });
+
+                // AuthorizedPeer is flat: { id, as, endpoint, domains }
+                const hasB = peers.some((p: any) => p.id === 'peer-b');
+                const hasC = peers.some((p: any) => p.id === 'peer-c');
+                if (hasB && hasC) {
+                    peersConnected = true;
+                    break;
+                }
+            } catch (e) { }
+        }
+        expect(peersConnected).toBe(true);
+        console.log('Peers B and C connected to A');
+
+        // 3. Publish Service on A
+        const serviceName = 'datachannel-on-a';
+        await runOp(portA, mgmt => mgmt.applyAction({
+            resource: 'localRoute',
+            resourceAction: 'create',
+            data: {
+                name: serviceName,
+                endpoint: 'http://a:9000',
+                protocol: 'tcp:datachannel'
+            }
+        }));
+        console.log(`Service ${serviceName} published on A`);
+
+        // 4. Verify B sees it
+        let bSawIt = false;
+        for (let i = 0; i < 60; i++) {
+            await new Promise(r => setTimeout(r, 1000));
+            try {
+                const routes = await runOp(portB, async mgmt => {
+                    const res = await mgmt.listLocalRoutes();
+                    return res.routes || [];
+                });
+                console.log(`[Query B ${i}] Routes:`, routes.map((r: any) => r.service.name));
+                if (routes.some((r: any) => r.service.name === serviceName)) {
+                    bSawIt = true;
+                    break;
+                }
+            } catch (e) {
+                console.error('Error checking B:', e);
+            }
+        }
+        expect(bSawIt).toBe(true);
+        console.log(`Peer B saw ${serviceName}`);
+
+        // 5. Verify C sees it
+        let cSawIt = false;
+        for (let i = 0; i < 60; i++) {
+            await new Promise(r => setTimeout(r, 1000));
+            try {
+                const routes = await runOp(portC, async mgmt => {
+                    const res = await mgmt.listLocalRoutes();
+                    return res.routes || [];
+                });
+                console.log(`[Query C ${i}] Routes:`, routes.map((r: any) => r.service.name));
+                if (routes.some((r: any) => r.service.name === serviceName)) {
+                    cSawIt = true;
+                    break;
+                }
+            } catch (e) {
+                console.error('Error checking C:', e);
+            }
+        }
+        expect(cSawIt).toBe(true);
+        console.log(`Peer C saw ${serviceName}`);
+
+    }, 120000);
+
+});


### PR DESCRIPTION
# Add WebRTC DataChannel Protocol Support and E2E Topology Tests

### TL;DR

Added support for the WebRTC DataChannel protocol and implemented end-to-end topology tests to verify route propagation across nodes.

### What changed?

- Added `tcp:datachannel` as a supported service protocol in the `ServiceProtocolSchema` enum
- Created a new end-to-end test file `topology.e2e.test.ts` that:
  - Sets up a star topology with three nodes (A as center, B and C as leaves)
  - Tests BGP peering connections between nodes
  - Verifies route propagation from node A to nodes B and C
  - Validates that a service using the new `tcp:datachannel` protocol is properly advertised and visible across the network

### How to test?

Run the end-to-end tests with:
```bash
bun test packages/orchestrator/tests/topology.e2e.test.ts
```

The test will:
1. Build a Docker image for testing
2. Create a network with three nodes in a star topology
3. Establish BGP peering connections
4. Publish a service on node A using the new protocol
5. Verify that nodes B and C can discover the service

### Why make this change?

This change enables WebRTC DataChannel support in the service mesh, allowing for peer-to-peer real-time communication between web clients. The end-to-end tests ensure that route propagation works correctly in a multi-node topology, which is critical for service discovery across the network.