### PR TITLE
feat(auth): add User, ServiceAccount, BootstrapState models

### DIFF
--- a/packages/auth/src/models/bootstrap.ts
+++ b/packages/auth/src/models/bootstrap.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+/**
+ * BootstrapState model - singleton tracking one-time bootstrap token state
+ *
+ * Used to create the first admin user. Once used, cannot be reused.
+ */
+export const BootstrapStateSchema = z.object({
+  tokenHash: z.string().min(1),
+  expiresAt: z.date(),
+  used: z.boolean().default(false),
+  createdAdminId: z.string().startsWith('usr_').optional(),
+})
+
+export type BootstrapState = z.infer<typeof BootstrapStateSchema>

--- a/packages/auth/src/models/index.ts
+++ b/packages/auth/src/models/index.ts
@@ -1,0 +1,15 @@
+// User model
+export { UserSchema, generateUserId } from './user.js'
+export type { User, CreateUserInput } from './user.js'
+
+// ServiceAccount model
+export {
+  ServiceAccountSchema,
+  generateServiceAccountId,
+  MAX_API_KEY_LIFETIME_MS,
+} from './service-account.js'
+export type { ServiceAccount, CreateServiceAccountInput } from './service-account.js'
+
+// BootstrapState model
+export { BootstrapStateSchema } from './bootstrap.js'
+export type { BootstrapState } from './bootstrap.js'

--- a/packages/auth/src/models/service-account.ts
+++ b/packages/auth/src/models/service-account.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod'
+
+/**
+ * ServiceAccount model - represents an automated system (CI/CD, etc.)
+ *
+ * API keys have required expiration (max 1 year from creation).
+ */
+export const ServiceAccountSchema = z.object({
+  id: z.string().startsWith('sa_'),
+  name: z.string().min(1).max(100),
+  apiKeyHash: z.string().min(1),
+  keyPrefix: z.string().regex(/^cat_sk_[a-z0-9]+_$/),
+  roles: z.array(z.string()),
+  orgId: z.string().default('default'),
+  expiresAt: z.date(), // Required, max 1 year (enforced at creation)
+  createdAt: z.date(),
+  createdBy: z.string().startsWith('usr_'),
+})
+
+export type ServiceAccount = z.infer<typeof ServiceAccountSchema>
+
+/**
+ * Input for creating a new service account (id and createdAt generated)
+ */
+export type CreateServiceAccountInput = Omit<ServiceAccount, 'id' | 'createdAt'>
+
+/**
+ * Generate a service account ID
+ */
+export function generateServiceAccountId(): string {
+  return `sa_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`
+}
+
+/**
+ * Maximum API key lifetime (1 year in milliseconds)
+ */
+export const MAX_API_KEY_LIFETIME_MS = 365 * 24 * 60 * 60 * 1000

--- a/packages/auth/src/models/user.ts
+++ b/packages/auth/src/models/user.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod'
+
+/**
+ * User model - represents a human user of the system
+ *
+ * POC Note: Only "admin" role supported. status field omitted (all users active).
+ */
+export const UserSchema = z.object({
+  id: z.string().startsWith('usr_'),
+  email: z
+    .string()
+    .email()
+    .transform((v) => v.toLowerCase()),
+  passwordHash: z.string().min(1),
+  roles: z.array(z.string()).min(1),
+  orgId: z.string().default('default'),
+  createdAt: z.date(),
+  lastLoginAt: z.date().optional(),
+})
+
+export type User = z.infer<typeof UserSchema>
+
+/**
+ * Input for creating a new user (id and createdAt generated)
+ */
+export type CreateUserInput = Omit<User, 'id' | 'createdAt'>
+
+/**
+ * Generate a user ID
+ */
+export function generateUserId(): string {
+  return `usr_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`
+}


### PR DESCRIPTION
- User: id, email (lowercased), passwordHash, roles, orgId, createdAt
- ServiceAccount: id, name, apiKeyHash, keyPrefix, roles, expiresAt
- BootstrapState: tokenHash, expiresAt, used, createdAdminId
- All models have Zod schemas per P4 constitution