### PR TITLE
feat(orchestrator): add auth threading and centralize action constants

### DIFF
--- a/packages/orchestrator/src/next/action-types.ts
+++ b/packages/orchestrator/src/next/action-types.ts
@@ -1,0 +1,22 @@
+/**
+ * Action type constants - single source of truth for all action strings.
+ * Schemas and handlers reference these constants.
+ */
+export const Actions = {
+  // Local peer management
+  LocalPeerCreate: 'local:peer:create',
+  LocalPeerUpdate: 'local:peer:update',
+  LocalPeerDelete: 'local:peer:delete',
+
+  // Local route management
+  LocalRouteCreate: 'local:route:create',
+  LocalRouteDelete: 'local:route:delete',
+
+  // Internal protocol (iBGP peering)
+  InternalProtocolOpen: 'internal:protocol:open',
+  InternalProtocolClose: 'internal:protocol:close',
+  InternalProtocolConnected: 'internal:protocol:connected',
+  InternalProtocolUpdate: 'internal:protocol:update',
+} as const
+
+export type ActionType = (typeof Actions)[keyof typeof Actions]

--- a/packages/orchestrator/src/next/index.ts
+++ b/packages/orchestrator/src/next/index.ts
@@ -9,10 +9,12 @@ const nodeId = process.env.CATALYST_NODE_ID || 'myself';
 const peeringEndpoint = process.env.CATALYST_PEERING_ENDPOINT || 'http://localhost:3000/rpc';
 
 const bus = new CatalystNodeBus({
-    myself: {
-        name: nodeId,
-        endpoint: peeringEndpoint,
-        domains: []
+    config: {
+        node: {
+            name: nodeId,
+            endpoint: peeringEndpoint,
+            domains: []
+        }
     },
     connectionPool: { type: 'ws' }
 });

--- a/packages/orchestrator/src/next/orchestrator.test.ts
+++ b/packages/orchestrator/src/next/orchestrator.test.ts
@@ -1,648 +1,716 @@
 import { describe, it, expect, beforeEach, mock } from 'bun:test'
-import type { PeerManager, PublicApi } from './orchestrator'
+import type { PeerManager, PublicApi, Inspector } from './orchestrator'
 import { CatalystNodeBus, ConnectionPool } from './orchestrator'
 import type { PeerInfo, RouteTable } from './routing/state'
 import { newRouteTable } from './routing/state'
 import type { RpcStub } from 'capnweb'
+import type { AuthContext } from './types'
+import { Actions } from './action-types'
+
+/**
+ * Admin auth context for tests.
+ *
+ * Most tests here verify business logic (state transitions, error handling),
+ * not auth enforcement. Using ADMIN_AUTH lets these tests focus on their
+ * primary concern without permission failures obscuring the behavior under test.
+ *
+ * Auth-specific tests are in the 'Auth Threading' describe block, which
+ * explicitly tests various auth scenarios (anonymous, viewer, admin, wildcards).
+ */
+const ADMIN_AUTH: AuthContext = { userId: 'test-admin', roles: ['admin'] }
 
 // Helper to access private state for testing
 interface TestBus {
-    state: RouteTable
-    config?: { ibgp?: { secret?: string } }
+  state: RouteTable
+  config: { node: PeerInfo; ibgp?: { secret?: string } }
 }
 
 // Mock ConnectionPool
 class MockConnectionPool extends ConnectionPool {
-    public updateMock = mock(async () => ({ success: true }))
+  public updateMock = mock(async () => ({ success: true }))
 
-    get(_endpoint: string) {
-        // Return a mock object that satisfies whatever RpcStub<PublicApi> needs for this test
-        // Key method is getPeerConnection().open()
+  get(_endpoint: string) {
+    // Return a mock object that satisfies whatever RpcStub<PublicApi> needs for this test
+    // Key method is getPeerConnection().open()
+    return {
+      getPeerConnection: async (_secret: string) => {
         return {
-            getPeerConnection: async (_secret: string) => {
-                return {
-                    success: true,
-                    connection: {
-                        open: async (_peer: PeerInfo) => {
-                            return { success: true }
-                        },
-                        close: async (_peer: PeerInfo, _code: number, _reason?: string) => {
-                            return { success: true }
-                        },
-                        update: this.updateMock,
-                    },
-                }
+          success: true,
+          connection: {
+            open: async (_peer: PeerInfo) => {
+              return { success: true }
             },
-        } as unknown as RpcStub<PublicApi>
-    }
+            close: async (_peer: PeerInfo, _code: number, _reason?: string) => {
+              return { success: true }
+            },
+            update: this.updateMock,
+          },
+        }
+      },
+    } as unknown as RpcStub<PublicApi>
+  }
 }
 
 describe('CatalystNodeBus', () => {
-    let bus: CatalystNodeBus
+  let bus: CatalystNodeBus
+  const MOCK_NODE: PeerInfo = {
+    name: 'myself',
+    endpoint: 'http://localhost:3000',
+    domains: [],
+  }
+
+  beforeEach(() => {
+    bus = new CatalystNodeBus({
+      state: newRouteTable(),
+      connectionPool: { pool: new MockConnectionPool() },
+      config: { node: MOCK_NODE },
+    })
+  })
+
+  it('should initialize with empty state', () => {
+    const state = (bus as unknown as TestBus).state
+    expect(state.internal.peers).toEqual([])
+    expect(state.internal.routes).toEqual([])
+  })
+
+  describe('local:peer:create', () => {
+    it('should create a new peer', async () => {
+      const peer: PeerInfo = {
+        name: 'peer1',
+        endpoint: 'http://localhost:8080',
+        domains: ['example.com'],
+      }
+
+      const result = await bus.dispatch({ action: Actions.LocalPeerCreate, data: peer }, ADMIN_AUTH)
+
+      expect(result).toEqual({ success: true })
+
+      const state = (bus as unknown as TestBus).state
+      expect(state.internal.peers).toHaveLength(1)
+      expect(state.internal.peers[0]).toMatchObject({
+        name: 'peer1',
+        endpoint: 'http://localhost:8080',
+        domains: ['example.com'],
+        connectionStatus: 'connected', // Expect connected because mock returns success
+      })
+    })
+
+    it('should return error if peer already exists', async () => {
+      const peer: PeerInfo = {
+        name: 'peer1',
+        endpoint: 'http://localhost:8080',
+        domains: ['example.com'],
+      }
+
+      await bus.dispatch({ action: Actions.LocalPeerCreate, data: peer }, ADMIN_AUTH)
+
+      const result = await bus.dispatch({ action: Actions.LocalPeerCreate, data: peer }, ADMIN_AUTH)
+
+      expect(result).toEqual({ success: false, error: 'Peer already exists' })
+    })
+  })
+
+  describe('local:peer:update', () => {
+    beforeEach(async () => {
+      await bus.dispatch(
+        {
+          action: Actions.LocalPeerCreate,
+          data: { name: 'peer1', endpoint: 'http://localhost:8080', domains: ['example.com'] },
+        },
+        ADMIN_AUTH
+      )
+    })
+
+    it('should update an existing peer', async () => {
+      const updateData: PeerInfo = {
+        name: 'peer1',
+        endpoint: 'http://localhost:9090',
+        domains: ['updated.com'],
+      }
+
+      const result = await bus.dispatch(
+        { action: Actions.LocalPeerUpdate, data: updateData },
+        ADMIN_AUTH
+      )
+
+      expect(result).toEqual({ success: true })
+
+      const state = (bus as unknown as TestBus).state
+      expect(state.internal.peers).toHaveLength(1)
+      expect(state.internal.peers[0]).toMatchObject({
+        name: 'peer1',
+        endpoint: 'http://localhost:9090',
+        domains: ['updated.com'],
+        connectionStatus: 'initializing', // Reset to initializing on update
+      })
+    })
+
+    it('should return error if peer does not exist', async () => {
+      const result = await bus.dispatch(
+        {
+          action: Actions.LocalPeerUpdate,
+          data: { name: 'non-existent', endpoint: '...', domains: [] },
+        },
+        ADMIN_AUTH
+      )
+
+      expect(result).toEqual({ success: false, error: 'Peer not found' })
+    })
+  })
+
+  describe('local:peer:delete', () => {
+    beforeEach(async () => {
+      await bus.dispatch(
+        {
+          action: Actions.LocalPeerCreate,
+          data: { name: 'peer1', endpoint: 'http://localhost:8080', domains: ['example.com'] },
+        },
+        ADMIN_AUTH
+      )
+    })
+
+    it('should remove an existing peer', async () => {
+      const result = await bus.dispatch(
+        { action: Actions.LocalPeerDelete, data: { name: 'peer1' } },
+        ADMIN_AUTH
+      )
+
+      expect(result).toEqual({ success: true })
+
+      const state = (bus as unknown as TestBus).state
+      expect(state.internal.peers).toHaveLength(0)
+    })
+
+    it('should return error if peer does not exist', async () => {
+      const result = await bus.dispatch(
+        { action: Actions.LocalPeerDelete, data: { name: 'non-existent' } },
+        ADMIN_AUTH
+      )
+
+      expect(result).toEqual({ success: false, error: 'Peer not found' })
+    })
+  })
+
+  describe('Public API', () => {
+    let api: PeerManager
 
     beforeEach(() => {
-        bus = new CatalystNodeBus({
-            state: newRouteTable(),
-            connectionPool: { pool: new MockConnectionPool() },
-        })
+      bus = new CatalystNodeBus({
+        state: newRouteTable(),
+        connectionPool: { pool: new MockConnectionPool() },
+        config: { node: MOCK_NODE },
+      })
+      api = bus.publicApi().getManagerConnection()
     })
 
-    it('should initialize with empty state', () => {
-        const state = (bus as unknown as TestBus).state
-        expect(state.internal.peers).toEqual([])
-        expect(state.internal.routes).toEqual([])
+    it('should add peer via public API', async () => {
+      const peer = {
+        name: 'api-peer',
+        endpoint: 'http://api.com',
+        domains: ['api.com'],
+      }
+
+      const result = await api.addPeer(peer, ADMIN_AUTH)
+      expect(result).toEqual({ success: true })
+
+      const state = (bus as unknown as TestBus).state
+      expect(state.internal.peers).toHaveLength(1)
+      expect(state.internal.peers[0].name).toBe('api-peer')
+      expect(state.internal.peers[0].connectionStatus).toBe('connected')
     })
 
-    describe('local:peer:create', () => {
-        it('should create a new peer', async () => {
-            const peer: PeerInfo = {
-                name: 'peer1',
-                endpoint: 'http://localhost:8080',
-                domains: ['example.com'],
-            }
+    it('should update peer via public API', async () => {
+      await api.addPeer(
+        { name: 'api-peer', endpoint: 'http://api.com', domains: ['api.com'] },
+        ADMIN_AUTH
+      )
 
-            const result = await bus.dispatch({
-                action: 'local:peer:create',
-                data: peer,
-            })
+      const result = await api.updatePeer(
+        { name: 'api-peer', endpoint: 'http://api-updated.com', domains: ['api-updated.com'] },
+        ADMIN_AUTH
+      )
+      expect(result).toEqual({ success: true })
 
-            expect(result).toEqual({ success: true })
-
-            const state = (bus as unknown as TestBus).state
-            expect(state.internal.peers).toHaveLength(1)
-            expect(state.internal.peers[0]).toMatchObject({
-                name: 'peer1',
-                endpoint: 'http://localhost:8080',
-                domains: ['example.com'],
-                connectionStatus: 'connected', // Expect connected because mock returns success
-            })
-        })
-
-        it('should return error if peer already exists', async () => {
-            const peer: PeerInfo = {
-                name: 'peer1',
-                endpoint: 'http://localhost:8080',
-                domains: ['example.com'],
-            }
-
-            await bus.dispatch({
-                action: 'local:peer:create',
-                data: peer,
-            })
-
-            const result = await bus.dispatch({
-                action: 'local:peer:create',
-                data: peer,
-            })
-
-            expect(result).toEqual({ success: false, error: 'Peer already exists' })
-        })
+      const state = (bus as unknown as TestBus).state
+      expect(state.internal.peers[0].endpoint).toBe('http://api-updated.com')
     })
 
-    describe('local:peer:update', () => {
-        beforeEach(async () => {
-            await bus.dispatch({
-                action: 'local:peer:create',
-                data: {
-                    name: 'peer1',
-                    endpoint: 'http://localhost:8080',
-                    domains: ['example.com'],
-                },
-            })
-        })
+    it('should remove peer via public API', async () => {
+      await api.addPeer(
+        { name: 'api-peer', endpoint: 'http://api.com', domains: ['api.com'] },
+        ADMIN_AUTH
+      )
 
-        it('should update an existing peer', async () => {
-            const updateData: PeerInfo = {
-                name: 'peer1',
-                endpoint: 'http://localhost:9090',
-                domains: ['updated.com'],
-            }
+      const result = await api.removePeer({ name: 'api-peer' }, ADMIN_AUTH)
+      expect(result).toEqual({ success: true })
 
-            const result = await bus.dispatch({
-                action: 'local:peer:update',
-                data: updateData,
-            })
+      const state = (bus as unknown as TestBus).state
+      expect(state.internal.peers).toHaveLength(0)
+    })
+  })
 
-            expect(result).toEqual({ success: true })
+  describe('internal:protocol:connected', () => {
+    it('should transition peer to connected state', async () => {
+      // 1. Configure peer (initially initializing)
+      await bus.dispatch(
+        {
+          action: Actions.LocalPeerCreate,
+          data: { name: 'connecting-peer', endpoint: 'http://connecting.com', domains: [] },
+        },
+        ADMIN_AUTH
+      )
 
-            const state = (bus as unknown as TestBus).state
-            expect(state.internal.peers).toHaveLength(1)
-            expect(state.internal.peers[0]).toMatchObject({
-                name: 'peer1',
-                endpoint: 'http://localhost:9090',
-                domains: ['updated.com'],
-                connectionStatus: 'initializing', // Reset to initializing on update
-            })
-        })
+      // Cheat to test handler in isolation - reset to initializing
+      const state = (bus as unknown as TestBus).state
+      state.internal.peers[0].connectionStatus = 'initializing'
 
-        it('should return error if peer does not exist', async () => {
-            const result = await bus.dispatch({
-                action: 'local:peer:update',
-                data: {
-                    name: 'non-existent',
-                    endpoint: '...',
-                    domains: [],
-                },
-            })
+      const result = await bus.dispatch(
+        {
+          action: Actions.InternalProtocolConnected,
+          data: {
+            peerInfo: { name: 'connecting-peer', endpoint: 'http://connecting.com', domains: [] },
+          },
+        },
+        ADMIN_AUTH
+      )
 
-            expect(result).toEqual({ success: false, error: 'Peer not found' })
-        })
+      expect(result).toEqual({ success: true })
+      const finalState = (bus as unknown as TestBus).state
+      expect(finalState.internal.peers[0].connectionStatus).toBe('connected')
+    })
+  })
+
+  describe('BGP Handshake Flow', () => {
+    it('should complete full open -> connected -> close sequence', async () => {
+      const peerInfo: PeerInfo = {
+        name: 'handshake-peer',
+        endpoint: 'http://handshake.com',
+        domains: [],
+      }
+
+      // 1. Initiate Connection (local:peer:create)
+      // This triggers handleAction (init) -> handleNotify (open) -> dispatch(connected) -> handleAction (connected)
+      await bus.dispatch({ action: Actions.LocalPeerCreate, data: peerInfo }, ADMIN_AUTH)
+
+      const state = (bus as unknown as TestBus).state
+      const peer = state.internal.peers.find((p) => p.name === 'handshake-peer')
+      expect(peer).toBeDefined()
+      expect(peer?.connectionStatus).toBe('connected')
+
+      // 2. Remote side closes (internal:protocol:close)
+      await bus.dispatch(
+        {
+          action: Actions.InternalProtocolClose,
+          data: { peerInfo: peerInfo, code: 1000, reason: 'Done' },
+        },
+        ADMIN_AUTH
+      )
+
+      const finalState = (bus as unknown as TestBus).state
+      const peerAfterClose = finalState.internal.peers.find((p) => p.name === 'handshake-peer')
+      expect(peerAfterClose).toBeUndefined()
+    })
+  })
+
+  describe('internal:protocol:open', () => {
+    it('should accept connection if peer is configured', async () => {
+      // 1. Configure peer (initially connected via mock)
+      await bus.dispatch(
+        {
+          action: Actions.LocalPeerCreate,
+          data: { name: 'remote-peer', endpoint: 'http://remote.com', domains: [] },
+        },
+        ADMIN_AUTH
+      )
+
+      // 2. Simulate disconnect / reset status manually for test
+      const state = (bus as unknown as TestBus).state
+      state.internal.peers[0].connectionStatus = 'initializing'
+
+      // 3. Receive open request
+      const result = await bus.dispatch(
+        {
+          action: Actions.InternalProtocolOpen,
+          data: { peerInfo: { name: 'remote-peer', endpoint: 'http://remote.com', domains: [] } },
+        },
+        ADMIN_AUTH
+      )
+
+      expect(result).toEqual({ success: true })
+      const finalState = (bus as unknown as TestBus).state
+      expect(finalState.internal.peers[0].connectionStatus).toBe('connected')
     })
 
-    describe('local:peer:delete', () => {
-        beforeEach(async () => {
-            await bus.dispatch({
-                action: 'local:peer:create',
-                data: {
-                    name: 'peer1',
-                    endpoint: 'http://localhost:8080',
-                    domains: ['example.com'],
-                },
-            })
-        })
+    it('should reject connection if peer is not configured', async () => {
+      const result = await bus.dispatch(
+        {
+          action: Actions.InternalProtocolOpen,
+          data: { peerInfo: { name: 'stranger', endpoint: 'http://remote.com', domains: [] } },
+        },
+        ADMIN_AUTH
+      )
 
-        it('should remove an existing peer', async () => {
-            const result = await bus.dispatch({
-                action: 'local:peer:delete',
-                data: {
-                    name: 'peer1',
-                },
-            })
+      expect(result).toEqual({
+        success: false,
+        error: "Peer 'stranger' is not configured on this node",
+      })
+    })
+  })
 
-            expect(result).toEqual({ success: true })
+  describe('internal:protocol:close', () => {
+    it('should remove peer if configured', async () => {
+      // 1. Configure peer
+      await bus.dispatch(
+        {
+          action: Actions.LocalPeerCreate,
+          data: { name: 'remote-peer', endpoint: 'http://remote.com', domains: [] },
+        },
+        ADMIN_AUTH
+      )
 
-            const state = (bus as unknown as TestBus).state
-            expect(state.internal.peers).toHaveLength(0)
-        })
+      // 2. Receive close request
+      const result = await bus.dispatch(
+        {
+          action: Actions.InternalProtocolClose,
+          data: {
+            peerInfo: { name: 'remote-peer', endpoint: 'http://remote.com', domains: [] },
+            code: 1000,
+            reason: 'Closed',
+          },
+        },
+        ADMIN_AUTH
+      )
 
-        it('should return error if peer does not exist', async () => {
-            const result = await bus.dispatch({
-                action: 'local:peer:delete',
-                data: {
-                    name: 'non-existent',
-                },
-            })
-
-            expect(result).toEqual({ success: false, error: 'Peer not found' })
-        })
+      expect(result).toEqual({ success: true })
+      const postState = (bus as unknown as TestBus).state
+      expect(postState.internal.peers).toHaveLength(0)
     })
 
-    describe('Public API', () => {
-        let api: PeerManager
+    it('should no-op if peer is not configured', async () => {
+      const result = await bus.dispatch(
+        {
+          action: Actions.InternalProtocolClose,
+          data: {
+            peerInfo: { name: 'stranger', endpoint: 'http://remote.com', domains: [] },
+            code: 1000,
+            reason: 'Closed',
+          },
+        },
+        ADMIN_AUTH
+      )
 
-        beforeEach(() => {
-            // Re-instantiate with mock pool for Public API tests too
-            // Note: PublicApi implementation in catalystNodeBus just dispatches actions
-            // so mocking the pool in constructor is sufficient.
-            bus = new CatalystNodeBus({
-                state: newRouteTable(),
-                connectionPool: { pool: new MockConnectionPool() },
-            })
-            api = bus.publicApi().getManagerConnection()
-        })
+      expect(result).toEqual({ success: true })
+    })
+  })
 
-        it('should add peer via public API', async () => {
-            const peer = {
-                name: 'api-peer',
-                endpoint: 'http://api.com',
-                domains: ['api.com'],
-            }
+  describe('Route Updates', () => {
+    it('should add local route', async () => {
+      const route = {
+        name: 'local-service',
+        protocol: 'http' as const,
+        endpoint: 'http://localhost:3000',
+      }
 
-            const result = await api.addPeer(peer)
-            expect(result).toEqual({ success: true })
+      const result = await bus.dispatch({ action: Actions.LocalRouteCreate, data: route }, ADMIN_AUTH)
 
-            const state = (bus as unknown as TestBus).state
-            expect(state.internal.peers).toHaveLength(1)
-            expect(state.internal.peers[0].name).toBe('api-peer')
-            expect(state.internal.peers[0].connectionStatus).toBe('connected')
-        })
-
-        it('should update peer via public API', async () => {
-            await api.addPeer({
-                name: 'api-peer',
-                endpoint: 'http://api.com',
-                domains: ['api.com'],
-            })
-
-            const result = await api.updatePeer({
-                name: 'api-peer',
-                endpoint: 'http://api-updated.com',
-                domains: ['api-updated.com'],
-            })
-            expect(result).toEqual({ success: true })
-
-            const state = (bus as unknown as TestBus).state
-            expect(state.internal.peers[0].endpoint).toBe('http://api-updated.com')
-        })
-
-        it('should remove peer via public API', async () => {
-            await api.addPeer({
-                name: 'api-peer',
-                endpoint: 'http://api.com',
-                domains: ['api.com'],
-            })
-
-            const result = await api.removePeer({ name: 'api-peer' })
-            expect(result).toEqual({ success: true })
-
-            const state = (bus as unknown as TestBus).state
-            expect(state.internal.peers).toHaveLength(0)
-        })
+      expect(result).toEqual({ success: true })
+      const state = (bus as unknown as TestBus).state
+      expect(state.local.routes).toHaveLength(1)
+      expect(state.local.routes[0]).toMatchObject(route)
     })
 
-    describe('internal:protocol:connected', () => {
-        it('should transition peer to connected state', async () => {
-            // 1. Configure peer (initially initializing)
-            await bus.dispatch({
-                action: 'local:peer:create',
-                data: {
-                    name: 'connecting-peer',
-                    endpoint: 'http://connecting.com',
-                    domains: [],
-                },
-            })
+    it('should remove local route', async () => {
+      const route = {
+        name: 'local-service',
+        protocol: 'http' as const,
+        endpoint: 'http://localhost:3000',
+      }
+      await bus.dispatch({ action: Actions.LocalRouteCreate, data: route }, ADMIN_AUTH)
 
-            // Manually force to initializing if create didn't leave it there (it does, but handleNotify -> open -> connected sequence happens fast in test)
-            // Actually, since handleNotify is awaited, state is already connected.
-            // So we need to cheat to test the action handler in isolation?
-            // OR we rely on the fact that dispatch('internal:protocol:connected') is what does it.
+      const result = await bus.dispatch({ action: Actions.LocalRouteDelete, data: route }, ADMIN_AUTH)
 
-            // Let's manually set it to initializing to verify the handler specifically
-            const state = (bus as unknown as TestBus).state
-            state.internal.peers[0].connectionStatus = 'initializing'
-
-            const result = await bus.dispatch({
-                action: 'internal:protocol:connected',
-                data: {
-                    peerInfo: {
-                        name: 'connecting-peer',
-                        endpoint: 'http://connecting.com',
-                        domains: [],
-                    },
-                },
-            })
-
-            expect(result).toEqual({ success: true })
-            const finalState = (bus as unknown as TestBus).state
-            expect(finalState.internal.peers[0].connectionStatus).toBe('connected')
-        })
+      expect(result).toEqual({ success: true })
+      const state = (bus as unknown as TestBus).state
+      expect(state.local.routes).toHaveLength(0)
     })
 
-    describe('BGP Handshake Flow', () => {
-        it('should complete full open -> connected -> close sequence', async () => {
-            const peerInfo: PeerInfo = {
-                name: 'handshake-peer',
-                endpoint: 'http://handshake.com',
-                domains: [],
-            }
+    it('should process internal:protocol:update adds', async () => {
+      const peerInfo = {
+        name: 'remote-peer',
+        endpoint: 'http://remote.com',
+        domains: [],
+      }
+      const route = {
+        name: 'remote-service',
+        protocol: 'http' as const,
+        endpoint: 'http://remote-service',
+      }
 
-            // 1. Initiate Connection (local:peer:create)
-            // This triggers handleAction (init) -> handleNotify (open) -> dispatch(connected) -> handleAction (connected)
-            await bus.dispatch({
-                action: 'local:peer:create',
-                data: peerInfo,
-            })
+      const result = await bus.dispatch(
+        {
+          action: Actions.InternalProtocolUpdate,
+          data: {
+            peerInfo: peerInfo,
+            update: {
+              updates: [{ action: 'add', route: route }],
+            },
+          },
+        },
+        ADMIN_AUTH
+      )
 
-            const state = (bus as unknown as TestBus).state
-            const peer = state.internal.peers.find((p) => p.name === 'handshake-peer')
-            expect(peer).toBeDefined()
-            expect(peer?.connectionStatus).toBe('connected')
-
-            // 2. Remote side closes (internal:protocol:close)
-            await bus.dispatch({
-                action: 'internal:protocol:close',
-                data: {
-                    peerInfo: peerInfo,
-                    code: 1000,
-                    reason: 'Done',
-                },
-            })
-
-            const finalState = (bus as unknown as TestBus).state
-            const peerAfterClose = finalState.internal.peers.find((p) => p.name === 'handshake-peer')
-            expect(peerAfterClose).toBeUndefined()
-        })
-    })
-    describe('internal:protocol:open', () => {
-        it('should accept connection if peer is configured', async () => {
-            // 1. Configure peer (initially connected via mock)
-            await bus.dispatch({
-                action: 'local:peer:create',
-                data: {
-                    name: 'remote-peer',
-                    endpoint: 'http://remote.com',
-                    domains: [],
-                },
-            })
-
-            // 2. Simulate disconnect / reset status manually for test?
-            // Or just verify it stays connected / returns success.
-            // Let's manually set it to initializing to test transition
-            const state = (bus as unknown as TestBus).state
-            state.internal.peers[0].connectionStatus = 'initializing'
-
-            // 3. Receive open request
-            const result = await bus.dispatch({
-                action: 'internal:protocol:open',
-                data: {
-                    peerInfo: {
-                        name: 'remote-peer',
-                        endpoint: 'http://remote.com',
-                        domains: [],
-                    },
-                },
-            })
-
-            expect(result).toEqual({ success: true })
-            const finalState = (bus as unknown as TestBus).state
-            expect(finalState.internal.peers[0].connectionStatus).toBe('connected')
-        })
-
-        it('should reject connection if peer is not configured', async () => {
-            const result = await bus.dispatch({
-                action: 'internal:protocol:open',
-                data: {
-                    peerInfo: {
-                        name: 'stranger',
-                        endpoint: 'http://remote.com',
-                        domains: [],
-                    },
-                },
-            })
-
-            expect(result).toEqual({ success: false, error: "Peer 'stranger' is not configured on this node" })
-        })
+      expect(result).toEqual({ success: true })
+      const state = (bus as unknown as TestBus).state
+      expect(state.internal.routes).toHaveLength(1)
+      expect(state.internal.routes[0]).toMatchObject({ ...route, peer: peerInfo })
     })
 
-    describe('internal:protocol:close', () => {
-        it('should remove peer if configured', async () => {
-            // 1. Configure peer
-            await bus.dispatch({
-                action: 'local:peer:create',
-                data: {
-                    name: 'remote-peer',
-                    endpoint: 'http://remote.com',
-                    domains: [],
-                },
-            })
+    it('should process internal:protocol:update removes', async () => {
+      const peerInfo = {
+        name: 'remote-peer',
+        endpoint: 'http://remote.com',
+        domains: [],
+      }
+      const route = {
+        name: 'remote-service',
+        protocol: 'http' as const,
+        endpoint: 'http://remote-service',
+      }
 
-            const preState = (bus as unknown as TestBus).state
-            expect(preState.internal.peers).toHaveLength(1)
+      // Add first
+      await bus.dispatch(
+        {
+          action: Actions.InternalProtocolUpdate,
+          data: {
+            peerInfo: peerInfo,
+            update: {
+              updates: [{ action: 'add', route: route }],
+            },
+          },
+        },
+        ADMIN_AUTH
+      )
 
-            // 2. Receive close request
-            const result = await bus.dispatch({
-                action: 'internal:protocol:close',
-                data: {
-                    peerInfo: {
-                        name: 'remote-peer',
-                        endpoint: 'http://remote.com',
-                        domains: [],
-                    },
-                    code: 1000,
-                    reason: 'Closed',
-                },
-            })
+      const result = await bus.dispatch(
+        {
+          action: Actions.InternalProtocolUpdate,
+          data: {
+            peerInfo: peerInfo,
+            update: {
+              updates: [{ action: 'remove', route: route }],
+            },
+          },
+        },
+        ADMIN_AUTH
+      )
 
-            expect(result).toEqual({ success: true })
-            const postState = (bus as unknown as TestBus).state
-            expect(postState.internal.peers).toHaveLength(0)
-        })
-
-        it('should no-op if peer is not configured', async () => {
-            const result = await bus.dispatch({
-                action: 'internal:protocol:close',
-                data: {
-                    peerInfo: {
-                        name: 'stranger',
-                        endpoint: 'http://remote.com',
-                        domains: [],
-                    },
-                    code: 1000,
-                    reason: 'Closed',
-                },
-            })
-
-            expect(result).toEqual({ success: true })
-        })
+      expect(result).toEqual({ success: true })
+      const state = (bus as unknown as TestBus).state
+      expect(state.internal.routes).toHaveLength(0)
     })
-    describe('Route Updates', () => {
-        it('should add local route', async () => {
-            const route = {
-                name: 'local-service',
-                protocol: 'http' as const,
-                endpoint: 'http://localhost:3000',
-            }
+  })
 
-            const result = await bus.dispatch({
-                action: 'local:route:create',
-                data: route,
-            })
+  describe('Route Lifecycle Edge Cases', () => {
+    it('should remove routes when peer disconnects', async () => {
+      const peerInfo: PeerInfo = { name: 'peer1', endpoint: 'http://p1', domains: [] }
+      const route = { name: 'r1', protocol: 'http' as const, endpoint: 'http://r1' }
 
-            expect(result).toEqual({ success: true })
-            const state = (bus as unknown as TestBus).state
-            expect(state.local.routes).toHaveLength(1)
-            expect(state.local.routes[0]).toMatchObject(route)
-        })
+      // 0. Ensure peer exists in state (simulating handshake)
+      await bus.dispatch({ action: Actions.LocalPeerCreate, data: peerInfo }, ADMIN_AUTH)
 
-        it('should remove local route', async () => {
-            const route = {
-                name: 'local-service',
-                protocol: 'http' as const,
-                endpoint: 'http://localhost:3000',
-            }
-            await bus.dispatch({
-                action: 'local:route:create',
-                data: route,
-            })
+      // 1. Add route via update
+      await bus.dispatch(
+        {
+          action: Actions.InternalProtocolUpdate,
+          data: {
+            peerInfo: peerInfo,
+            update: {
+              updates: [{ action: 'add', route: route }],
+            },
+          },
+        },
+        ADMIN_AUTH
+      )
 
-            const result = await bus.dispatch({
-                action: 'local:route:delete',
-                data: route,
-            })
+      // Verify route exists
+      let state = (bus as unknown as TestBus).state
+      expect(state.internal.routes).toHaveLength(1)
+      expect(state.internal.routes[0]).toMatchObject({
+        peerName: 'peer1',
+      })
 
-            expect(result).toEqual({ success: true })
-            const state = (bus as unknown as TestBus).state
-            expect(state.local.routes).toHaveLength(0)
-        })
+      // 2. Disconnect peer
+      await bus.dispatch(
+        {
+          action: Actions.InternalProtocolClose,
+          data: { peerInfo: peerInfo, code: 1000, reason: 'bye' },
+        },
+        ADMIN_AUTH
+      )
 
-        it('should process internal:protocol:update adds', async () => {
-            const peerInfo = {
-                name: 'remote-peer',
-                endpoint: 'http://remote.com',
-                domains: [],
-            }
-            const route = {
-                name: 'remote-service',
-                protocol: 'http' as const,
-                endpoint: 'http://remote-service',
-            }
-
-            const result = await bus.dispatch({
-                action: 'internal:protocol:update',
-                data: {
-                    peerInfo: peerInfo,
-                    update: {
-                        updates: [{ action: 'add', route: route }],
-                    },
-                },
-            })
-
-            expect(result).toEqual({ success: true })
-            const state = (bus as unknown as TestBus).state
-            expect(state.internal.routes).toHaveLength(1)
-            expect(state.internal.routes[0]).toMatchObject({ ...route, peer: peerInfo })
-        })
-
-        it('should process internal:protocol:update removes', async () => {
-            const peerInfo = {
-                name: 'remote-peer',
-                endpoint: 'http://remote.com',
-                domains: [],
-            }
-            const route = {
-                name: 'remote-service',
-                protocol: 'http' as const,
-                endpoint: 'http://remote-service',
-            }
-
-            // Add first
-            await bus.dispatch({
-                action: 'internal:protocol:update',
-                data: {
-                    peerInfo: peerInfo,
-                    update: {
-                        updates: [{ action: 'add', route: route }],
-                    },
-                },
-            })
-
-            const result = await bus.dispatch({
-                action: 'internal:protocol:update',
-                data: {
-                    peerInfo: peerInfo,
-                    update: {
-                        updates: [{ action: 'remove', route: route }],
-                    },
-                },
-            })
-
-            expect(result).toEqual({ success: true })
-            const state = (bus as unknown as TestBus).state
-            expect(state.internal.routes).toHaveLength(0)
-        })
+      // Verify route is gone
+      state = (bus as unknown as TestBus).state
+      expect(state.internal.routes).toHaveLength(0)
     })
 
-    describe('Route Lifecycle Edge Cases', () => {
-        it('should remove routes when peer disconnects', async () => {
-            const peerInfo: PeerInfo = { name: 'peer1', endpoint: 'http://p1', domains: [] }
+    it('should sync existing routes to new peer', async () => {
+      // 1. Create local route
+      const route = { name: 'local1', protocol: 'http' as const, endpoint: 'http://l1' }
+      await bus.dispatch({ action: Actions.LocalRouteCreate, data: route }, ADMIN_AUTH)
 
-            // 0. Ensure peer exists in state (simulating handshake)
-            await bus.dispatch({
-                action: 'local:peer:create',
-                data: peerInfo,
-            })
+      // 2. Simulate new peer connecting
+      const peerInfo: PeerInfo = { name: 'peer2', endpoint: 'http://p2', domains: [] }
 
-            const route = { name: 'r1', protocol: 'http' as const, endpoint: 'http://r1' }
+      await bus.dispatch(
+        { action: Actions.InternalProtocolConnected, data: { peerInfo: peerInfo } },
+        ADMIN_AUTH
+      )
 
-            // 1. Add route via update
-            await bus.dispatch({
-                action: 'internal:protocol:update',
-                data: {
-                    peerInfo: peerInfo,
-                    update: {
-                        updates: [{ action: 'add', route: route }],
-                    },
-                },
-            })
+      // Verify update was called on the new peer
+      const pool = (bus as unknown as { connectionPool: MockConnectionPool }).connectionPool
+      expect(pool.updateMock).toHaveBeenCalled()
 
-            // Verify route exists
-            let state = (bus as unknown as TestBus).state
-            expect(state.internal.routes).toHaveLength(1)
-            expect(state.internal.routes[0]).toMatchObject({
-                peerName: 'peer1',
-            })
+      const calls = pool.updateMock.mock.calls
+      const lastCall = calls[calls.length - 1] as unknown[]
+      expect(lastCall).toBeDefined()
+      const updateMsg = lastCall[1] as { updates: { action: string; route: { name: string } }[] }
+      expect(updateMsg.updates).toHaveLength(1)
+      expect(updateMsg.updates[0].action).toBe('add')
+      expect(updateMsg.updates[0].route.name).toBe('local1')
+    })
+  })
 
-            // 2. Disconnect peer
-            await bus.dispatch({
-                action: 'internal:protocol:close',
-                data: { peerInfo: peerInfo, code: 1000, reason: 'bye' },
-            })
+  describe('Config', () => {
+    it('should accept config in constructor', () => {
+      const configuredBus = new CatalystNodeBus({
+        state: newRouteTable(),
+        config: { node: MOCK_NODE, ibgp: { secret: 'test-secret' } },
+      })
 
-            // Verify route is gone
-            state = (bus as unknown as TestBus).state
-            expect(state.internal.routes).toHaveLength(0)
-        })
-
-        it('should sync existing routes to new peer', async () => {
-            // 1. Create local route
-            const route = { name: 'local1', protocol: 'http' as const, endpoint: 'http://l1' }
-            await bus.dispatch({
-                action: 'local:route:create',
-                data: route,
-            })
-
-            // 2. Simulate new peer connecting
-            const peerInfo: PeerInfo = { name: 'peer2', endpoint: 'http://p2', domains: [] }
-
-            await bus.dispatch({
-                action: 'internal:protocol:connected',
-                data: { peerInfo: peerInfo },
-            })
-
-            // Verify update was called on the new peer
-            const pool = (bus as unknown as { connectionPool: MockConnectionPool }).connectionPool
-            expect(pool.updateMock).toHaveBeenCalled()
-
-            const calls = pool.updateMock.mock.calls
-            const lastCall = calls[calls.length - 1] as unknown[]
-            expect(lastCall).toBeDefined()
-            const updateMsg = lastCall[1] as { updates: { action: string; route: { name: string } }[] }
-            expect(updateMsg.updates).toHaveLength(1)
-            expect(updateMsg.updates[0].action).toBe('add')
-            expect(updateMsg.updates[0].route.name).toBe('local1')
-        })
+      const busInternal = configuredBus as unknown as TestBus
+      expect(busInternal.config).toBeDefined()
+      expect(busInternal.config.node).toEqual(MOCK_NODE)
+      expect(busInternal.config.ibgp?.secret).toBe('test-secret')
     })
 
-    describe('Config', () => {
-        it('should accept config in constructor', () => {
-            const configuredBus = new CatalystNodeBus({
-                state: newRouteTable(),
-                config: { ibgp: { secret: 'test-secret' } },
-            })
+    it('should make config.ibgp.secret accessible', () => {
+      const configuredBus = new CatalystNodeBus({
+        state: newRouteTable(),
+        config: { node: MOCK_NODE, ibgp: { secret: 'my-mesh-secret' } },
+      })
 
-            const busInternal = configuredBus as unknown as TestBus
-            expect(busInternal.config).toBeDefined()
-            expect(busInternal.config?.ibgp?.secret).toBe('test-secret')
-        })
-
-        it('should make config.ibgp.secret accessible', () => {
-            const configuredBus = new CatalystNodeBus({
-                state: newRouteTable(),
-                config: { ibgp: { secret: 'my-mesh-secret' } },
-            })
-
-            const busInternal = configuredBus as unknown as TestBus
-            expect(busInternal.config?.ibgp?.secret).toBe('my-mesh-secret')
-        })
-
-        it('should default gracefully when config is not provided', () => {
-            const busWithoutConfig = new CatalystNodeBus({
-                state: newRouteTable(),
-            })
-
-            const busInternal = busWithoutConfig as unknown as TestBus
-            expect(busInternal.config).toBeUndefined()
-        })
-
-        it('should default gracefully when ibgp config is empty', () => {
-            const busWithEmptyConfig = new CatalystNodeBus({
-                state: newRouteTable(),
-                config: {},
-            })
-
-            const busInternal = busWithEmptyConfig as unknown as TestBus
-            expect(busInternal.config).toBeDefined()
-            expect(busInternal.config?.ibgp).toBeUndefined()
-        })
+      const busInternal = configuredBus as unknown as TestBus
+      expect(busInternal.config.ibgp?.secret).toBe('my-mesh-secret')
     })
+  })
+
+  describe('Auth Threading', () => {
+    it('should use anonymous context when auth not provided', async () => {
+      // Without auth, should use { userId: 'anonymous', roles: [] }
+      // With empty roles, permission check should fail
+      const result = await bus.dispatch({
+        action: Actions.LocalPeerCreate,
+        data: { name: 'test', endpoint: 'http://test', domains: [] },
+      })
+
+      expect(result.success).toBe(false)
+      expect((result as { error: string }).error).toContain('Permission denied')
+    })
+
+    it('should pass auth to handleAction when provided', async () => {
+      const result = await bus.dispatch(
+        {
+          action: Actions.LocalPeerCreate,
+          data: { name: 'test', endpoint: 'http://test', domains: [] },
+        },
+        { userId: 'admin-user', roles: ['admin'] }
+      )
+
+      expect(result).toEqual({ success: true })
+    })
+
+    it('should reject when roles lack required permission', async () => {
+      const result = await bus.dispatch(
+        {
+          action: Actions.LocalPeerCreate,
+          data: { name: 'test', endpoint: 'http://test', domains: [] },
+        },
+        { userId: 'viewer', roles: ['viewer'] }
+      )
+
+      expect(result.success).toBe(false)
+      expect((result as { error: string }).error).toBe('Permission denied: peer:create')
+    })
+
+    it('should succeed when roles include required permission', async () => {
+      const result = await bus.dispatch(
+        {
+          action: Actions.LocalPeerCreate,
+          data: { name: 'test', endpoint: 'http://test', domains: [] },
+        },
+        { userId: 'peer-admin', roles: ['peer:create'] }
+      )
+
+      expect(result).toEqual({ success: true })
+    })
+
+    it('should succeed when roles include admin', async () => {
+      const result = await bus.dispatch(
+        {
+          action: Actions.LocalRouteCreate,
+          data: { name: 'route1', protocol: 'http', endpoint: 'http://r1' },
+        },
+        { userId: 'super-admin', roles: ['admin'] }
+      )
+
+      expect(result).toEqual({ success: true })
+    })
+
+    it('should succeed when roles include category wildcard', async () => {
+      const result = await bus.dispatch(
+        {
+          action: Actions.LocalPeerDelete,
+          data: { name: 'nonexistent' },
+        },
+        { userId: 'peer-manager', roles: ['peer:*'] }
+      )
+
+      // Will fail with "Peer not found" - but that's AFTER permission check passes
+      expect((result as { error: string }).error).toBe('Peer not found')
+    })
+
+    it('should not modify state when permission denied', async () => {
+      const stateBefore = (bus as unknown as TestBus).state
+      const peersBefore = stateBefore.internal.peers.length
+
+      await bus.dispatch(
+        {
+          action: Actions.LocalPeerCreate,
+          data: { name: 'unauthorized', endpoint: 'http://test', domains: [] },
+        },
+        { userId: 'viewer', roles: [] }
+      )
+
+      const stateAfter = (bus as unknown as TestBus).state
+      expect(stateAfter.internal.peers.length).toBe(peersBefore)
+    })
+
+    it('should not trigger handleNotify when permission denied', async () => {
+      // If handleNotify was called, it would try to connect and the mock would be called
+      // We can verify by checking that no connection attempt was made
+      const pool = (bus as unknown as { connectionPool: MockConnectionPool }).connectionPool
+      const callsBefore = pool.updateMock.mock.calls.length
+
+      await bus.dispatch(
+        {
+          action: Actions.LocalPeerCreate,
+          data: { name: 'unauthorized', endpoint: 'http://test', domains: [] },
+        },
+        { userId: 'viewer', roles: [] }
+      )
+
+      // No new calls to the mock - handleNotify wasn't triggered
+      expect(pool.updateMock.mock.calls.length).toBe(callsBefore)
+    })
+  })
 })

--- a/packages/orchestrator/src/next/orchestrator.ts
+++ b/packages/orchestrator/src/next/orchestrator.ts
@@ -3,488 +3,548 @@ import { type Action } from './schema.js'
 import type { PeerInfo } from './routing/state.js'
 import { newRouteTable, type RouteTable } from './routing/state.js'
 import type { UpdateMessageSchema } from './routing/internal/actions.js'
+import { type AuthContext, AuthContextSchema } from './types.js'
+import { getRequiredPermission, hasPermission } from './permissions.js'
+import { Actions } from './action-types.js'
 import {
-    newHttpBatchRpcSession,
-    newWebSocketRpcSession,
-    type RpcCompatible,
-    type RpcStub,
-    RpcTarget,
+  newHttpBatchRpcSession,
+  newWebSocketRpcSession,
+  type RpcCompatible,
+  type RpcStub,
+  RpcTarget,
 } from 'capnweb'
 
 export interface PublicApi {
-    getManagerConnection(): PeerManager
-    getPeerConnection(
-        secret: string
-    ): { success: true; connection: PeerConnection } | { success: false; error: string }
-    getInspector(): Inspector
-    dispatch(action: Action): Promise<{ success: true } | { success: false; error: string }>
+  getManagerConnection(): PeerManager
+  getPeerConnection(
+    secret: string
+  ): { success: true; connection: PeerConnection } | { success: false; error: string }
+  getInspector(): Inspector
+  dispatch(action: Action): Promise<{ success: true } | { success: false; error: string }>
 }
 
 export interface Inspector {
-    listPeers(): Promise<PeerInfo[]>
-    listRoutes(): Promise<{ local: any[], internal: any[] }>
+  listPeers(): Promise<PeerInfo[]>
+  listRoutes(): Promise<{ local: any[], internal: any[] }>
 }
 
 export interface PeerManager {
-    addPeer(peer: PeerInfo): Promise<{ success: true } | { success: false; error: string }>
-    updatePeer(peer: PeerInfo): Promise<{ success: true } | { success: false; error: string }>
-    removePeer(
-        peer: Pick<PeerInfo, 'name'>
-    ): Promise<{ success: true } | { success: false; error: string }>
+  addPeer(
+    peer: PeerInfo,
+    auth?: AuthContext
+  ): Promise<{ success: true } | { success: false; error: string }>
+  updatePeer(
+    peer: PeerInfo,
+    auth?: AuthContext
+  ): Promise<{ success: true } | { success: false; error: string }>
+  removePeer(
+    peer: Pick<PeerInfo, 'name'>,
+    auth?: AuthContext
+  ): Promise<{ success: true } | { success: false; error: string }>
 }
 
 export interface PeerConnection {
-    open(peer: PeerInfo): Promise<{ success: true } | { success: false; error: string }>
-    close(
-        peer: PeerInfo,
-        code: number,
-        reason?: string
-    ): Promise<{ success: true } | { success: false; error: string }>
-    update(
-        peer: PeerInfo,
-        update: z.infer<typeof UpdateMessageSchema>
-    ): Promise<{ success: true } | { success: false; error: string }>
+  open(peer: PeerInfo): Promise<{ success: true } | { success: false; error: string }>
+  close(
+    peer: PeerInfo,
+    code: number,
+    reason?: string
+  ): Promise<{ success: true } | { success: false; error: string }>
+  update(
+    peer: PeerInfo,
+    update: z.infer<typeof UpdateMessageSchema>
+  ): Promise<{ success: true } | { success: false; error: string }>
 }
 
+
 export function getHttpPeerSession<API extends RpcCompatible<API>>(endpoint: string) {
-    return newHttpBatchRpcSession<API>(endpoint)
+  return newHttpBatchRpcSession<API>(endpoint)
 }
 
 export function getWebSocketPeerSession<API extends RpcCompatible<API>>(endpoint: string) {
-    return newWebSocketRpcSession<API>(endpoint)
+  return newWebSocketRpcSession<API>(endpoint)
 }
 
 export class ConnectionPool {
-    private stubs: Map<string, RpcStub<PublicApi>>
-    constructor(private type: 'ws' | 'http' = 'http') {
-        this.stubs = new Map<string, RpcStub<PublicApi>>()
-    }
+  private stubs: Map<string, RpcStub<PublicApi>>
+  constructor(private type: 'ws' | 'http' = 'http') {
+    this.stubs = new Map<string, RpcStub<PublicApi>>()
+  }
 
-    get(endpoint: string) {
-        if (this.stubs.has(endpoint)) {
-            return this.stubs.get(endpoint)
-        }
-        switch (this.type) {
-            case 'http': {
-                const stub = newHttpBatchRpcSession<PublicApi>(endpoint)
-                this.stubs.set(endpoint, stub)
-                return stub
-            }
-            case 'ws': {
-                const stub = newWebSocketRpcSession<PublicApi>(endpoint)
-                this.stubs.set(endpoint, stub)
-                return stub
-            }
-        }
+  get(endpoint: string) {
+    if (this.stubs.has(endpoint)) {
+      return this.stubs.get(endpoint)
     }
+    switch (this.type) {
+      case 'http': {
+        const stub = newHttpBatchRpcSession<PublicApi>(endpoint)
+        this.stubs.set(endpoint, stub)
+        return stub
+      }
+      case 'ws': {
+        const stub = newWebSocketRpcSession<PublicApi>(endpoint)
+        this.stubs.set(endpoint, stub)
+        return stub
+      }
+    }
+  }
+}
+
+export interface OrchestratorConfig {
+  node: PeerInfo
+  ibgp?: {
+    secret?: string
+  }
 }
 
 export class CatalystNodeBus extends RpcTarget {
-    private state: RouteTable
-    private connectionPool: ConnectionPool
-    private config?: { ibgp?: { secret?: string } }
+  private state: RouteTable
+  private connectionPool: ConnectionPool
+  private config: OrchestratorConfig
 
-    constructor(opts: {
-        state?: RouteTable
-        connectionPool?: { type?: 'ws' | 'http'; pool?: ConnectionPool }
-        config?: { ibgp?: { secret?: string } }
-    }) {
-        super()
-        this.state = opts.state ?? newRouteTable()
-        this.config = opts.config
-        this.connectionPool =
-            opts.connectionPool?.pool ??
-            (opts.connectionPool?.type
-                ? new ConnectionPool(opts.connectionPool.type)
-                : new ConnectionPool())
+  constructor(opts: {
+    state?: RouteTable
+    connectionPool?: { type?: 'ws' | 'http'; pool?: ConnectionPool }
+    config: OrchestratorConfig
+  }) {
+    super()
+    this.state = opts.state ?? newRouteTable()
+    this.config = opts.config
+    this.connectionPool =
+      opts.connectionPool?.pool ??
+      (opts.connectionPool?.type ? new ConnectionPool(opts.connectionPool.type) : new ConnectionPool())
+  }
+
+  async dispatch(
+    sentAction: Action,
+    auth?: AuthContext
+  ): Promise<{ success: true } | { success: false; error: string }> {
+    // Validate and default to anonymous context
+    const resolvedAuth: AuthContext = auth ? AuthContextSchema.parse(auth) : { userId: 'anonymous', roles: [] }
+
+    const prevState = this.state
+    const result = await this.handleAction(sentAction, this.state, resolvedAuth)
+    if (result.success) {
+      this.state = result.state
+      // Fire notifications/side-effects after state update
+      await this.handleNotify(sentAction, result.state, prevState, resolvedAuth)
+      return { success: true }
+    }
+    return result
+  }
+
+  async handleAction(
+    action: Action,
+    state: RouteTable,
+    auth: AuthContext
+  ): Promise<{ success: true; state: RouteTable } | { success: false; error: string }> {
+    // Permission check - single enforcement point
+    const permission = getRequiredPermission(action)
+    if (!hasPermission(auth.roles, permission)) {
+      return { success: false, error: `Permission denied: ${permission}` }
     }
 
-    async dispatch(
-        sentAction: Action
-    ): Promise<{ success: true } | { success: false; error: string }> {
-        const prevState = this.state
-        const result = await this.handleAction(sentAction, this.state)
-        if (result.success) {
-            this.state = result.state
-            await this.handleNotify(sentAction, result.state, prevState)
-            return { success: true }
-        }
-        return result
-    }
-
-    async handleAction(
-        action: Action,
-        state: RouteTable
-    ): Promise<{ success: true; state: RouteTable } | { success: false; error: string }> {
-        switch (action.action) {
-            case 'local:peer:create': {
-                const peerList = state.internal.peers
-                if (peerList.find((p) => p.name === action.data.name)) {
-                    return { success: false, error: 'Peer already exists' }
-                }
-
-                state = {
-                    ...state,
-                    internal: {
-                        routes: state.internal.routes,
-                        peers: [
-                            ...state.internal.peers,
-                            {
-                                name: action.data.name,
-                                endpoint: action.data.endpoint,
-                                domains: action.data.domains,
-                                connectionStatus: 'initializing' as const,
-                                lastConnected: undefined,
-                            },
-                        ],
-                    },
-                }
-                break
-            }
-            case 'local:peer:update': {
-                const peerList = state.internal.peers
-                const peer = peerList.find((p) => p.name === action.data.name)
-                if (!peer) {
-                    return { success: false, error: 'Peer not found' }
-                }
-                state = {
-                    ...state,
-                    internal: {
-                        routes: state.internal.routes,
-                        peers: peerList.map((p) =>
-                            p.name === action.data.name
-                                ? {
-                                    ...p,
-                                    endpoint: action.data.endpoint,
-                                    domains: action.data.domains,
-                                    connectionStatus: 'initializing',
-                                    lastConnected: undefined,
-                                }
-                                : p
-                        ),
-                    },
-                }
-                break
-            }
-            case 'local:peer:delete': {
-                const peerList = state.internal.peers
-                const peer = peerList.find((p) => p.name === action.data.name)
-                if (!peer) {
-                    return { success: false, error: 'Peer not found' }
-                }
-                state = {
-                    ...state,
-                    internal: {
-                        routes: state.internal.routes,
-                        peers: peerList.filter((p) => p.name !== action.data.name),
-                    },
-                }
-                break
-            }
-            case 'internal:protocol:close': {
-                const peerList = state.internal.peers
-                const peer = peerList.find(p => p.name === action.data.peerInfo.name)
-                if (peer) {
-                    state = {
-                        ...state,
-                        internal: {
-                            routes: state.internal.routes.filter(r => r.peerName !== action.data.peerInfo.name),
-                            peers: peerList.filter(p => p.name !== action.data.peerInfo.name)
-                        }
-                    }
-                }
-                break
-            }
-            case 'internal:protocol:open': {
-                const peer = state.internal.peers.find(p => p.name === action.data.peerInfo.name)
-                if (!peer) {
-                    return { success: false, error: `Peer '${action.data.peerInfo.name}' is not configured on this node` }
-                }
-
-                if (peer.connectionStatus !== 'connected') {
-                    state = {
-                        ...state,
-                        internal: {
-                            ...state.internal,
-                            peers: state.internal.peers.map(p => p.name === action.data.peerInfo.name ? { ...p, connectionStatus: 'connected' } : p)
-                        }
-                    }
-                }
-                break
-            }
-            case 'internal:protocol:connected': {
-                const peerList = state.internal.peers
-                const peer = peerList.find((p) => p.name === action.data.peerInfo.name)
-                if (peer) {
-                    state = {
-                        ...state,
-                        internal: {
-                            ...state.internal,
-                            peers: state.internal.peers.map(p => p.name === action.data.peerInfo.name ? { ...p, connectionStatus: 'connected' } : p)
-                        }
-                    }
-                }
-                break
-            }
-            case 'local:route:create': {
-                if (state.local.routes.find(r => r.name === action.data.name)) {
-                    return { success: false, error: 'Route already exists' }
-                }
-                state = {
-                    ...state,
-                    local: {
-                        ...state.local,
-                        routes: [...state.local.routes, action.data]
-                    }
-                }
-                break
-            }
-            case 'local:route:delete': {
-                if (!state.local.routes.find(r => r.name === action.data.name)) {
-                    return { success: false, error: 'Route not found' }
-                }
-                state = {
-                    ...state,
-                    local: {
-                        ...state.local,
-                        routes: state.local.routes.filter(r => r.name !== action.data.name)
-                    }
-                }
-                break
-            }
-            case 'internal:protocol:update': {
-                const peerInfo = action.data.peerInfo
-                let currentInternalRoutes = [...state.internal.routes]
-
-                for (const update of action.data.update.updates) {
-                    if (update.action === 'add') {
-                        const routeToAdd = { ...update.route, peer: peerInfo, peerName: peerInfo.name }
-                        currentInternalRoutes = currentInternalRoutes.filter(r => !(r.name === update.route.name && r.peerName === peerInfo.name))
-                        currentInternalRoutes.push(routeToAdd)
-                    } else if (update.action === 'remove') {
-                        currentInternalRoutes = currentInternalRoutes.filter(r => !(r.name === update.route.name && r.peerName === peerInfo.name))
-                    }
-                }
-
-                state = {
-                    ...state,
-                    internal: {
-                        ...state.internal,
-                        routes: currentInternalRoutes,
-                    },
-                }
-                break
-            }
-            default: {
-                console.log('Unknown action', action)
-                break
-            }
+    switch (action.action) {
+      case Actions.LocalPeerCreate: {
+        const peerList = state.internal.peers
+        if (peerList.find((p) => p.name === action.data.name)) {
+          return { success: false, error: 'Peer already exists' }
         }
 
-        return { success: true, state }
-    }
-
-    async handleNotify(
-        action: Action,
-        _state: RouteTable,
-        prevState: RouteTable
-    ): Promise<void> {
-        switch (action.action) {
-            case 'local:peer:create': {
-                try {
-                    const stub = this.connectionPool.get(action.data.endpoint)
-                    if (stub) {
-                        const connectionResult = await stub.getPeerConnection("secret")
-                        if (connectionResult.success) {
-                            const result = await connectionResult.connection.open(this.myself)
-                            if (result.success) {
-                                await this.dispatch({
-                                    action: 'internal:protocol:connected',
-                                    data: { peerInfo: action.data }
-                                })
-                            }
-                        }
-                    }
-                } catch (e) {
-                    console.error(`[${this.myself.name}] Failed to open connection to ${action.data.name}`, e)
-                }
-                break
-            }
-            case 'internal:protocol:open': {
-                for (const route of _state.local.routes) {
-                    try {
-                        const stub = this.connectionPool.get(action.data.peerInfo.endpoint)
-                        if (stub) {
-                            const connectionResult = await stub.getPeerConnection("secret")
-                            if (connectionResult.success) {
-                                await connectionResult.connection.update(this.myself, {
-                                    updates: [{ action: 'add', route }]
-                                })
-                            }
-                        }
-                    } catch (e) {
-                        console.error(`[${this.myself.name}] Failed to sync route back to ${action.data.peerInfo.name}`, e)
-                    }
-                }
-                break
-            }
-            case 'internal:protocol:connected': {
-                for (const route of _state.local.routes) {
-                    try {
-                        const stub = this.connectionPool.get(action.data.peerInfo.endpoint)
-                        if (stub) {
-                            const connectionResult = await stub.getPeerConnection("secret")
-                            if (connectionResult.success) {
-                                await connectionResult.connection.update(this.myself, {
-                                    updates: [{ action: 'add', route }]
-                                })
-                            }
-                        }
-                    } catch (e) {
-                        console.error(`[${this.myself.name}] Failed to sync route to ${action.data.peerInfo.name}`, e)
-                    }
-                }
-                break
-            }
-            case 'local:peer:delete': {
-                const peer = prevState.internal.peers.find(p => p.name === action.data.name)
-                if (peer) {
-                    try {
-                        const stub = this.connectionPool.get(peer.endpoint)
-                        if (stub) {
-                            const connectionResult = await stub.getPeerConnection("secret")
-                            if (connectionResult.success) {
-                                await connectionResult.connection.close(this.myself, 1000, "Peer removed")
-                            }
-                        }
-                    } catch (e) {
-                        console.error(`[${this.myself.name}] Failed to close connection to ${peer.name}`, e)
-                    }
-                }
-                break
-            }
-            case 'local:route:create': {
-                for (const peer of _state.internal.peers.filter(p => p.connectionStatus === 'connected')) {
-                    try {
-                        const stub = this.connectionPool.get(peer.endpoint)
-                        if (stub) {
-                            const connectionResult = await stub.getPeerConnection("secret")
-                            if (connectionResult.success) {
-                                await connectionResult.connection.update(this.myself, {
-                                    updates: [{ action: 'add', route: action.data }]
-                                })
-                            }
-                        }
-                    } catch (e) {
-                        console.error(`[${this.myself.name}] Failed to broadcast route to ${peer.name}`, e)
-                    }
-                }
-                break
-            }
-            case 'local:route:delete': {
-                for (const peer of _state.internal.peers.filter(p => p.connectionStatus === 'connected')) {
-                    try {
-                        const stub = this.connectionPool.get(peer.endpoint)
-                        if (stub) {
-                            const connectionResult = await stub.getPeerConnection("secret")
-                            if (connectionResult.success) {
-                                await connectionResult.connection.update(this.myself, {
-                                    updates: [{ action: 'remove', route: action.data }]
-                                })
-                            }
-                        }
-                    } catch (e) {
-                        console.error(`[${this.myself.name}] Failed to broadcast route removal to ${peer.name}`, e)
-                    }
-                }
-                break
-            }
-            case 'internal:protocol:update': {
-                const sourcePeerName = action.data.peerInfo.name
-                for (const peer of _state.internal.peers.filter(p => p.connectionStatus === 'connected' && p.name !== sourcePeerName)) {
-                    try {
-                        const stub = this.connectionPool.get(peer.endpoint)
-                        if (stub) {
-                            const connectionResult = await stub.getPeerConnection("secret")
-                            if (connectionResult.success) {
-                                await connectionResult.connection.update(this.myself, action.data.update)
-                            }
-                        }
-                    } catch (e) {
-                        console.error(`[${this.myself.name}] Failed to propagate update to ${peer.name}`, e)
-                    }
-                }
-                break
-            }
+        // Optimistically add peer as initializing
+        const newState = {
+          ...state,
+          internal: {
+            routes: state.internal.routes,
+            peers: [
+              ...state.internal.peers,
+              {
+                name: action.data.name,
+                endpoint: action.data.endpoint,
+                domains: action.data.domains,
+                connectionStatus: 'initializing' as const,
+                lastConnected: undefined,
+              },
+            ],
+          },
         }
+
+        state = newState
+        break
+      }
+      case Actions.LocalPeerUpdate: {
+        const peerList = state.internal.peers
+        const peer = peerList.find((p) => p.name === action.data.name)
+        if (!peer) {
+          return { success: false, error: 'Peer not found' }
+        }
+        state = {
+          ...state,
+          internal: {
+            routes: state.internal.routes,
+            peers: peerList.map((p) =>
+              p.name === action.data.name
+                ? {
+                  ...p,
+                  endpoint: action.data.endpoint,
+                  domains: action.data.domains,
+                  connectionStatus: 'initializing',
+                  lastConnected: undefined,
+                }
+                : p
+            ),
+          },
+        }
+        break
+      }
+      case Actions.LocalPeerDelete: {
+        const peerList = state.internal.peers
+        const peer = peerList.find((p) => p.name === action.data.name)
+        if (!peer) {
+          return { success: false, error: 'Peer not found' }
+        }
+        state = {
+          ...state,
+          internal: {
+            routes: state.internal.routes,
+            peers: peerList.filter((p) => p.name !== action.data.name),
+          },
+        }
+        break
+      }
+      case Actions.InternalProtocolClose: {
+        const peerList = state.internal.peers
+        // Find peer by matching info from sender
+        const peer = peerList.find((p) => p.name === action.data.peerInfo.name)
+
+        // If found, remove it. If not found, it's already gone or never existed.
+        if (peer) {
+          state = {
+            ...state,
+            internal: {
+              routes: state.internal.routes.filter((r) => r.peerName !== action.data.peerInfo.name),
+              peers: peerList.filter((p) => p.name !== action.data.peerInfo.name),
+            },
+          }
+        }
+        break
+      }
+      case Actions.InternalProtocolOpen: {
+        const peer = state.internal.peers.find((p) => p.name === action.data.peerInfo.name)
+        if (!peer) {
+          return {
+            success: false,
+            error: `Peer '${action.data.peerInfo.name}' is not configured on this node`,
+          }
+        }
+
+        if (peer.connectionStatus !== 'connected') {
+          state = {
+            ...state,
+            internal: {
+              ...state.internal,
+              peers: state.internal.peers.map((p) =>
+                p.name === action.data.peerInfo.name ? { ...p, connectionStatus: 'connected' } : p
+              ),
+            },
+          }
+        }
+        break
+      }
+      case Actions.InternalProtocolConnected: {
+        const peerList = state.internal.peers
+        const peer = peerList.find((p) => p.name === action.data.peerInfo.name)
+        if (peer) {
+          state = {
+            ...state,
+            internal: {
+              ...state.internal,
+              peers: state.internal.peers.map((p) =>
+                p.name === action.data.peerInfo.name ? { ...p, connectionStatus: 'connected' } : p
+              ),
+            },
+          }
+        }
+        break
+      }
+      case Actions.LocalRouteCreate: {
+        // Check if route already exists
+        if (state.local.routes.find((r) => r.name === action.data.name)) {
+          return { success: false, error: 'Route already exists' }
+        }
+        state = {
+          ...state,
+          local: {
+            ...state.local,
+            routes: [...state.local.routes, action.data],
+          },
+        }
+        break
+      }
+      case Actions.LocalRouteDelete: {
+        // Check if route exists
+        if (!state.local.routes.find((r) => r.name === action.data.name)) {
+          return { success: false, error: 'Route not found' }
+        }
+        state = {
+          ...state,
+          local: {
+            ...state.local,
+            routes: state.local.routes.filter((r) => r.name !== action.data.name),
+          },
+        }
+        break
+      }
+      case Actions.InternalProtocolUpdate: {
+        const peerInfo = action.data.peerInfo
+        let currentInternalRoutes = [...state.internal.routes]
+
+        for (const update of action.data.update.updates) {
+          if (update.action === 'add') {
+            // Add if not exists (keyed by route name + peer name)
+
+            const routeToAdd = { ...update.route, peer: peerInfo, peerName: peerInfo.name }
+
+            // Remove existing if any (upsert)
+            currentInternalRoutes = currentInternalRoutes.filter(
+              (r) => !(r.name === update.route.name && r.peerName === peerInfo.name)
+            )
+            currentInternalRoutes.push(routeToAdd)
+          } else if (update.action === 'remove') {
+            currentInternalRoutes = currentInternalRoutes.filter(
+              (r) => !(r.name === update.route.name && r.peerName === peerInfo.name)
+            )
+          }
+        }
+
+        state = {
+          ...state,
+          internal: {
+            ...state.internal,
+            routes: currentInternalRoutes,
+          },
+        }
+        break
+      }
+      default: {
+        console.log('Unknown action', action)
+        break
+      }
     }
 
-    publicApi(): PublicApi {
+    return { success: true, state }
+  }
+
+  /**
+   * Handle side effects after state changes.
+   */
+  async handleNotify(
+    action: Action,
+    _state: RouteTable,
+    prevState: RouteTable,
+    auth: AuthContext
+  ): Promise<void> {
+    switch (action.action) {
+      case Actions.LocalPeerCreate: {
+        // Perform side effect: Try to open connection
+        try {
+          const stub = this.connectionPool.get(action.data.endpoint)
+          if (stub) {
+            const connectionResult = await stub.getPeerConnection('secret')
+            if (connectionResult.success) {
+              const result = await connectionResult.connection.open(this.config.node)
+
+              if (result.success) {
+                // Dispatch connected action with inherited auth
+                await this.dispatch(
+                  {
+                    action: Actions.InternalProtocolConnected,
+                    data: { peerInfo: action.data },
+                  },
+                  auth
+                )
+              }
+            } else {
+              console.error('Failed to get peer connection', connectionResult.error)
+            }
+          }
+        } catch (e) {
+          // Connection failed, leave as initializing (or could transition to error state)
+          console.error(`[${this.config.node.name}] Failed to open connection to ${action.data.name}`, e)
+        }
+        break
+      }
+      case Actions.InternalProtocolOpen: {
+        // Sync existing local routes back to the new peer
+        for (const route of _state.local.routes) {
+          try {
+            const stub = this.connectionPool.get(action.data.peerInfo.endpoint)
+            if (stub) {
+              const connectionResult = await stub.getPeerConnection('secret')
+              if (connectionResult.success) {
+                await connectionResult.connection.update(this.config.node, {
+                  updates: [{ action: 'add', route }],
+                })
+              }
+            }
+          } catch (e) {
+            console.error(`[${this.config.node.name}] Failed to sync route back to ${action.data.peerInfo.name}`, e)
+          }
+        }
+        break
+      }
+      case Actions.InternalProtocolConnected: {
+        // Sync existing local routes to the new peer
+        for (const route of _state.local.routes) {
+          try {
+            const stub = this.connectionPool.get(action.data.peerInfo.endpoint)
+            if (stub) {
+              const connectionResult = await stub.getPeerConnection('secret')
+              if (connectionResult.success) {
+                await connectionResult.connection.update(this.config.node, {
+                  updates: [{ action: 'add', route }],
+                })
+              }
+            }
+          } catch (e) {
+            console.error(`[${this.config.node.name}] Failed to sync route to ${action.data.peerInfo.name}`, e)
+          }
+        }
+        break
+      }
+      case Actions.LocalPeerDelete: {
+        // Use prevState to find the peer info that was just deleted
+        const peer = prevState.internal.peers.find((p) => p.name === action.data.name)
+        if (peer) {
+          try {
+            const stub = this.connectionPool.get(peer.endpoint)
+            if (stub) {
+              const connectionResult = await stub.getPeerConnection('secret')
+              if (connectionResult.success) {
+                await connectionResult.connection.close(this.config.node, 1000, 'Peer removed')
+              }
+            }
+          } catch (e) {
+            console.error(`[${this.config.node.name}] Failed to close connection to ${peer.name}`, e)
+          }
+        }
+        break
+      }
+      case Actions.LocalRouteCreate: {
+        for (const peer of _state.internal.peers.filter((p) => p.connectionStatus === 'connected')) {
+          try {
+            const stub = this.connectionPool.get(peer.endpoint)
+            if (stub) {
+              const connectionResult = await stub.getPeerConnection('secret')
+              if (connectionResult.success) {
+                await connectionResult.connection.update(this.config.node, {
+                  updates: [{ action: 'add', route: action.data }],
+                })
+              }
+            }
+          } catch (e) {
+            console.error(`[${this.config.node.name}] Failed to broadcast route to ${peer.name}`, e)
+          }
+        }
+        break
+      }
+      case Actions.LocalRouteDelete: {
+        for (const peer of _state.internal.peers.filter((p) => p.connectionStatus === 'connected')) {
+          try {
+            const stub = this.connectionPool.get(peer.endpoint)
+            if (stub) {
+              const connectionResult = await stub.getPeerConnection('secret')
+              if (connectionResult.success) {
+                await connectionResult.connection.update(this.config.node, {
+                  updates: [{ action: 'remove', route: action.data }],
+                })
+              }
+            }
+          } catch (e) {
+            console.error(`[${this.config.node.name}] Failed to broadcast route removal to ${peer.name}`, e)
+          }
+        }
+        break
+      }
+      case Actions.InternalProtocolUpdate: {
+        const sourcePeerName = action.data.peerInfo.name
+        for (const peer of _state.internal.peers.filter(
+          (p) => p.connectionStatus === 'connected' && p.name !== sourcePeerName
+        )) {
+          try {
+            const stub = this.connectionPool.get(peer.endpoint)
+            if (stub) {
+              const connectionResult = await stub.getPeerConnection('secret')
+              if (connectionResult.success) {
+                await connectionResult.connection.update(this.config.node, action.data.update)
+              }
+            }
+          } catch (e) {
+            console.error(`[${this.config.node.name}] Failed to propagate update to ${peer.name}`, e)
+          }
+        }
+        break
+      }
+    }
+  }
+
+  publicApi(): PublicApi {
+    return {
+      getManagerConnection: (): PeerManager => {
         return {
-            getManagerConnection: (): PeerManager => {
-                return {
-                    addPeer: async (peer: PeerInfo) => {
-                        return this.dispatch({
-                            action: 'local:peer:create',
-                            data: peer,
-                        })
-                    },
-                    updatePeer: async (peer: PeerInfo) => {
-                        return this.dispatch({
-                            action: 'local:peer:update',
-                            data: peer,
-                        })
-                    },
-                    removePeer: async (peer: Pick<PeerInfo, 'name'>) => {
-                        return this.dispatch({
-                            action: 'local:peer:delete',
-                            data: peer,
-                        })
-                    },
-                }
-            },
-            getPeerConnection: (
-                _secret: string
-            ): { success: true; connection: PeerConnection } | { success: false; error: string } => {
-                return {
-                    success: true,
-                    connection: {
-                        open: async (peer: PeerInfo) => {
-                            return this.dispatch({
-                                action: 'internal:protocol:open',
-                                data: { peerInfo: peer }
-                            })
-                        },
-                        close: async (peer: PeerInfo, code: number, reason?: string) => {
-                            return this.dispatch({
-                                action: 'internal:protocol:close',
-                                data: { peerInfo: peer, code, reason }
-                            })
-                        },
-                        update: async (peer: PeerInfo, update: z.infer<typeof UpdateMessageSchema>) => {
-                            return this.dispatch({
-                                action: 'internal:protocol:update',
-                                data: {
-                                    peerInfo: peer,
-                                    update: update
-                                }
-                            })
-                        },
-                    },
-                }
-            },
-            getInspector: (): Inspector => {
-                return {
-                    listPeers: async () => this.state.internal.peers,
-                    listRoutes: async () => ({
-                        local: this.state.local.routes,
-                        internal: this.state.internal.routes
-                    }),
-                }
-            },
-            dispatch: async (action: Action) => {
-                return this.dispatch(action)
-            },
+          addPeer: async (peer: PeerInfo, auth?: AuthContext) => {
+            return this.dispatch({ action: Actions.LocalPeerCreate, data: peer }, auth)
+          },
+          updatePeer: async (peer: PeerInfo, auth?: AuthContext) => {
+            return this.dispatch({ action: Actions.LocalPeerUpdate, data: peer }, auth)
+          },
+          removePeer: async (peer: Pick<PeerInfo, 'name'>, auth?: AuthContext) => {
+            return this.dispatch({ action: Actions.LocalPeerDelete, data: peer }, auth)
+          },
         }
+      },
+      getPeerConnection: (
+        _secret: string
+      ): { success: true; connection: PeerConnection } | { success: false; error: string } => {
+        return {
+          success: true,
+          connection: {
+            open: async (peer: PeerInfo) => {
+              return this.dispatch({
+                action: Actions.InternalProtocolOpen,
+                data: { peerInfo: peer },
+              })
+            },
+            close: async (peer: PeerInfo, code: number, reason?: string) => {
+              return this.dispatch({
+                action: Actions.InternalProtocolClose,
+                data: { peerInfo: peer, code, reason },
+              })
+            },
+            update: async (peer: PeerInfo, update: z.infer<typeof UpdateMessageSchema>) => {
+              return this.dispatch({
+                action: Actions.InternalProtocolUpdate,
+                data: {
+                  peerInfo: peer,
+                  update: update,
+                },
+              })
+            },
+          },
+        }
+      },
+      getInspector: (): Inspector => {
+        return {
+          listPeers: async () => this.state.internal.peers,
+          listRoutes: async () => ({
+            local: this.state.local.routes,
+            internal: this.state.internal.routes,
+          }),
+        }
+      },
+      dispatch: async (action: Action) => {
+        return this.dispatch(action)
+      },
     }
+  }
 }

--- a/packages/orchestrator/src/next/permissions.test.ts
+++ b/packages/orchestrator/src/next/permissions.test.ts
@@ -1,50 +1,61 @@
 import { describe, it, expect } from 'bun:test'
 import { getRequiredPermission, hasPermission, isSecretValid } from './permissions'
 import type { Action } from './schema'
+import { Actions } from './action-types'
 
 describe('getRequiredPermission', () => {
-  it('should return peer:create for local:peer:create', () => {
-    expect(getRequiredPermission({ action: 'local:peer:create', data: {} })).toBe('peer:create')
-  })
-
-  it('should return peer:update for local:peer:update', () => {
-    expect(getRequiredPermission({ action: 'local:peer:update', data: {} })).toBe('peer:update')
-  })
-
-  it('should return peer:delete for local:peer:delete', () => {
-    expect(getRequiredPermission({ action: 'local:peer:delete', data: {} })).toBe('peer:delete')
-  })
-
-  it('should return route:create for local:route:create', () => {
-    expect(getRequiredPermission({ action: 'local:route:create', data: {} })).toBe('route:create')
-  })
-
-  it('should return route:delete for local:route:delete', () => {
-    expect(getRequiredPermission({ action: 'local:route:delete', data: {} })).toBe('route:delete')
-  })
-
-  it('should return ibgp:connect for internal:protocol:open', () => {
-    expect(getRequiredPermission({ action: 'internal:protocol:open', data: {} })).toBe(
-      'ibgp:connect'
+  it('should return peer:create for LocalPeerCreate', () => {
+    expect(getRequiredPermission({ action: Actions.LocalPeerCreate, data: {} } as Action)).toBe(
+      'peer:create'
     )
   })
 
-  it('should return ibgp:disconnect for internal:protocol:close', () => {
-    expect(getRequiredPermission({ action: 'internal:protocol:close', data: {} })).toBe(
-      'ibgp:disconnect'
+  it('should return peer:update for LocalPeerUpdate', () => {
+    expect(getRequiredPermission({ action: Actions.LocalPeerUpdate, data: {} } as Action)).toBe(
+      'peer:update'
     )
   })
 
-  it('should return ibgp:connect for internal:protocol:connected', () => {
-    expect(getRequiredPermission({ action: 'internal:protocol:connected', data: {} })).toBe(
-      'ibgp:connect'
+  it('should return peer:delete for LocalPeerDelete', () => {
+    expect(getRequiredPermission({ action: Actions.LocalPeerDelete, data: {} } as Action)).toBe(
+      'peer:delete'
     )
   })
 
-  it('should return ibgp:update for internal:protocol:update', () => {
-    expect(getRequiredPermission({ action: 'internal:protocol:update', data: {} })).toBe(
-      'ibgp:update'
+  it('should return route:create for LocalRouteCreate', () => {
+    expect(getRequiredPermission({ action: Actions.LocalRouteCreate, data: {} } as Action)).toBe(
+      'route:create'
     )
+  })
+
+  it('should return route:delete for LocalRouteDelete', () => {
+    expect(getRequiredPermission({ action: Actions.LocalRouteDelete, data: {} } as Action)).toBe(
+      'route:delete'
+    )
+  })
+
+  it('should return ibgp:connect for InternalProtocolOpen', () => {
+    expect(
+      getRequiredPermission({ action: Actions.InternalProtocolOpen, data: {} } as Action)
+    ).toBe('ibgp:connect')
+  })
+
+  it('should return ibgp:disconnect for InternalProtocolClose', () => {
+    expect(
+      getRequiredPermission({ action: Actions.InternalProtocolClose, data: {} } as Action)
+    ).toBe('ibgp:disconnect')
+  })
+
+  it('should return ibgp:connect for InternalProtocolConnected', () => {
+    expect(
+      getRequiredPermission({ action: Actions.InternalProtocolConnected, data: {} } as Action)
+    ).toBe('ibgp:connect')
+  })
+
+  it('should return ibgp:update for InternalProtocolUpdate', () => {
+    expect(
+      getRequiredPermission({ action: Actions.InternalProtocolUpdate, data: {} } as Action)
+    ).toBe('ibgp:update')
   })
 
   it('should return * for unknown action types', () => {

--- a/packages/orchestrator/src/next/permissions.ts
+++ b/packages/orchestrator/src/next/permissions.ts
@@ -1,5 +1,6 @@
 import { timingSafeEqual } from 'node:crypto'
 import type { Action } from './schema.js'
+import { Actions } from './action-types.js'
 
 /**
  * Permission types for RBAC.
@@ -21,15 +22,15 @@ export type Permission =
  * Unknown actions require '*' (admin only).
  */
 const ACTION_PERMISSION_MAP: Record<string, Permission> = {
-  'local:peer:create': 'peer:create',
-  'local:peer:update': 'peer:update',
-  'local:peer:delete': 'peer:delete',
-  'local:route:create': 'route:create',
-  'local:route:delete': 'route:delete',
-  'internal:protocol:open': 'ibgp:connect',
-  'internal:protocol:close': 'ibgp:disconnect',
-  'internal:protocol:connected': 'ibgp:connect',
-  'internal:protocol:update': 'ibgp:update',
+  [Actions.LocalPeerCreate]: 'peer:create',
+  [Actions.LocalPeerUpdate]: 'peer:update',
+  [Actions.LocalPeerDelete]: 'peer:delete',
+  [Actions.LocalRouteCreate]: 'route:create',
+  [Actions.LocalRouteDelete]: 'route:delete',
+  [Actions.InternalProtocolOpen]: 'ibgp:connect',
+  [Actions.InternalProtocolClose]: 'ibgp:disconnect',
+  [Actions.InternalProtocolConnected]: 'ibgp:connect',
+  [Actions.InternalProtocolUpdate]: 'ibgp:update',
 }
 
 /**

--- a/packages/orchestrator/src/next/routing/internal/actions.ts
+++ b/packages/orchestrator/src/next/routing/internal/actions.ts
@@ -1,51 +1,51 @@
-import { z } from "zod";
-import { PeerInfoSchema } from "../state.js";
+import { z } from 'zod'
+import { PeerInfoSchema } from '../state.js'
+import { DataChannelDefinitionSchema } from '../datachannel.js'
+import { Actions } from '../../action-types.js'
 
-// Action Types
-export const internalProtocolOpenAction = z.literal("internal:protocol:open");
-export const internalProtocolUpdateAction = z.literal("internal:protocol:update");
-export const internalProtocolCloseAction = z.literal("internal:protocol:close");
-
-// Data Schemas
-import { DataChannelDefinitionSchema } from "../datachannel.js";
+// Re-export for backward compatibility with existing imports
+export const internalProtocolOpenAction = z.literal(Actions.InternalProtocolOpen)
+export const internalProtocolUpdateAction = z.literal(Actions.InternalProtocolUpdate)
+export const internalProtocolCloseAction = z.literal(Actions.InternalProtocolClose)
+export const internalProtocolConnectedAction = z.literal(Actions.InternalProtocolConnected)
 
 // Data Schemas
 export const UpdateMessageSchema = z.object({
-    updates: z.array(z.object({
-        action: z.enum(['add', 'remove']),
-        route: DataChannelDefinitionSchema
-    }))
-});
+  updates: z.array(
+    z.object({
+      action: z.enum(['add', 'remove']),
+      route: DataChannelDefinitionSchema,
+    })
+  ),
+})
 
 export const InternalProtocolOpenMessageSchema = z.object({
-    action: internalProtocolOpenAction,
-    data: z.object({
-        peerInfo: PeerInfoSchema
-    })
-});
+  action: z.literal(Actions.InternalProtocolOpen),
+  data: z.object({
+    peerInfo: PeerInfoSchema,
+  }),
+})
 
 export const InternalProtocolUpdateMessageSchema = z.object({
-    action: internalProtocolUpdateAction,
-    data: z.object({
-        peerInfo: PeerInfoSchema,
-        update: UpdateMessageSchema
-    })
-});
+  action: z.literal(Actions.InternalProtocolUpdate),
+  data: z.object({
+    peerInfo: PeerInfoSchema,
+    update: UpdateMessageSchema,
+  }),
+})
 
 export const InternalProtocolCloseMessageSchema = z.object({
-    action: internalProtocolCloseAction,
-    data: z.object({
-        peerInfo: PeerInfoSchema,
-        code: z.number(),
-        reason: z.string().optional()
-    })
-});
-
-export const internalProtocolConnectedAction = z.literal("internal:protocol:connected");
+  action: z.literal(Actions.InternalProtocolClose),
+  data: z.object({
+    peerInfo: PeerInfoSchema,
+    code: z.number(),
+    reason: z.string().optional(),
+  }),
+})
 
 export const InternalProtocolConnectedMessageSchema = z.object({
-    action: internalProtocolConnectedAction,
-    data: z.object({
-        peerInfo: PeerInfoSchema
-    })
-});
+  action: z.literal(Actions.InternalProtocolConnected),
+  data: z.object({
+    peerInfo: PeerInfoSchema,
+  }),
+})

--- a/packages/orchestrator/src/next/routing/local/actions.ts
+++ b/packages/orchestrator/src/next/routing/local/actions.ts
@@ -1,37 +1,40 @@
 import { z } from 'zod'
-import { PeerInfoSchema } from '../state'
+import { PeerInfoSchema } from '../state.js'
+import { DataChannelDefinitionSchema } from '../datachannel.js'
+import { Actions } from '../../action-types.js'
 
-export const localPeerCreateAction = z.literal('local:peer:create')
-export const localPeerUpdateAction = z.literal('local:peer:update')
-export const localPeerDeleteAction = z.literal('local:peer:delete')
-export const localRouteCreateAction = z.literal('local:route:create')
-export const localRouteDeleteAction = z.literal('local:route:delete')
+// Re-export for backward compatibility with existing imports
+export const localPeerCreateAction = z.literal(Actions.LocalPeerCreate)
+export const localPeerUpdateAction = z.literal(Actions.LocalPeerUpdate)
+export const localPeerDeleteAction = z.literal(Actions.LocalPeerDelete)
+export const localRouteCreateAction = z.literal(Actions.LocalRouteCreate)
+export const localRouteDeleteAction = z.literal(Actions.LocalRouteDelete)
 
 export const localPeerCreateMessageSchema = z.object({
-    action: localPeerCreateAction,
-    data: PeerInfoSchema,
+  action: z.literal(Actions.LocalPeerCreate),
+  data: PeerInfoSchema,
 })
 
 export const localPeerUpdateMessageSchema = z.object({
-    action: localPeerUpdateAction,
-    data: PeerInfoSchema,
+  action: z.literal(Actions.LocalPeerUpdate),
+  data: PeerInfoSchema,
 })
 
 export const localPeerDeleteMessageSchema = z.object({
-    action: localPeerDeleteAction,
-    data: z.object({
-        name: z.string(),
-    }).and(PeerInfoSchema.partial()),
+  action: z.literal(Actions.LocalPeerDelete),
+  data: z
+    .object({
+      name: z.string(),
+    })
+    .and(PeerInfoSchema.partial()),
 })
 
-import { DataChannelDefinitionSchema } from "../datachannel.js";
-
 export const localRouteCreateMessageSchema = z.object({
-    action: localRouteCreateAction,
-    data: DataChannelDefinitionSchema,
+  action: z.literal(Actions.LocalRouteCreate),
+  data: DataChannelDefinitionSchema,
 })
 
 export const localRouteDeleteMessageSchema = z.object({
-    action: localRouteDeleteAction,
-    data: DataChannelDefinitionSchema,
+  action: z.literal(Actions.LocalRouteDelete),
+  data: DataChannelDefinitionSchema,
 })


### PR DESCRIPTION
# Add Action Type Constants and Auth Threading

- Add action-types.ts with centralized Actions constants as single source of truth
- Thread AuthContext through dispatch → handleAction → handleNotify
- Add permission checks in handleAction with single enforcement point
- Add AuthContextSchema validation at dispatch entry point
- Update PeerManager interface to accept optional auth parameter
- Add Auth Threading test suite covering permission scenarios
- Update all action schemas and handlers to use Actions constants