### PR TITLE
feat: orchestrstor clustering

### DIFF
--- a/packages/orchestrator/src/rpc/client.ts
+++ b/packages/orchestrator/src/rpc/client.ts
@@ -2,8 +2,7 @@ import { newHttpBatchRpcSession, newWebSocketRpcSession } from 'capnweb';
 import type { PublicIBGPScope } from './schema/peering.js';
 
 export function getHttpPeerSession(endpoint: string, secret: string) {
-    const wsEndpoint = endpoint.replace(/^http/, 'ws');
-    const session = newWebSocketRpcSession<PublicIBGPScope>(wsEndpoint);
+    const session = newHttpBatchRpcSession<PublicIBGPScope>(endpoint);
     return session.connectToIBGPPeer(secret);
 }
 

--- a/packages/orchestrator/src/rpc/schema/index.ts
+++ b/packages/orchestrator/src/rpc/schema/index.ts
@@ -24,6 +24,7 @@ export const LocalRouteSchema = z.object({
     id: z.string(),
     service: ServiceDefinitionSchema,
     sourcePeerId: z.string().optional(),
+    asPath: z.array(z.number()).optional(),
 });
 export type LocalRoute = z.infer<typeof LocalRouteSchema>;
 

--- a/packages/orchestrator/src/rpc/schema/peering.ts
+++ b/packages/orchestrator/src/rpc/schema/peering.ts
@@ -22,6 +22,7 @@ export type PeerInfo = z.infer<typeof PeerInfoSchema>;
 export const UpdateMesssageAddSchema = z.object({
     type: z.literal('add'),
     route: ServiceDefinitionSchema,
+    asPath: z.array(z.number()).optional(),
 });
 
 export const UpdateMesssageRemoveSchema = z.object({

--- a/packages/orchestrator/src/state/route-table.ts
+++ b/packages/orchestrator/src/state/route-table.ts
@@ -34,7 +34,8 @@ export class RouteTable {
     private addRouteToMap(
         currentMap: Map<string, LocalRoute>,
         service: ServiceDefinition,
-        sourcePeerId?: string
+        sourcePeerId?: string,
+        asPath?: number[]
     ): { map: Map<string, LocalRoute>, metrics: Map<string, DataChannelMetrics>, id: string } {
         const id = this.createId(service);
         const newMap = new Map(currentMap);
@@ -42,6 +43,7 @@ export class RouteTable {
             id,
             service,
             sourcePeerId,
+            asPath
         });
 
         const newMetrics = new Map(this.metrics);
@@ -60,8 +62,8 @@ export class RouteTable {
         return this.addInternalRoute(service);
     }
 
-    addInternalRoute(service: ServiceDefinition, sourcePeerId?: string): { state: RouteTable, id: string } {
-        const { map, metrics, id } = this.addRouteToMap(this.internalRoutes, service, sourcePeerId);
+    addInternalRoute(service: ServiceDefinition, sourcePeerId?: string, asPath?: number[]): { state: RouteTable, id: string } {
+        const { map, metrics, id } = this.addRouteToMap(this.internalRoutes, service, sourcePeerId, asPath);
         return {
             state: this.clone({ internalRoutes: map, metrics }),
             id
@@ -129,7 +131,8 @@ export class RouteTable {
     private updateRouteInMap(
         currentMap: Map<string, LocalRoute>,
         service: ServiceDefinition,
-        sourcePeerId?: string
+        sourcePeerId?: string,
+        asPath?: number[]
     ): { map: Map<string, LocalRoute>, id: string } | null {
         const id = this.createId(service);
         if (currentMap.has(id)) {
@@ -140,6 +143,7 @@ export class RouteTable {
                 id,
                 service,
                 sourcePeerId: sourcePeerId ?? existing?.sourcePeerId,
+                asPath: asPath ?? existing?.asPath
             });
             // Init metrics if missing (safety check)
             // But usually update happens after add.
@@ -149,8 +153,8 @@ export class RouteTable {
         return null;
     }
 
-    updateInternalRoute(service: ServiceDefinition, sourcePeerId?: string): { state: RouteTable, id: string } | null {
-        const result = this.updateRouteInMap(this.internalRoutes, service, sourcePeerId);
+    updateInternalRoute(service: ServiceDefinition, sourcePeerId?: string, asPath?: number[]): { state: RouteTable, id: string } | null {
+        const result = this.updateRouteInMap(this.internalRoutes, service, sourcePeerId, asPath);
         if (result) {
             return { state: this.clone({ internalRoutes: result.map }), id: result.id };
         }


### PR DESCRIPTION
### TL;DR

Added AS path tracking and loop prevention to BGP route propagation.

### What changed?

- Added AS path tracking to BGP route updates, allowing routes to carry information about which autonomous systems they've traversed
- Implemented loop prevention by checking if a route's AS path already contains the current AS
- Modified route propagation logic to properly prepend the local AS number when forwarding routes
- Updated the route table schema to store AS path information with routes
- Fixed peer ID references in tests to use the correct property path

### How to test?

- Run the transit topology test which verifies route propagation across multiple AS nodes
- Check the topology E2E test which now includes a specific test for route propagation from C -> A -> B
- Verify AS path correctness in the propagated routes (should show the sequence of AS numbers the route has traversed)

### Why make this change?

This change implements a critical BGP feature that prevents routing loops in multi-AS topologies. By tracking the AS path, the system can detect and drop routes that would create loops, ensuring proper route propagation across complex network topologies. This is essential for building reliable distributed service meshes where routes need to be shared across multiple autonomous systems.