### PR TITLE
feat(auth): add key-manager abstraction layer

### DIFF
--- a/packages/auth/src/key-manager/base.ts
+++ b/packages/auth/src/key-manager/base.ts
@@ -1,0 +1,245 @@
+import type { JSONWebKeySet } from 'jose'
+import { decodeProtectedHeader } from 'jose'
+
+import type { KeyPair } from '../keys.js'
+import { generateKeyPair, getPublicKeyJwk } from '../keys.js'
+import { signToken, verifyToken } from '../jwt.js'
+import type {
+  IKeyManager,
+  SignOptions,
+  VerifyOptions,
+  VerifyResult,
+  RotateOptions,
+  RotationResult,
+  KeyState,
+} from './types.js'
+
+/** Default grace period: 24 hours */
+const DEFAULT_GRACE_PERIOD_MS = 24 * 60 * 60 * 1000
+
+/** Managed key with expiration tracking */
+export interface ManagedKey {
+  keyPair: KeyPair
+  state: KeyState
+}
+
+/**
+ * BaseKeyManager - Abstract base class for key management implementations
+ *
+ * Provides shared logic for signing, verification, JWKS generation, and rotation.
+ * Subclasses implement persistence-specific behavior via initialize() and optional hooks.
+ */
+export abstract class BaseKeyManager implements IKeyManager {
+  protected currentKey: ManagedKey | null = null
+  protected previousKeys: ManagedKey[] = []
+  protected keysByKid: Map<string, ManagedKey> = new Map()
+  protected _initialized = false
+  protected rotationPromise: Promise<RotationResult> | null = null
+  protected readonly defaultGracePeriodMs: number
+
+  constructor(options?: { gracePeriodMs?: number }) {
+    this.defaultGracePeriodMs = options?.gracePeriodMs ?? DEFAULT_GRACE_PERIOD_MS
+  }
+
+  isInitialized(): boolean {
+    return this._initialized
+  }
+
+  /**
+   * Initialize the key manager (load or generate keys)
+   * Subclasses implement persistence-specific initialization.
+   */
+  abstract initialize(): Promise<void>
+
+  /**
+   * Shutdown the key manager, clearing all state.
+   * Subclasses can override onShutdown() for cleanup.
+   */
+  async shutdown(): Promise<void> {
+    await this.onShutdown()
+    this.currentKey = null
+    this.previousKeys = []
+    this.keysByKid.clear()
+    this._initialized = false
+  }
+
+  /**
+   * Hook for subclass-specific shutdown cleanup.
+   * Default implementation does nothing.
+   */
+  protected async onShutdown(): Promise<void> {
+    // Default: no cleanup needed
+  }
+
+  /**
+   * Hook called during rotation for persistence operations.
+   * Default implementation does nothing (suitable for in-memory managers).
+   */
+  protected async onRotate(
+    _oldKey: ManagedKey,
+    _newKey: ManagedKey,
+    _immediate: boolean
+  ): Promise<void> {
+    // Default: no persistence
+  }
+
+  async sign(options: SignOptions): Promise<string> {
+    const key = this.getCurrentKey()
+    return signToken(key.keyPair, options)
+  }
+
+  async verify(token: string, options?: VerifyOptions): Promise<VerifyResult> {
+    this.ensureInitialized('verify')
+
+    // Extract kid from token header for targeted lookup
+    const kid = this.extractKidFromToken(token)
+
+    if (kid) {
+      const managedKey = this.keysByKid.get(kid)
+      if (managedKey) {
+        // Check if key is still valid (not expired)
+        if (managedKey.state.expiresAt && Date.now() > managedKey.state.expiresAt) {
+          return { valid: false, error: 'Invalid token' }
+        }
+        return verifyToken(managedKey.keyPair, token, options)
+      }
+    }
+
+    // Fallback: try current key first, then previous keys
+    const key = this.getCurrentKey()
+    const currentResult = await verifyToken(key.keyPair, token, options)
+    if (currentResult.valid) {
+      return currentResult
+    }
+
+    // Try previous keys (only non-expired ones)
+    for (const prev of this.previousKeys) {
+      if (!prev.state.expiresAt || Date.now() < prev.state.expiresAt) {
+        const prevResult = await verifyToken(prev.keyPair, token, options)
+        if (prevResult.valid) {
+          return prevResult
+        }
+      }
+    }
+
+    return { valid: false, error: 'Invalid token' }
+  }
+
+  async getJwks(): Promise<JSONWebKeySet> {
+    const key = this.getCurrentKey()
+    const keys = []
+
+    // Current key
+    const currentJwk = await getPublicKeyJwk(key.keyPair)
+    keys.push(currentJwk)
+
+    // Previous keys (only non-expired ones)
+    for (const prev of this.previousKeys) {
+      if (!prev.state.expiresAt || Date.now() < prev.state.expiresAt) {
+        const prevJwk = await getPublicKeyJwk(prev.keyPair)
+        keys.push(prevJwk)
+      }
+    }
+
+    return { keys }
+  }
+
+  async getCurrentKeyId(): Promise<string> {
+    const key = this.getCurrentKey()
+    return key.keyPair.kid
+  }
+
+  async rotate(options?: RotateOptions): Promise<RotationResult> {
+    this.ensureInitialized('rotate')
+
+    // If rotation already in progress, return that promise.
+    // This ensures concurrent callers get the same result rather than racing.
+    if (this.rotationPromise) {
+      return this.rotationPromise
+    }
+
+    this.rotationPromise = this.doRotate(options)
+    try {
+      return await this.rotationPromise
+    } finally {
+      this.rotationPromise = null
+    }
+  }
+
+  private async doRotate(options?: RotateOptions): Promise<RotationResult> {
+    const immediate = options?.immediate ?? false
+    const gracePeriodMs = options?.gracePeriodMs ?? this.defaultGracePeriodMs
+
+    const oldKey = this.getCurrentKey()
+    const previousKeyId = oldKey.keyPair.kid
+
+    // Generate new key
+    const newKeyPair = await generateKeyPair()
+    const newKey: ManagedKey = {
+      keyPair: newKeyPair,
+      state: {
+        kid: newKeyPair.kid,
+        createdAt: Date.now(),
+      },
+    }
+
+    let gracePeriodEndsAt: Date | undefined
+
+    if (!immediate) {
+      // Keep old key with expiration
+      const expiresAt = Date.now() + gracePeriodMs
+      gracePeriodEndsAt = new Date(expiresAt)
+      oldKey.state.expiresAt = expiresAt
+      this.previousKeys.push(oldKey)
+    } else {
+      // Immediate rotation: remove old key
+      this.keysByKid.delete(previousKeyId)
+      this.previousKeys = []
+    }
+
+    // Call subclass hook for persistence
+    await this.onRotate(oldKey, newKey, immediate)
+
+    // Update state
+    this.currentKey = newKey
+    this.keysByKid.set(newKeyPair.kid, newKey)
+
+    return {
+      previousKeyId,
+      newKeyId: newKeyPair.kid,
+      gracePeriodEndsAt,
+    }
+  }
+
+  /**
+   * Get current key with type narrowing.
+   * Throws if not initialized.
+   */
+  protected getCurrentKey(): ManagedKey {
+    if (!this._initialized || !this.currentKey) {
+      throw new Error('KeyManager must be initialized before use')
+    }
+    return this.currentKey
+  }
+
+  /**
+   * Ensure the manager is initialized before operations
+   */
+  protected ensureInitialized(operation: string): void {
+    if (!this._initialized) {
+      throw new Error(`KeyManager must be initialized before calling ${operation}()`)
+    }
+  }
+
+  /**
+   * Extract kid from JWT header
+   */
+  protected extractKidFromToken(token: string): string | null {
+    try {
+      const header = decodeProtectedHeader(token)
+      return header.kid ?? null
+    } catch {
+      return null
+    }
+  }
+}

--- a/packages/auth/src/key-manager/ephemeral.ts
+++ b/packages/auth/src/key-manager/ephemeral.ts
@@ -1,0 +1,34 @@
+import { generateKeyPair } from '../keys.js'
+import { BaseKeyManager } from './base.js'
+
+/**
+ * EphemeralKeyManager - In-memory key management
+ *
+ * Keys are generated fresh on each initialization and only exist in memory.
+ */
+export class EphemeralKeyManager extends BaseKeyManager {
+  constructor(options?: { gracePeriodMs?: number }) {
+    super(options)
+  }
+
+  async initialize(): Promise<void> {
+    if (this._initialized) {
+      throw new Error('KeyManager already initialized')
+    }
+
+    const keyPair = await generateKeyPair()
+
+    this.currentKey = {
+      keyPair,
+      state: {
+        kid: keyPair.kid,
+        createdAt: Date.now(),
+      },
+    }
+    this.keysByKid.set(keyPair.kid, this.currentKey)
+
+    this._initialized = true
+  }
+
+  // Uses default onRotate() and shutdown() from BaseKeyManager
+}

--- a/packages/auth/src/key-manager/factory.ts
+++ b/packages/auth/src/key-manager/factory.ts
@@ -1,0 +1,50 @@
+import type { IKeyManager, KeyManagerConfig } from './types.js'
+import { FileSystemKeyManager } from './local.js'
+import { EphemeralKeyManager } from './ephemeral.js'
+
+/**
+ * Create a KeyManager instance based on configuration
+ *
+ * @param config Configuration specifying type and options
+ * @returns Configured KeyManager (not yet initialized)
+ *
+ * @example
+ * ```typescript
+ * // Create from environment
+ * const keyManager = createKeyManager({
+ *     type: process.env.KEY_MANAGER_TYPE || 'local',
+ *     keysDir: process.env.CATALYST_AUTH_KEYS_DIR,
+ * });
+ * await keyManager.initialize();
+ * ```
+ */
+export function createKeyManager(config: KeyManagerConfig): IKeyManager {
+  const { type, keysDir, gracePeriodMs } = config
+
+  switch (type) {
+    case 'local':
+      return new FileSystemKeyManager(keysDir, { gracePeriodMs })
+
+    case 'ephemeral':
+      return new EphemeralKeyManager({ gracePeriodMs })
+
+    default:
+      throw new Error(`Unknown KeyManager type: ${type}. Supported types: 'local', 'ephemeral'`)
+  }
+}
+
+/**
+ * Create a KeyManager from environment variables
+ *
+ * Environment variables:
+ * - KEY_MANAGER_TYPE: 'local' (default) or 'ephemeral'
+ * - CATALYST_AUTH_KEYS_DIR: Directory for key storage (local only)
+ *
+ * @returns Configured KeyManager (not yet initialized)
+ */
+export function createKeyManagerFromEnv(): IKeyManager {
+  const type = (process.env.KEY_MANAGER_TYPE as 'local' | 'ephemeral') || 'local'
+  const keysDir = process.env.CATALYST_AUTH_KEYS_DIR
+
+  return createKeyManager({ type, keysDir })
+}

--- a/packages/auth/src/key-manager/index.ts
+++ b/packages/auth/src/key-manager/index.ts
@@ -1,0 +1,21 @@
+// Types and interfaces
+export type {
+  IKeyManager,
+  SignOptions,
+  VerifyOptions,
+  VerifyResult,
+  RotateOptions,
+  RotationResult,
+  KeyState,
+  KeyManagerConfig,
+} from './types.js'
+
+// Base class and types
+export { BaseKeyManager, type ManagedKey } from './base.js'
+
+// Implementations
+export { FileSystemKeyManager } from './local.js'
+export { EphemeralKeyManager } from './ephemeral.js'
+
+// Factory
+export { createKeyManager, createKeyManagerFromEnv } from './factory.js'

--- a/packages/auth/src/key-manager/local.ts
+++ b/packages/auth/src/key-manager/local.ts
@@ -1,0 +1,166 @@
+import { mkdir, readdir, readFile, writeFile, unlink, stat } from 'fs/promises'
+import { join } from 'path'
+
+import {
+  loadOrGenerateKeyPair,
+  saveKeyPair,
+  exportKeyPair,
+  importKeyPair,
+  type SerializedKeyPair,
+} from '../keys.js'
+import { BaseKeyManager, type ManagedKey } from './base.js'
+
+/**
+ * FileSystemKeyManager - File-based key management with rotation support
+ *
+ * Keys are stored on the local filesystem:
+ * - Current key: {keysDir}/keypair.json
+ * - Archived keys: {keysDir}/archive/keypair.{expiresAt}.json
+ */
+export class FileSystemKeyManager extends BaseKeyManager {
+  private readonly archiveDir: string
+
+  constructor(
+    private readonly keysDir: string = process.env.CATALYST_AUTH_KEYS_DIR || '/data/keys',
+    options?: { gracePeriodMs?: number }
+  ) {
+    super(options)
+    this.archiveDir = join(keysDir, 'archive')
+  }
+
+  async initialize(): Promise<void> {
+    if (this._initialized) {
+      throw new Error('KeyManager is already initialized')
+    }
+
+    // Ensure archive directory exists
+    await mkdir(this.archiveDir, { recursive: true, mode: 0o700 }).catch(() => {
+      // Directory may already exist
+    })
+
+    // Load or generate current key
+    const { keyPair, generated } = await loadOrGenerateKeyPair(this.keysDir)
+
+    // Get actual creation time from file if key was loaded
+    let createdAt = Date.now()
+    if (!generated) {
+      try {
+        const keyPath = join(this.keysDir, 'keypair.json')
+        const stats = await stat(keyPath)
+        const birthtime = stats.birthtime.getTime()
+        // Validate birthtime - some filesystems return 0 or ctime instead
+        // Use a reasonable minimum date (2020) to detect invalid values
+        const minValidTime = new Date('2020-01-01').getTime()
+        if (birthtime > minValidTime && birthtime <= Date.now()) {
+          createdAt = birthtime
+        }
+      } catch {
+        // Fall back to now if we can't get file stats
+      }
+    }
+
+    this.currentKey = {
+      keyPair,
+      state: {
+        kid: keyPair.kid,
+        createdAt,
+      },
+    }
+    this.keysByKid.set(keyPair.kid, this.currentKey)
+
+    // Load archived keys
+    await this.loadArchivedKeys()
+
+    this._initialized = true
+  }
+
+  protected override async onRotate(
+    oldKey: ManagedKey,
+    newKey: ManagedKey,
+    immediate: boolean
+  ): Promise<void> {
+    if (!immediate) {
+      await this.archiveKey(oldKey, oldKey.state.expiresAt!)
+    } else {
+      await this.clearArchive()
+    }
+
+    await saveKeyPair(newKey.keyPair, this.keysDir)
+  }
+
+  /**
+   * Load archived keys from disk
+   */
+  private async loadArchivedKeys(): Promise<void> {
+    this.previousKeys = []
+
+    let files: string[]
+    try {
+      files = await readdir(this.archiveDir)
+    } catch {
+      return // Archive directory doesn't exist or can't be read
+    }
+
+    for (const filename of files) {
+      const match = filename.match(/^keypair\.(\d+)\.json$/)
+      if (!match) continue
+
+      const expiresAt = parseInt(match[1], 10)
+
+      // Skip and clean up expired keys
+      if (Date.now() > expiresAt) {
+        await unlink(join(this.archiveDir, filename)).catch(() => {})
+        continue
+      }
+
+      try {
+        const filePath = join(this.archiveDir, filename)
+        const data = await readFile(filePath, 'utf-8')
+        const parsed = JSON.parse(data) as SerializedKeyPair
+        const keyPair = await importKeyPair(parsed)
+
+        const managedKey: ManagedKey = {
+          keyPair,
+          state: {
+            kid: keyPair.kid,
+            createdAt: new Date(parsed.createdAt).getTime(),
+            expiresAt,
+          },
+        }
+
+        this.previousKeys.push(managedKey)
+        this.keysByKid.set(keyPair.kid, managedKey)
+      } catch {
+        // Skip keys that fail to load - could log this
+      }
+    }
+  }
+
+  /**
+   * Archive a key to disk
+   */
+  private async archiveKey(managedKey: ManagedKey, expiresAt: number): Promise<void> {
+    const archivePath = join(this.archiveDir, `keypair.${expiresAt}.json`)
+
+    // Preserve original creation time when archiving
+    const createdAt = new Date(managedKey.state.createdAt)
+    const serialized = await exportKeyPair(managedKey.keyPair, createdAt)
+    await writeFile(archivePath, JSON.stringify(serialized, null, 2), { mode: 0o600 })
+  }
+
+  /**
+   * Clear all archived keys
+   */
+  private async clearArchive(): Promise<void> {
+    let files: string[]
+    try {
+      files = await readdir(this.archiveDir)
+    } catch {
+      return
+    }
+
+    await Promise.all(
+      files.map((filename) => unlink(join(this.archiveDir, filename)).catch(() => {}))
+    )
+  }
+}

--- a/packages/auth/src/key-manager/types.ts
+++ b/packages/auth/src/key-manager/types.ts
@@ -1,0 +1,97 @@
+import type { JSONWebKeySet } from 'jose'
+import type { SignOptions, VerifyOptions, VerifyResult } from '../jwt.js'
+
+// Re-export for convenience
+export type { SignOptions, VerifyOptions, VerifyResult }
+
+/**
+ * Options for key rotation
+ */
+export interface RotateOptions {
+  /** Skip grace period, invalidate old key immediately */
+  immediate?: boolean
+  /** Custom grace period in milliseconds (default: 24 hours) */
+  gracePeriodMs?: number
+}
+
+/**
+ * Result of a key rotation operation
+ */
+export interface RotationResult {
+  /** Key ID of the previous current key */
+  previousKeyId: string
+  /** Key ID of the new current key */
+  newKeyId: string
+  /** When the previous key will be removed from JWKS (undefined if immediate) */
+  gracePeriodEndsAt?: Date
+}
+
+/**
+ * Internal state for a managed key
+ */
+export interface KeyState {
+  /** Key identifier */
+  kid: string
+  /** When the key was created */
+  createdAt: number
+  /** When this key stops being valid for verification (for rotated keys) */
+  expiresAt?: number
+}
+
+/**
+ * Configuration for creating a KeyManager
+ */
+export interface KeyManagerConfig {
+  /** Type of key manager to create */
+  type: 'local' | 'ephemeral'
+  /** Directory for key storage (only for 'local' type) */
+  keysDir?: string
+  /** Default grace period for rotation in milliseconds */
+  gracePeriodMs?: number
+}
+
+/**
+ * Core KeyManager interface for all key management operations.
+ *
+ * Implementations handle key generation, persistence, signing, verification,
+ * and rotation. This abstraction enables future cloud KMS integration.
+ */
+export interface IKeyManager {
+  /** Sign a JWT with the current key */
+  sign(options: SignOptions): Promise<string>
+
+  /**
+   * Verify a JWT against managed keys (current and previous)
+   * @param token JWT string to verify
+   * @param options Optional verification options (audience)
+   * @returns Verification result with payload if valid
+   */
+  verify(token: string, options?: VerifyOptions): Promise<VerifyResult>
+
+  /**
+   * Get the JSON Web Key Set containing all valid public keys
+   * @returns JWKS with current key and any keys still in grace period
+   */
+  getJwks(): Promise<JSONWebKeySet>
+
+  /** Get the key ID of the current signing key */
+  getCurrentKeyId(): Promise<string>
+
+  /** Rotate to a new signing key */
+  rotate(options?: RotateOptions): Promise<RotationResult>
+
+  /** Initialize the key manager (load or generate keys) */
+  initialize(): Promise<void>
+
+  /**
+   * Shutdown the key manager, cleaning up any resources
+   * Clears rotation timers and internal state
+   */
+  shutdown(): Promise<void>
+
+  /**
+   * Check if the key manager has been initialized
+   * @returns true if initialize() has been called successfully
+   */
+  isInitialized(): boolean
+}

--- a/packages/auth/tests/key-manager.test.ts
+++ b/packages/auth/tests/key-manager.test.ts
@@ -1,92 +1,93 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { FileSystemKeyManager } from '../src/key-manager.js';
-import { rmSync, mkdirSync, existsSync, readdirSync } from 'fs';
-import { join } from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { FileSystemKeyManager } from '../src/key-manager/local.js'
+import { rmSync, mkdirSync, existsSync, readdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
 
-const TEST_KEYS_DIR = join(__dirname, 'test-keys-manager-persistence');
+const TEST_KEYS_DIR = join(__dirname, 'test-keys-manager-persistence')
 
 describe('FileSystemKeyManager Persistence', () => {
-    beforeEach(() => {
-        try {
-            rmSync(TEST_KEYS_DIR, { recursive: true, force: true });
-        } catch {
-            // Ignore error
-        }
-        mkdirSync(TEST_KEYS_DIR, { recursive: true });
-    });
+  beforeEach(() => {
+    try {
+      rmSync(TEST_KEYS_DIR, { recursive: true, force: true })
+    } catch {
+      /* ignore cleanup errors */
+    }
+    mkdirSync(TEST_KEYS_DIR, { recursive: true })
+  })
 
-    afterEach(() => {
-        try {
-            rmSync(TEST_KEYS_DIR, { recursive: true, force: true });
-        } catch {
-            // Ignore error
-        }
-    });
+  afterEach(() => {
+    try {
+      rmSync(TEST_KEYS_DIR, { recursive: true, force: true })
+    } catch {
+      /* ignore cleanup errors */
+    }
+  })
 
-    it('should persist current key', async () => {
-        const km1 = new FileSystemKeyManager(TEST_KEYS_DIR);
-        await km1.init();
-        const keys1 = await km1.getPublicKeys();
-        const kid1 = keys1.keys[0].kid;
+  it('should persist current key', async () => {
+    const km1 = new FileSystemKeyManager(TEST_KEYS_DIR)
+    await km1.initialize()
+    const keys1 = await km1.getJwks()
+    const kid1 = keys1.keys[0].kid
+    await km1.shutdown()
 
-        // New instance, same dir
-        const km2 = new FileSystemKeyManager(TEST_KEYS_DIR);
-        await km2.init();
-        const keys2 = await km2.getPublicKeys();
+    // New instance, same dir
+    const km2 = new FileSystemKeyManager(TEST_KEYS_DIR)
+    await km2.initialize()
+    const keys2 = await km2.getJwks()
 
-        expect(keys2.keys[0].kid).toBe(kid1);
-    });
+    expect(keys2.keys[0].kid).toBe(kid1)
+    await km2.shutdown()
+  })
 
-    it('should persist archived keys after graceful rotation', async () => {
-        const km1 = new FileSystemKeyManager(TEST_KEYS_DIR);
-        await km1.init();
+  it('should persist archived keys after graceful rotation', async () => {
+    const km1 = new FileSystemKeyManager(TEST_KEYS_DIR)
+    await km1.initialize()
 
-        // Sign with key 1
-        const token1 = await km1.sign({ subject: 'u1', expiresIn: '1h' });
-        const keys1 = await km1.getPublicKeys();
-        const kid1 = keys1.keys[0].kid;
+    // Sign with key 1
+    const token1 = await km1.sign({ subject: 'u1', expiresIn: '1h' })
+    const keys1 = await km1.getJwks()
+    const kid1 = keys1.keys[0].kid
 
-        // Rotate
-        await km1.rotate(false); // Graceful
+    // Rotate (graceful)
+    await km1.rotate({ immediate: false })
+    await km1.shutdown()
 
-        // Check filesystem
-        const archiveDir = join(TEST_KEYS_DIR, 'archive');
-        expect(existsSync(archiveDir)).toBe(true);
-        const archives = readdirSync(archiveDir);
-        expect(archives.length).toBe(1);
+    // Check filesystem
+    const archiveDir = join(TEST_KEYS_DIR, 'archive')
+    expect(existsSync(archiveDir)).toBe(true)
+    const archives = readdirSync(archiveDir)
+    expect(archives.length).toBe(1)
 
-        // New instance (simulate restart)
-        const km2 = new FileSystemKeyManager(TEST_KEYS_DIR);
-        await km2.init();
+    // New instance (simulate restart)
+    const km2 = new FileSystemKeyManager(TEST_KEYS_DIR)
+    await km2.initialize()
 
-        // Should have 2 keys loaded
-        const keys2 = await km2.getPublicKeys();
-        expect(keys2.keys).toHaveLength(2);
+    // Should have 2 keys loaded
+    const keys2 = await km2.getJwks()
+    expect(keys2.keys).toHaveLength(2)
 
-        const kids = keys2.keys.map(k => k.kid);
-        expect(kids).toContain(kid1);
+    const kids = keys2.keys.map((k) => k.kid)
+    expect(kids).toContain(kid1)
 
-        // Should verify old token
-        const res = await km2.verify(token1);
-        expect(res.valid).toBe(true);
-    });
+    // Should verify old token
+    const res = await km2.verify(token1)
+    expect(res.valid).toBe(true)
+    await km2.shutdown()
+  })
 
-    it('should clean up expired archived keys (mocked via low grace period)', async () => {
-        // We can't easily wait 24h, but we can call loadArchivedKeys? 
-        // Or we can manually create an expired archive file to test cleanup logic.
+  it('should clean up expired archived keys on load', async () => {
+    const archiveDir = join(TEST_KEYS_DIR, 'archive')
+    mkdirSync(archiveDir, { recursive: true })
 
-        const archiveDir = join(TEST_KEYS_DIR, 'archive');
-        mkdirSync(archiveDir, { recursive: true });
+    // Create a dummy expired key file
+    const expiredTime = Date.now() - 10000
+    writeFileSync(join(archiveDir, `keypair.${expiredTime}.json`), '{}')
 
-        // Create a dummy expired key file
-        const expiredTime = Date.now() - 10000;
-        const fs = await import('fs');
-        fs.writeFileSync(join(archiveDir, `keypair.${expiredTime}.json`), '{}');
+    const km = new FileSystemKeyManager(TEST_KEYS_DIR)
+    await km.initialize()
 
-        const km = new FileSystemKeyManager(TEST_KEYS_DIR);
-        await km.init(); // Should trigger loadArchivedKeys and cleanup
-
-        const archives = readdirSync(archiveDir);
-        expect(archives.length).toBe(0); // Should be gone
-    });
-});
+    const archives = readdirSync(archiveDir)
+    expect(archives.length).toBe(0) // Should be gone
+    await km.shutdown()
+  })
+})


### PR DESCRIPTION
# Key Manager Refactoring

- Add BaseKeyManager abstract class with sign/verify/getJwks
- Add LocalKeyManager for file-system based key storage
- Add EphemeralKeyManager for in-memory testing
- Add createKeyManagerFromEnv factory function
- Update key-manager tests for new abstraction