### PR TITLE
fix: docker network error causing test failure

### DIFF
--- a/packages/cli/tests/service.integration.test.ts
+++ b/packages/cli/tests/service.integration.test.ts
@@ -132,13 +132,17 @@ describe('CLI E2E with Containers', () => {
     }, TIMEOUT);
 
     afterAll(async () => {
-        await Promise.all([
-            moviesContainer?.stop(),
-            booksContainer?.stop(),
-            gatewayContainer?.stop(),
-            orchestratorContainer?.stop(),
-            network?.stop()
-        ]);
+        console.log('Teardown: Stopping containers...');
+        if (orchestratorContainer) await orchestratorContainer.stop();
+        if (gatewayContainer) await gatewayContainer.stop();
+        if (booksContainer) await booksContainer.stop();
+        if (moviesContainer) await moviesContainer.stop();
+
+        if (network) {
+            console.log('Teardown: Stopping network...');
+            await network.stop();
+        }
+        console.log('Teardown: Complete.');
     });
 
     it('should add services via CLI and reflect in list', async () => {


### PR DESCRIPTION
### TL;DR

Improved container teardown process in integration tests with sequential shutdown and logging.

### What changed?

Modified the `afterAll` function in the CLI integration tests to:
- Replace parallel container shutdown with sequential shutdown
- Add explicit null checks before stopping each container
- Add logging statements to track the teardown process
- Separate network shutdown into its own conditional block

### How to test?

Run the CLI integration tests and verify that:
- Containers shut down properly in the correct order
- Teardown logs appear in the console output
- No errors occur during the teardown process

### Why make this change?

Sequential container shutdown is more reliable than parallel shutdown, especially in CI environments. Adding logging helps with debugging test teardown issues, and explicit null checks prevent errors when containers failed to start. This change improves test stability and makes troubleshooting easier.