### PR TITLE
feat: simplify orchestrator test

### DIFF
--- a/packages/orchestrator/src/config.ts
+++ b/packages/orchestrator/src/config.ts
@@ -1,59 +1,66 @@
-import { z } from 'zod';
-import os from 'os';
+import { z } from 'zod'
+import os from 'os'
+
+export const GatewayConfigSchema = z.object({
+  endpoint: z.string().url(),
+})
+export type GatewayConfig = z.infer<typeof GatewayConfigSchema>
 
 export const OrchestratorConfigSchema = z.object({
-    gqlGatewayConfig: z.object({
-        endpoint: z.string().url(),
-    }).optional(),
-    as: z.number().default(0),
-    ibgp: z.object({
-        localId: z.string().optional(),
-        endpoint: z.string().url().optional(),
-        domains: z.array(z.string()).default([]),
-        secret: z.string().default('valid-secret'),
-        transport: z.enum(['http', 'websocket']).default('http')
-    }).default({ domains: [], secret: 'valid-secret', transport: 'http' }),
-    port: z.number().default(3000),
-});
+  gqlGatewayConfig: GatewayConfigSchema.optional(),
+  as: z.number().default(0),
+  ibgp: z
+    .object({
+      localId: z.string().optional(),
+      endpoint: z.string().url().optional(),
+      domains: z.array(z.string()).default([]),
+      secret: z.string().default('valid-secret'),
+      transport: z.enum(['http', 'websocket']).default('http'),
+    })
+    .default({ domains: [], secret: 'valid-secret', transport: 'http' }),
+  port: z.number().default(3000),
+})
 
-export type OrchestratorConfig = z.infer<typeof OrchestratorConfigSchema>;
+export type OrchestratorConfig = z.infer<typeof OrchestratorConfigSchema>
 
 export function getConfig(): OrchestratorConfig {
-    const gatewayEndpoint = process.env.CATALYST_GQL_GATEWAY_ENDPOINT;
-    const peeringAs = process.env.CATALYST_AS;
-    const peeringDomains = process.env.CATALYST_DOMAINS; // Comma separated
-    const peeringNodeId = process.env.CATALYST_NODE_ID;
-    const peeringEndpoint = process.env.CATALYST_PEERING_ENDPOINT;
-    const peeringSecret = process.env.CATALYST_PEERING_SECRET;
-    const port = process.env.PORT ? parseInt(process.env.PORT) : 3000;
-    const peeringTransport = process.env.CATALYST_IBGP_TRANSPORT; // 'http' | 'websocket'
+  const gatewayEndpoint = process.env.CATALYST_GQL_GATEWAY_ENDPOINT
+  const peeringAs = process.env.CATALYST_AS
+  const peeringDomains = process.env.CATALYST_DOMAINS // Comma separated
+  const peeringNodeId = process.env.CATALYST_NODE_ID
+  const peeringEndpoint = process.env.CATALYST_PEERING_ENDPOINT
+  const peeringSecret = process.env.CATALYST_PEERING_SECRET
+  const port = process.env.PORT ? parseInt(process.env.PORT) : 3000
+  const peeringTransport = process.env.CATALYST_IBGP_TRANSPORT // 'http' | 'websocket'
 
-    const config: Record<string, unknown> = {
-        port,
-        as: peeringAs ? parseInt(peeringAs) : 0,
-        ibgp: {
-            domains: peeringDomains ? peeringDomains.split(',').map(d => d.trim()) : [],
-            localId: peeringNodeId || os.hostname(),
-            endpoint: peeringEndpoint,
-            secret: peeringSecret || 'valid-secret',
-            transport: peeringTransport === 'websocket' ? 'websocket' : 'http'
-        }
-    };
+  const config: Record<string, unknown> = {
+    port,
+    as: peeringAs ? parseInt(peeringAs) : 0,
+    ibgp: {
+      domains: peeringDomains ? peeringDomains.split(',').map((d) => d.trim()) : [],
+      localId: peeringNodeId || os.hostname(),
+      endpoint: peeringEndpoint,
+      secret: peeringSecret || 'valid-secret',
+      transport: peeringTransport === 'websocket' ? 'websocket' : 'http',
+    },
+  }
 
-    if (gatewayEndpoint) {
-        console.log(`[Config] Found CATALYST_GQL_GATEWAY_ENDPOINT: ${gatewayEndpoint}`);
-        config.gqlGatewayConfig = {
-            endpoint: gatewayEndpoint,
-        };
-    } else {
-        console.log('[Config] No CATALYST_GQL_GATEWAY_ENDPOINT found. GraphQL Gateway integration disabled.');
+  if (gatewayEndpoint) {
+    console.log(`[Config] Found CATALYST_GQL_GATEWAY_ENDPOINT: ${gatewayEndpoint}`)
+    config.gqlGatewayConfig = {
+      endpoint: gatewayEndpoint,
     }
+  } else {
+    console.log(
+      '[Config] No CATALYST_GQL_GATEWAY_ENDPOINT found. GraphQL Gateway integration disabled.'
+    )
+  }
 
-    // Validate the config
-    try {
-        return OrchestratorConfigSchema.parse(config);
-    } catch (error) {
-        console.error('[Config] Invalid configuration:', error);
-        throw error;
-    }
+  // Validate the config
+  try {
+    return OrchestratorConfigSchema.parse(config)
+  } catch (error) {
+    console.error('[Config] Invalid configuration:', error)
+    throw error
+  }
 }

--- a/packages/orchestrator/src/next/orchestrator.test.ts
+++ b/packages/orchestrator/src/next/orchestrator.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import type { PeerManager } from './orchestrator'
+import { CatalystNodeBus } from './orchestrator'
+import type { PeerInfo, RouteTable } from './routing/state'
+import { newRouteTable } from './routing/state'
+
+// Helper to access private state for testing
+interface TestBus {
+  state: RouteTable
+}
+
+describe('CatalystNodeBus', () => {
+  let bus: CatalystNodeBus
+
+  beforeEach(() => {
+    bus = new CatalystNodeBus({ state: newRouteTable() })
+  })
+
+  it('should initialize with empty state', () => {
+    const state = (bus as unknown as TestBus).state
+    expect(state.internal.peers).toEqual([])
+    expect(state.internal.routes).toEqual([])
+  })
+
+  describe('local:peer:create', () => {
+    it('should create a new peer', async () => {
+      const peer: PeerInfo = {
+        name: 'peer1',
+        endpoint: 'http://localhost:8080',
+        domains: ['example.com'],
+      }
+
+      const result = await bus.dispatch({
+        action: 'local:peer:create',
+        data: { peerInfo: peer },
+      })
+
+      expect(result).toEqual({ success: true })
+
+      const state = (bus as unknown as TestBus).state
+      expect(state.internal.peers).toHaveLength(1)
+      expect(state.internal.peers[0]).toMatchObject({
+        name: 'peer1',
+        endpoint: 'http://localhost:8080',
+        domains: ['example.com'],
+        connectionStatus: 'initializing',
+      })
+    })
+
+    it('should return error if peer already exists', async () => {
+      const peer: PeerInfo = {
+        name: 'peer1',
+        endpoint: 'http://localhost:8080',
+        domains: ['example.com'],
+      }
+
+      await bus.dispatch({
+        action: 'local:peer:create',
+        data: { peerInfo: peer },
+      })
+
+      const result = await bus.dispatch({
+        action: 'local:peer:create',
+        data: { peerInfo: peer },
+      })
+
+      expect(result).toEqual({ success: false, error: 'Peer already exists' })
+    })
+  })
+
+  describe('local:peer:update', () => {
+    beforeEach(async () => {
+      await bus.dispatch({
+        action: 'local:peer:create',
+        data: {
+          peerInfo: {
+            name: 'peer1',
+            endpoint: 'http://localhost:8080',
+            domains: ['example.com'],
+          },
+        },
+      })
+    })
+
+    it('should update an existing peer', async () => {
+      const updateData: PeerInfo = {
+        name: 'peer1',
+        endpoint: 'http://localhost:9090',
+        domains: ['updated.com'],
+      }
+
+      const result = await bus.dispatch({
+        action: 'local:peer:update',
+        data: { peerInfo: updateData },
+      })
+
+      expect(result).toEqual({ success: true })
+
+      const state = (bus as unknown as TestBus).state
+      expect(state.internal.peers).toHaveLength(1)
+      expect(state.internal.peers[0]).toMatchObject({
+        name: 'peer1',
+        endpoint: 'http://localhost:9090',
+        domains: ['updated.com'],
+        connectionStatus: 'initializing',
+      })
+    })
+
+    it('should return error if peer does not exist', async () => {
+      const result = await bus.dispatch({
+        action: 'local:peer:update',
+        data: {
+          peerInfo: {
+            name: 'non-existent',
+            endpoint: '...',
+            domains: [],
+          },
+        },
+      })
+
+      expect(result).toEqual({ success: false, error: 'Peer not found' })
+    })
+  })
+
+  describe('local:peer:delete', () => {
+    beforeEach(async () => {
+      await bus.dispatch({
+        action: 'local:peer:create',
+        data: {
+          peerInfo: {
+            name: 'peer1',
+            endpoint: 'http://localhost:8080',
+            domains: ['example.com'],
+          },
+        },
+      })
+    })
+
+    it('should remove an existing peer', async () => {
+      const result = await bus.dispatch({
+        action: 'local:peer:delete',
+        data: {
+          peerInfo: {
+            name: 'peer1',
+            endpoint: '',
+            domains: [],
+          },
+        },
+      })
+
+      expect(result).toEqual({ success: true })
+
+      const state = (bus as unknown as TestBus).state
+      expect(state.internal.peers).toHaveLength(0)
+    })
+
+    it('should return error if peer does not exist', async () => {
+      const result = await bus.dispatch({
+        action: 'local:peer:delete',
+        data: {
+          peerInfo: {
+            name: 'non-existent',
+            endpoint: '',
+            domains: [],
+          },
+        },
+      })
+
+      expect(result).toEqual({ success: false, error: 'Peer not found' })
+    })
+  })
+
+  describe('Public API', () => {
+    let api: PeerManager
+
+    beforeEach(() => {
+      api = bus.publicApi().getManagerConnection()
+    })
+
+    it('should add peer via public API', async () => {
+      const peer = {
+        name: 'api-peer',
+        endpoint: 'http://api.com',
+        domains: ['api.com'],
+      }
+
+      const result = await api.addPeer(peer)
+      expect(result).toEqual({ success: true })
+
+      const state = (bus as unknown as TestBus).state
+      expect(state.internal.peers).toHaveLength(1)
+      expect(state.internal.peers[0].name).toBe('api-peer')
+    })
+
+    it('should update peer via public API', async () => {
+      await api.addPeer({
+        name: 'api-peer',
+        endpoint: 'http://api.com',
+        domains: ['api.com'],
+      })
+
+      const result = await api.updatePeer({
+        name: 'api-peer',
+        endpoint: 'http://api-updated.com',
+        domains: ['api-updated.com'],
+      })
+      expect(result).toEqual({ success: true })
+
+      const state = (bus as unknown as TestBus).state
+      expect(state.internal.peers[0].endpoint).toBe('http://api-updated.com')
+    })
+
+    it('should remove peer via public API', async () => {
+      await api.addPeer({
+        name: 'api-peer',
+        endpoint: 'http://api.com',
+        domains: ['api.com'],
+      })
+
+      const result = await api.removePeer({ name: 'api-peer' })
+      expect(result).toEqual({ success: true })
+
+      const state = (bus as unknown as TestBus).state
+      expect(state.internal.peers).toHaveLength(0)
+    })
+  })
+})

--- a/packages/orchestrator/src/next/orchestrator.ts
+++ b/packages/orchestrator/src/next/orchestrator.ts
@@ -1,0 +1,201 @@
+import { RpcTarget } from 'capnweb'
+import { type Action } from './schema.js'
+import type { PeerInfo } from './routing/state.js'
+import { newRouteTable, type RouteTable } from './routing/state.js'
+import {
+  newHttpBatchRpcSession,
+  newWebSocketRpcSession,
+  type RpcCompatible,
+  type RpcStub,
+} from 'capnweb'
+// Interface for classes that need to emit actions
+export interface PublicApi {
+  getManagerConnection(): PeerManager
+  getPeerConnection(
+    secret: string
+  ): { success: true; connection: PeerConnection } | { success: false; error: string }
+}
+
+export interface PeerManager {
+  addPeer(peer: PeerInfo): Promise<{ success: true } | { success: false; error: string }>
+  updatePeer(peer: PeerInfo): Promise<{ success: true } | { success: false; error: string }>
+  removePeer(
+    peer: Pick<PeerInfo, 'name'>
+  ): Promise<{ success: true } | { success: false; error: string }>
+}
+
+export interface PeerConnection {
+  open(peer: PeerInfo): Promise<{ success: true } | { success: false; error: string }>
+}
+
+export function getHttpPeerSession<API extends RpcCompatible<API>>(endpoint: string) {
+  return newHttpBatchRpcSession<API>(endpoint)
+}
+
+export function getWebSocketPeerSession<API extends RpcCompatible<API>>(endpoint: string) {
+  return newWebSocketRpcSession<API>(endpoint)
+}
+
+class ConnectionPool {
+  private stubs: Map<string, RpcStub<PublicApi>>
+  constructor(private type: 'ws' | 'http' = 'http') {
+    this.stubs = new Map<string, RpcStub<PublicApi>>()
+  }
+
+  get(endpoint: string) {
+    if (this.stubs.has(endpoint)) {
+      return this.stubs.get(endpoint)
+    }
+    switch (this.type) {
+      case 'http': {
+        const stub = newHttpBatchRpcSession<PublicApi>(endpoint)
+        this.stubs.set(endpoint, stub)
+        return stub
+      }
+      case 'ws': {
+        const stub = newWebSocketRpcSession<PublicApi>(endpoint)
+        this.stubs.set(endpoint, stub)
+        return stub
+      }
+    }
+  }
+}
+
+export class CatalystNodeBus extends RpcTarget {
+  private state: RouteTable
+  private connectionPool: ConnectionPool
+  constructor(opts: {
+    state?: RouteTable
+    connectionPool?: { type?: 'ws' | 'http'; pool?: ConnectionPool }
+  }) {
+    super()
+    this.state = opts.state ?? newRouteTable()
+    this.connectionPool =
+      (opts.connectionPool?.pool ?? opts.connectionPool?.type)
+        ? new ConnectionPool(opts.connectionPool.type)
+        : new ConnectionPool()
+  }
+
+  async dispatch(
+    sentAction: Action
+  ): Promise<{ success: true } | { success: false; error: string }> {
+    const result = await this.handleAction(sentAction, this.state)
+    if (result.success) {
+      this.state = result.state
+      return { success: true }
+    }
+    return result
+  }
+
+  async handleAction(
+    action: Action,
+    state: RouteTable
+  ): Promise<{ success: true; state: RouteTable } | { success: false; error: string }> {
+    switch (action.action) {
+      case 'local:peer:create': {
+        const peerList = state.internal.peers
+        if (peerList.find((p) => p.name === action.data.peerInfo.name)) {
+          return { success: false, error: 'Peer already exists' }
+        }
+        state = {
+          ...state,
+          internal: {
+            routes: state.internal.routes,
+            peers: [
+              ...state.internal.peers,
+              {
+                name: action.data.peerInfo.name,
+                endpoint: action.data.peerInfo.endpoint,
+                domains: action.data.peerInfo.domains,
+                connectionStatus: 'initializing',
+                lastConnected: undefined,
+              },
+            ],
+          },
+        }
+        break
+      }
+      case 'local:peer:update': {
+        const peerList = state.internal.peers
+        const peer = peerList.find((p) => p.name === action.data.peerInfo.name)
+        if (!peer) {
+          return { success: false, error: 'Peer not found' }
+        }
+        state = {
+          ...state,
+          internal: {
+            routes: state.internal.routes,
+            peers: peerList.map((p) =>
+              p.name === action.data.peerInfo.name
+                ? {
+                    ...p,
+                    endpoint: action.data.peerInfo.endpoint,
+                    domains: action.data.peerInfo.domains,
+                    connectionStatus: 'initializing',
+                    lastConnected: undefined,
+                  }
+                : p
+            ),
+          },
+        }
+        break
+      }
+      case 'local:peer:delete': {
+        const peerList = state.internal.peers
+        const peer = peerList.find((p) => p.name === action.data.peerInfo.name)
+        if (!peer) {
+          return { success: false, error: 'Peer not found' }
+        }
+        state = {
+          ...state,
+          internal: {
+            routes: state.internal.routes,
+            peers: peerList.filter((p) => p.name !== action.data.peerInfo.name),
+          },
+        }
+        break
+      }
+      default: {
+        console.log('Unknown action', action)
+        break
+      }
+    }
+
+    return { success: true, state }
+  }
+
+  publicApi(): PublicApi {
+    return {
+      getManagerConnection: (): PeerManager => {
+        return {
+          addPeer: async (peer: PeerInfo) => {
+            console.log('addPeer', peer)
+            return this.dispatch({
+              action: 'local:peer:create',
+              data: { peerInfo: peer },
+            })
+          },
+          updatePeer: async (peer: PeerInfo) => {
+            console.log('updatePeer', peer)
+            return this.dispatch({
+              action: 'local:peer:update',
+              data: { peerInfo: peer },
+            })
+          },
+          removePeer: async (peer: Omit<PeerInfo, 'endpoint' | 'domains'>) => {
+            console.log('removePeer', peer)
+            return this.dispatch({
+              action: 'local:peer:delete',
+              data: { peerInfo: peer },
+            })
+          },
+        }
+      },
+      getPeerConnection: (
+        _secret: string
+      ): { success: true; connection: PeerConnection } | { success: false; error: string } => {
+        return { success: false, error: 'Not implemented' }
+      },
+    }
+  }
+}

--- a/packages/orchestrator/src/next/routing/datachannel.ts
+++ b/packages/orchestrator/src/next/routing/datachannel.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+// Local re-definition to decouple from V1
+export const DataChannelProtocolEnum = z.enum(['http', 'http:graphql', 'http:gql', 'http:grpc'])
+export type DataChannelProtocol = z.infer<typeof DataChannelProtocolEnum>
+
+export const DataChannelDefinitionSchema = z.object({
+  name: z.string(),
+  endpoint: z.string().optional(),
+  protocol: DataChannelProtocolEnum,
+  region: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+})
+export type DataChannelDefinition = z.infer<typeof DataChannelDefinitionSchema>

--- a/packages/orchestrator/src/next/routing/local/actions.ts
+++ b/packages/orchestrator/src/next/routing/local/actions.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+import { PeerInfoSchema } from '../state'
+
+export const localPeerCreateAction = z.literal('local:peer:create')
+export const localPeerUpdateAction = z.literal('local:peer:update')
+export const localPeerDeleteAction = z.literal('local:peer:delete')
+
+export const localPeerCreateMessageSchema = z.object({
+  action: localPeerCreateAction,
+  data: z.object({
+    peerInfo: PeerInfoSchema,
+  }),
+})
+
+export const localPeerUpdateMessageSchema = z.object({
+  action: localPeerUpdateAction,
+  data: z.object({
+    peerInfo: PeerInfoSchema,
+  }),
+})
+
+export const localPeerDeleteMessageSchema = z.object({
+  action: localPeerDeleteAction,
+  data: z.object({
+    peerInfo: PeerInfoSchema,
+  }),
+})

--- a/packages/orchestrator/src/next/routing/state.ts
+++ b/packages/orchestrator/src/next/routing/state.ts
@@ -1,0 +1,49 @@
+import type { DataChannelDefinition } from './datachannel.js'
+import { z } from 'zod'
+
+export const PeerInfoSchema = z.object({
+  name: z.string(),
+  endpoint: z.string(),
+  domains: z.array(z.string()),
+})
+
+export type PeerInfo = z.infer<typeof PeerInfoSchema>
+
+export const PeerConnectionStatusEnum = z.enum(['initializing', 'connected', 'closed'])
+export type PeerConnectionStatus = z.infer<typeof PeerConnectionStatusEnum>
+
+export const PeerRecordSchema = PeerInfoSchema.extend({
+  connectionStatus: PeerConnectionStatusEnum,
+  lastConnected: z.date().optional(),
+})
+
+export type PeerRecord = z.infer<typeof PeerRecordSchema>
+
+export type InternalRoute = DataChannelDefinition & PeerInfo
+
+export type RouteTable = {
+  local: {
+    routes: DataChannelDefinition[]
+  }
+  internal: {
+    peers: PeerRecord[]
+    routes: InternalRoute[]
+  }
+  external: {
+    // Placeholder for future extensibility
+    [key: string]: unknown
+  }
+}
+
+export function newRouteTable(): RouteTable {
+  return {
+    local: {
+      routes: [],
+    },
+    internal: {
+      peers: [],
+      routes: [],
+    },
+    external: {},
+  }
+}

--- a/packages/orchestrator/src/next/schema.ts
+++ b/packages/orchestrator/src/next/schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+import {
+  localPeerCreateMessageSchema,
+  localPeerUpdateMessageSchema,
+  localPeerDeleteMessageSchema,
+} from './routing/local/actions'
+
+/**
+ * Unified Action Schema
+ */
+export const ActionSchema = z.discriminatedUnion('action', [
+  localPeerCreateMessageSchema,
+  localPeerUpdateMessageSchema,
+  localPeerDeleteMessageSchema,
+])
+
+export type Action = z.infer<typeof ActionSchema>

--- a/packages/orchestrator/src/next/types.ts
+++ b/packages/orchestrator/src/next/types.ts
@@ -1,0 +1,59 @@
+import type { Action } from './schema.js'
+import type { RouteTable } from './routing/state.js'
+import { z } from 'zod'
+
+export const AuthContextSchema = z.object({
+  userId: z.string(),
+  roles: z.array(z.string()),
+})
+export type AuthContext = z.infer<typeof AuthContextSchema>
+
+export type StateResult =
+  | { success: true; state: RouteTable; action: Action; data?: unknown; nextActions?: Action[] }
+  | { success: false; error: string; state?: RouteTable }
+
+export type NotificationResult =
+  | { success: true; nextActions?: Action[] }
+  | { success: false; error: string; nextActions?: Action[] }
+
+/**
+ * State plugins are responsible for validating actions and updating the internal state.
+ * They must not perform external I/O.
+ */
+export interface StatePlugin {
+  name: string
+
+  /**
+   * Processes an action and returns the new state.
+   * returning { success: false } stops the pipeline and reverts.
+   */
+  apply(action: Action, state: RouteTable, auth: AuthContext): Promise<StateResult>
+}
+
+export type Dispatcher = (action: Action) => Promise<ApplyActionResult>
+
+/**
+ * Notification plugins observe the transition from originalState to newState
+ * and perform side effects.
+ */
+export interface NotificationPlugin {
+  name: string
+
+  /**
+   * Reacts to a completed state change.
+   * These are executed sequentially after the State implementation is finalized.
+   */
+  notify(
+    action: Action,
+    originalState: RouteTable,
+    newState: RouteTable,
+    auth: AuthContext,
+    dispatch: Dispatcher
+  ): Promise<NotificationResult>
+}
+
+export type ApplyActionResult = {
+  success: boolean
+  results: unknown[]
+  error?: string
+}

--- a/packages/orchestrator/src/rpc/server.ts
+++ b/packages/orchestrator/src/rpc/server.ts
@@ -1,265 +1,291 @@
-
-import { RpcTarget } from 'capnweb';
+import { RpcTarget } from 'capnweb'
 import type {
-    Action,
-    ListLocalRoutesResult,
-    ListMetricsResult,
-    ApplyActionResult
-} from './schema/index.js';
-import type { RouteTable } from '../state/route-table.js';
-import { GlobalRouteTable } from '../state/route-table.js';
-import type { PluginInterface } from '../plugins/types.js';
-import { PluginPipeline } from '../plugins/pipeline.js';
-import { LoggerPlugin } from '../plugins/implementations/logger.js';
-import { GatewayIntegrationPlugin } from '../plugins/implementations/gateway.js';
-import { LocalRoutingTablePlugin } from '../plugins/implementations/local-routing.js';
-import { InternalBGPPlugin } from '../plugins/implementations/Internal-bgp.js';
-import type { ListPeersResult, PeerInfo, UpdateMessage, IBGPScope } from './schema/peering.js';
-import { IBGPProtocolResource, IBGPProtocolResourceAction, IBGPConfigResource, IBGPConfigResourceAction } from './schema/peering.js';
-import type { OrchestratorConfig } from '../config.js';
-import { getConfig } from '../config.js';
-import { getHttpPeerSession, getWebSocketPeerSession } from './client.js';
+  Action,
+  ListLocalRoutesResult,
+  ListMetricsResult,
+  ApplyActionResult,
+} from './schema/index.js'
+import type { RouteTable } from '../state/route-table.js'
+import { GlobalRouteTable } from '../state/route-table.js'
+import type { PluginInterface } from '../plugins/types.js'
+import { PluginPipeline } from '../plugins/pipeline.js'
+import { LoggerPlugin } from '../plugins/implementations/logger.js'
+import { GatewayIntegrationPlugin } from '../plugins/implementations/gateway.js'
+import { LocalRoutingTablePlugin } from '../plugins/implementations/local-routing.js'
+import { InternalBGPPlugin } from '../plugins/implementations/Internal-bgp.js'
+import type { ListPeersResult, PeerInfo, UpdateMessage, IBGPScope } from './schema/peering.js'
+import {
+  IBGPProtocolResource,
+  IBGPProtocolResourceAction,
+  IBGPConfigResource,
+  IBGPConfigResourceAction,
+} from './schema/peering.js'
+import type { OrchestratorConfig } from '../config.js'
+import { getConfig } from '../config.js'
+import { getHttpPeerSession, getWebSocketPeerSession } from './client.js'
 
 export class OrchestratorRpcServer extends RpcTarget {
-    private pipeline: PluginPipeline;
-    private state: RouteTable;
-    private config: OrchestratorConfig;
+  private pipeline: PluginPipeline
+  private state: RouteTable
+  private config: OrchestratorConfig
 
-    constructor(config?: OrchestratorConfig) {
-        super();
-        this.config = config || getConfig();
+  constructor(config?: OrchestratorConfig) {
+    super()
+    this.config = config || getConfig()
 
-        // Initialize State with GlobalRouteTable (empty/initial)
-        this.state = GlobalRouteTable;
+    // Initialize State with GlobalRouteTable (empty/initial)
+    this.state = GlobalRouteTable
 
-        // Initialize Plugins
-        const plugins: PluginInterface[] = [
-            new LoggerPlugin(),
-        ];
+    // Initialize Plugins
+    const plugins: PluginInterface[] = [new LoggerPlugin()]
 
-        // Conditionally add Gateway Plugin
-        if (this.config.gqlGatewayConfig) {
-            plugins.push(new GatewayIntegrationPlugin(this.config.gqlGatewayConfig, {
-                triggerOnResources: [
-                    'localRoute'
-                ]
-            }));
+    // Conditionally add Gateway Plugin
+    if (this.config.gqlGatewayConfig) {
+      plugins.push(
+        new GatewayIntegrationPlugin(this.config.gqlGatewayConfig, {
+          triggerOnResources: ['localRoute'],
+        })
+      )
+    }
+
+    // Initialize plugins
+    const routingPlugin = new LocalRoutingTablePlugin()
+
+    const sessionFactory =
+      this.config.ibgp.transport === 'websocket' ? getWebSocketPeerSession : getHttpPeerSession
+
+    if (this.config.ibgp.transport === 'websocket') {
+      console.log('[Orchestrator] Using WebSocket transport for iBGP')
+    }
+
+    const internalBgpPlugin = new InternalBGPPlugin(sessionFactory)
+
+    this.pipeline = new PluginPipeline(
+      [routingPlugin, internalBgpPlugin, ...plugins],
+      'OrchestratorPipeline'
+    )
+  }
+
+  /*
+    // V2 MIGRATION NOTE:
+    // The architecture is moving towards a split State/Notification pipeline.
+    // The integration would look like this:
+    
+    // import { OrchestratorV2 } from '../next/orchestrator.js';
+    // const v2 = new OrchestratorV2();
+    // return v2; 
+    
+    // For now, this class maintains the V1 PluginPipeline compatibility.
+    */
+
+  async connectionFromManagementSDK(): Promise<ManagementScope> {
+    return new ManagementRpcScope(this)
+  }
+
+  async createPeer(endpoint: string, domains?: string[]): Promise<ApplyActionResult> {
+    const action: Action = {
+      resource: IBGPConfigResource.value,
+      resourceAction: IBGPConfigResourceAction.enum.create,
+      data: { endpoint, domains },
+    }
+    return this.applyAction(action)
+  }
+
+  async updatePeer(
+    peerId: string,
+    endpoint: string,
+    domains?: string[]
+  ): Promise<ApplyActionResult> {
+    const action: Action = {
+      resource: IBGPConfigResource.value,
+      resourceAction: IBGPConfigResourceAction.enum.update,
+      data: { peerId, endpoint, domains },
+    }
+    return this.applyAction(action)
+  }
+
+  async deletePeer(peerId: string): Promise<ApplyActionResult> {
+    const action: Action = {
+      resource: IBGPConfigResource.value,
+      resourceAction: IBGPConfigResourceAction.enum.delete,
+      data: { peerId },
+    }
+    return this.applyAction(action)
+  }
+
+  async connectToIBGPPeer(secret: string): Promise<IBGPScope> {
+    if (this.config.as === 0) {
+      throw new Error('This node is not configured for iBGP')
+    }
+    if (secret !== this.config.ibgp.secret) {
+      throw new Error('Invalid secret')
+    }
+
+    return {
+      open: async (peerInfo: PeerInfo) => {
+        console.log(`[iBGP] Peer connected: ${peerInfo.id} (AS ${peerInfo.as})`)
+
+        // If new, register via pipeline
+        // The plugin will handle the reverse connection
+        const action: Action = {
+          resource: IBGPProtocolResource.value,
+          resourceAction: IBGPProtocolResourceAction.enum.open,
+          data: {
+            peerInfo,
+          },
         }
 
-        // Initialize plugins
-        const routingPlugin = new LocalRoutingTablePlugin();
+        const result = await this.applyAction(action)
 
-        const sessionFactory = this.config.ibgp.transport === 'websocket'
-            ? getWebSocketPeerSession
-            : getHttpPeerSession;
-
-        if (this.config.ibgp.transport === 'websocket') {
-            console.log('[Orchestrator] Using WebSocket transport for iBGP');
+        if (!result.success) {
+          return {
+            success: false,
+            error: result.error,
+          }
         }
 
-        const internalBgpPlugin = new InternalBGPPlugin(sessionFactory);
-
-        this.pipeline = new PluginPipeline([routingPlugin, internalBgpPlugin, ...plugins], 'OrchestratorPipeline');
-    }
-
-    async connectionFromManagementSDK(): Promise<ManagementScope> {
-        return new ManagementRpcScope(this);
-    }
-
-    async createPeer(endpoint: string, domains?: string[]): Promise<ApplyActionResult> {
-        const action: Action = {
-            resource: IBGPConfigResource.value,
-            resourceAction: IBGPConfigResourceAction.enum.create,
-            data: { endpoint, domains }
-        };
-        return this.applyAction(action);
-    }
-
-    async updatePeer(peerId: string, endpoint: string, domains?: string[]): Promise<ApplyActionResult> {
-        const action: Action = {
-            resource: IBGPConfigResource.value,
-            resourceAction: IBGPConfigResourceAction.enum.update,
-            data: { peerId, endpoint, domains }
-        };
-        return this.applyAction(action);
-    }
-
-    async deletePeer(peerId: string): Promise<ApplyActionResult> {
-        const action: Action = {
-            resource: IBGPConfigResource.value,
-            resourceAction: IBGPConfigResourceAction.enum.delete,
-            data: { peerId }
-        };
-        return this.applyAction(action);
-    }
-
-    async connectToIBGPPeer(secret: string): Promise<IBGPScope> {
-        if (this.config.as === 0) {
-            throw new Error('This node is not configured for iBGP');
-        }
-        if (secret !== this.config.ibgp.secret) {
-            throw new Error('Invalid secret');
+        // Return our local PeerInfo so the initiator knows who we are
+        const myConfig = this.config
+        const myPeerInfo: PeerInfo = {
+          id: myConfig.ibgp.localId || 'unknown',
+          as: myConfig.as,
+          endpoint: myConfig.ibgp.endpoint || 'unknown',
+          domains: myConfig.ibgp.domains,
         }
 
         return {
-            open: async (peerInfo: PeerInfo) => {
-                console.log(`[iBGP] Peer connected: ${peerInfo.id} (AS ${peerInfo.as})`);
+          success: true,
+          peerInfo: myPeerInfo,
+        }
+      },
+      update: async (peerInfo: PeerInfo, routes: UpdateMessage[]) => {
+        const action: Action = {
+          resource: IBGPProtocolResource.value,
+          resourceAction: IBGPProtocolResourceAction.enum.update,
+          data: {
+            peerInfo: peerInfo,
+            updateMessages: routes,
+          },
+        }
 
-                // If new, register via pipeline
-                // The plugin will handle the reverse connection
-                const action: Action = {
-                    resource: IBGPProtocolResource.value,
-                    resourceAction: IBGPProtocolResourceAction.enum.open,
-                    data: {
-                        peerInfo,
-                    }
-                };
+        return this.applyAction(action)
+      },
+      close: async (peerInfo: Omit<PeerInfo, 'domains'>) => {
+        const action: Action = {
+          resource: IBGPProtocolResource.value,
+          resourceAction: IBGPProtocolResourceAction.enum.close,
+          data: {
+            peerInfo: peerInfo as unknown as PeerInfo,
+          },
+        }
 
-                const result = await this.applyAction(action);
-
-                if (!result.success) {
-                    return {
-                        success: false,
-                        error: result.error
-                    };
-                }
-
-                // Return our local PeerInfo so the initiator knows who we are
-                const myConfig = this.config;
-                const myPeerInfo: PeerInfo = {
-                    id: myConfig.ibgp.localId || 'unknown',
-                    as: myConfig.as,
-                    endpoint: myConfig.ibgp.endpoint || 'unknown',
-                    domains: myConfig.ibgp.domains
-                };
-
-                return {
-                    success: true,
-                    peerInfo: myPeerInfo
-                };
-            },
-            update: async (peerInfo: PeerInfo, routes: UpdateMessage[]) => {
-                const action: Action = {
-                    resource: IBGPProtocolResource.value,
-                    resourceAction: IBGPProtocolResourceAction.enum.update,
-                    data: {
-                        peerInfo: peerInfo,
-                        updateMessages: routes
-                    }
-                };
-
-                return this.applyAction(action);
-            },
-            close: async (peerInfo: Omit<PeerInfo, 'domains'>) => {
-                const action: Action = {
-                    resource: IBGPProtocolResource.value,
-                    resourceAction: IBGPProtocolResourceAction.enum.close,
-                    data: {
-                        peerInfo: peerInfo as unknown as PeerInfo,
-                    }
-                };
-
-                return this.applyAction(action);
-            }
-        };
+        return this.applyAction(action)
+      },
     }
+  }
 
-    private actionLock: Promise<unknown> = Promise.resolve();
+  private actionLock: Promise<unknown> = Promise.resolve()
 
-    async applyAction(action: Action): Promise<ApplyActionResult> {
-        const resultPromise = this.actionLock.then(async () => {
-            try {
-                const result = await this.pipeline.apply({
-                    action,
-                    state: this.state,
-                    authxContext: { userId: 'stub-user', roles: ['admin'] }, // Stub auth context
-                    results: []
-                });
+  async applyAction(action: Action): Promise<ApplyActionResult> {
+    const resultPromise = this.actionLock.then(async () => {
+      try {
+        const result = await this.pipeline.apply({
+          action,
+          state: this.state,
+          authxContext: { userId: 'stub-user', roles: ['admin'] }, // Stub auth context
+          results: [],
+        })
 
-                if (!result.success) {
-                    return { success: false, error: result.error?.message || 'Unknown error' } as ApplyActionResult;
-                }
+        if (!result.success) {
+          return {
+            success: false,
+            error: result.error?.message || 'Unknown error',
+          } as ApplyActionResult
+        }
 
-                // Update local state with the state returned from the pipeline
-                this.state = result.ctx.state;
+        // Update local state with the state returned from the pipeline
+        this.state = result.ctx.state
 
-                return {
-                    success: true,
-                    results: result.ctx.results
-                } as ApplyActionResult;
-            } catch (e: unknown) {
-                const message = e instanceof Error ? e.message : String(e);
-                return { success: false, error: message } as ApplyActionResult;
-            }
-        });
+        return {
+          success: true,
+          results: result.ctx.results,
+        } as ApplyActionResult
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : String(e)
+        return { success: false, error: message } as ApplyActionResult
+      }
+    })
 
-        this.actionLock = resultPromise.catch(() => {
-            // Ignore lock errors to allow subsequent actions
-        }); // Continue chain even on error
-        return resultPromise;
-    }
+    this.actionLock = resultPromise.catch(() => {
+      // Ignore lock errors to allow subsequent actions
+    }) // Continue chain even on error
+    return resultPromise
+  }
 
+  async listLocalRoutes(): Promise<ListLocalRoutesResult> {
+    const routes = this.state.getRoutes()
+    return { routes }
+  }
 
-    async listLocalRoutes(): Promise<ListLocalRoutesResult> {
-        const routes = this.state.getRoutes();
-        return { routes };
-    }
+  async listMetrics(): Promise<ListMetricsResult> {
+    const metrics = this.state.getMetrics()
+    return { metrics }
+  }
 
-    async listMetrics(): Promise<ListMetricsResult> {
-        const metrics = this.state.getMetrics();
-        return { metrics };
-    }
+  // ----------------------------------------------------------------
+  // Peer Public API Implementation
+  // ----------------------------------------------------------------
 
-    // ----------------------------------------------------------------
-    // Peer Public API Implementation
-    // ----------------------------------------------------------------
-
-    async listPeers(): Promise<ListPeersResult> {
-        const peers = this.state.getPeers();
-        return { peers };
-    }
+  async listPeers(): Promise<ListPeersResult> {
+    const peers = this.state.getPeers()
+    return { peers }
+  }
 }
 
 export interface ManagementScope {
-    applyAction(action: Action): Promise<ApplyActionResult>;
-    listLocalRoutes(): Promise<ListLocalRoutesResult>;
-    listMetrics(): Promise<ListMetricsResult>;
-    listPeers(): Promise<ListPeersResult>;
-    createPeer(endpoint: string, domains?: string[]): Promise<ApplyActionResult>;
-    updatePeer(peerId: string, endpoint: string, domains?: string[]): Promise<ApplyActionResult>;
-    deletePeer(peerId: string): Promise<ApplyActionResult>;
+  applyAction(action: Action): Promise<ApplyActionResult>
+  listLocalRoutes(): Promise<ListLocalRoutesResult>
+  listMetrics(): Promise<ListMetricsResult>
+  listPeers(): Promise<ListPeersResult>
+  createPeer(endpoint: string, domains?: string[]): Promise<ApplyActionResult>
+  updatePeer(peerId: string, endpoint: string, domains?: string[]): Promise<ApplyActionResult>
+  deletePeer(peerId: string): Promise<ApplyActionResult>
 }
 
 export class ManagementRpcScope extends RpcTarget implements ManagementScope {
-    constructor(private server: OrchestratorRpcServer) {
-        super();
-    }
+  constructor(private server: OrchestratorRpcServer) {
+    super()
+  }
 
-    async applyAction(action: Action): Promise<ApplyActionResult> {
-        return this.server.applyAction(action);
-    }
+  async applyAction(action: Action): Promise<ApplyActionResult> {
+    return this.server.applyAction(action)
+  }
 
-    async listLocalRoutes(): Promise<ListLocalRoutesResult> {
-        return this.server.listLocalRoutes();
-    }
+  async listLocalRoutes(): Promise<ListLocalRoutesResult> {
+    return this.server.listLocalRoutes()
+  }
 
-    async listMetrics(): Promise<ListMetricsResult> {
-        return this.server.listMetrics();
-    }
+  async listMetrics(): Promise<ListMetricsResult> {
+    return this.server.listMetrics()
+  }
 
-    async listPeers(): Promise<ListPeersResult> {
-        return this.server.listPeers();
-    }
+  async listPeers(): Promise<ListPeersResult> {
+    return this.server.listPeers()
+  }
 
-    async createPeer(endpoint: string, domains?: string[]): Promise<ApplyActionResult> {
-        return this.server.createPeer(endpoint, domains);
-    }
+  async createPeer(endpoint: string, domains?: string[]): Promise<ApplyActionResult> {
+    return this.server.createPeer(endpoint, domains)
+  }
 
-    async updatePeer(peerId: string, endpoint: string, domains?: string[]): Promise<ApplyActionResult> {
-        return this.server.updatePeer(peerId, endpoint, domains);
-    }
+  async updatePeer(
+    peerId: string,
+    endpoint: string,
+    domains?: string[]
+  ): Promise<ApplyActionResult> {
+    return this.server.updatePeer(peerId, endpoint, domains)
+  }
 
-    async deletePeer(peerId: string): Promise<ApplyActionResult> {
-        return this.server.deletePeer(peerId);
-    }
+  async deletePeer(peerId: string): Promise<ApplyActionResult> {
+    return this.server.deletePeer(peerId)
+  }
 }


### PR DESCRIPTION
### TL;DR

Implemented a new orchestrator architecture with a cleaner state management approach and improved event handling.

### What changed?

- Added a new `CatalystNodeBus` class in the next/orchestrator.ts file that implements a more robust event-driven architecture
- Created comprehensive test suite for the new orchestrator implementation
- Added detailed events and plugins documentation to the README
- Implemented a type-safe routing state model with Zod schemas
- Separated state management from notification handling for better separation of concerns
- Formatted code with consistent styling (semicolons removed, consistent indentation)
- Added GatewayConfig schema and improved configuration type safety

### How to test?

1. Run the new test suite:
```bash
bun test packages/orchestrator/src/next/orchestrator.test.ts
```

2. The tests verify core functionality including:
   - Adding, updating, and removing peers
   - State management
   - Public API functionality

### Why make this change?

The current orchestrator implementation mixes state management with side effects, making it difficult to reason about and test. This new architecture:

1. Separates state management from notification handling
2. Provides a cleaner, more type-safe API
3. Improves testability with a more modular design
4. Prepares for future extensibility with a well-defined event model
5. Adds comprehensive documentation of the event flow between components

The changes maintain backward compatibility while introducing a more maintainable architecture for future development.