### PR TITLE
feat(auth): add in-memory stores with interfaces

### DIFF
--- a/packages/auth/src/stores/index.ts
+++ b/packages/auth/src/stores/index.ts
@@ -1,0 +1,5 @@
+// Store interfaces
+export type { UserStore, ServiceAccountStore, BootstrapStore } from './types.js'
+
+// In-memory implementations
+export { InMemoryUserStore, InMemoryServiceAccountStore, InMemoryBootstrapStore } from './memory.js'

--- a/packages/auth/src/stores/memory.ts
+++ b/packages/auth/src/stores/memory.ts
@@ -1,0 +1,131 @@
+import type { User, CreateUserInput } from '../models/user.js'
+import { generateUserId } from '../models/user.js'
+import type { ServiceAccount, CreateServiceAccountInput } from '../models/service-account.js'
+import { generateServiceAccountId } from '../models/service-account.js'
+import type { BootstrapState } from '../models/bootstrap.js'
+import type { UserStore, ServiceAccountStore, BootstrapStore } from './types.js'
+
+/**
+ * In-memory UserStore implementation
+ *
+ * Suitable for testing and single-instance deployments.
+ */
+export class InMemoryUserStore implements UserStore {
+  private users = new Map<string, User>()
+
+  async create(input: CreateUserInput): Promise<User> {
+    const id = generateUserId()
+    const user: User = {
+      ...input,
+      id,
+      email: input.email.toLowerCase().trim(),
+      createdAt: new Date(),
+    }
+    this.users.set(id, user)
+    return user
+  }
+
+  async findById(id: string): Promise<User | null> {
+    return this.users.get(id) ?? null
+  }
+
+  async findByEmail(email: string, orgId = 'default'): Promise<User | null> {
+    const normalizedEmail = email.toLowerCase().trim()
+    for (const user of this.users.values()) {
+      if (user.email === normalizedEmail && user.orgId === orgId) {
+        return user
+      }
+    }
+    return null
+  }
+
+  async update(id: string, updates: Partial<User>): Promise<User> {
+    const user = this.users.get(id)
+    if (!user) {
+      throw new Error('User not found')
+    }
+    const updated = { ...user, ...updates }
+    this.users.set(id, updated)
+    return updated
+  }
+
+  async delete(id: string): Promise<void> {
+    this.users.delete(id)
+  }
+
+  async list(orgId?: string): Promise<User[]> {
+    const users = Array.from(this.users.values())
+    return orgId ? users.filter((u) => u.orgId === orgId) : users
+  }
+}
+
+/**
+ * In-memory ServiceAccountStore implementation
+ */
+export class InMemoryServiceAccountStore implements ServiceAccountStore {
+  private accounts = new Map<string, ServiceAccount>()
+
+  async create(input: CreateServiceAccountInput): Promise<ServiceAccount> {
+    const id = generateServiceAccountId()
+    const sa: ServiceAccount = {
+      ...input,
+      id,
+      createdAt: new Date(),
+    }
+    this.accounts.set(id, sa)
+    return sa
+  }
+
+  async findById(id: string): Promise<ServiceAccount | null> {
+    return this.accounts.get(id) ?? null
+  }
+
+  async findByPrefix(prefix: string): Promise<ServiceAccount | null> {
+    for (const sa of this.accounts.values()) {
+      if (sa.keyPrefix === prefix) {
+        return sa
+      }
+    }
+    return null
+  }
+
+  async findByName(name: string, orgId = 'default'): Promise<ServiceAccount | null> {
+    for (const sa of this.accounts.values()) {
+      if (sa.name === name && sa.orgId === orgId) {
+        return sa
+      }
+    }
+    return null
+  }
+
+  async delete(id: string): Promise<void> {
+    this.accounts.delete(id)
+  }
+
+  async list(orgId?: string): Promise<ServiceAccount[]> {
+    const accounts = Array.from(this.accounts.values())
+    return orgId ? accounts.filter((sa) => sa.orgId === orgId) : accounts
+  }
+}
+
+/**
+ * In-memory BootstrapStore implementation
+ */
+export class InMemoryBootstrapStore implements BootstrapStore {
+  private state: BootstrapState | null = null
+
+  async get(): Promise<BootstrapState | null> {
+    return this.state
+  }
+
+  async set(state: BootstrapState): Promise<void> {
+    this.state = state
+  }
+
+  async markUsed(adminId: string): Promise<void> {
+    if (this.state) {
+      this.state.used = true
+      this.state.createdAdminId = adminId
+    }
+  }
+}

--- a/packages/auth/src/stores/types.ts
+++ b/packages/auth/src/stores/types.ts
@@ -1,0 +1,36 @@
+import type { User, CreateUserInput } from '../models/user.js'
+import type { ServiceAccount, CreateServiceAccountInput } from '../models/service-account.js'
+import type { BootstrapState } from '../models/bootstrap.js'
+
+/**
+ * UserStore interface - persistence for User entities
+ */
+export interface UserStore {
+  create(user: CreateUserInput): Promise<User>
+  findById(id: string): Promise<User | null>
+  findByEmail(email: string, orgId?: string): Promise<User | null>
+  update(id: string, updates: Partial<User>): Promise<User>
+  delete(id: string): Promise<void>
+  list(orgId?: string): Promise<User[]>
+}
+
+/**
+ * ServiceAccountStore interface - persistence for ServiceAccount entities
+ */
+export interface ServiceAccountStore {
+  create(sa: CreateServiceAccountInput): Promise<ServiceAccount>
+  findById(id: string): Promise<ServiceAccount | null>
+  findByPrefix(prefix: string): Promise<ServiceAccount | null>
+  findByName(name: string, orgId?: string): Promise<ServiceAccount | null>
+  delete(id: string): Promise<void>
+  list(orgId?: string): Promise<ServiceAccount[]>
+}
+
+/**
+ * BootstrapStore interface - persistence for BootstrapState singleton
+ */
+export interface BootstrapStore {
+  get(): Promise<BootstrapState | null>
+  set(state: BootstrapState): Promise<void>
+  markUsed(adminId: string): Promise<void>
+}

--- a/packages/auth/tests/models.test.ts
+++ b/packages/auth/tests/models.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'bun:test'
+import { UserSchema } from '../src/models/user.js'
+import { ServiceAccountSchema } from '../src/models/service-account.js'
+import { BootstrapStateSchema } from '../src/models/bootstrap.js'
+
+describe('UserSchema', () => {
+  it('should validate a complete user', () => {
+    const user = {
+      id: 'usr_abc123',
+      email: 'Admin@Example.Com',
+      passwordHash: '$argon2id$...',
+      roles: ['admin'],
+      orgId: 'default',
+      createdAt: new Date(),
+    }
+
+    const result = UserSchema.parse(user)
+    expect(result.id).toBe('usr_abc123')
+    expect(result.email).toBe('admin@example.com') // lowercased
+    expect(result.roles).toEqual(['admin'])
+  })
+
+  it('should reject user without usr_ prefix', () => {
+    const user = {
+      id: 'invalid_id',
+      email: 'test@example.com',
+      passwordHash: 'hash',
+      roles: ['admin'],
+      createdAt: new Date(),
+    }
+
+    expect(() => UserSchema.parse(user)).toThrow()
+  })
+
+  it('should reject user with empty roles', () => {
+    const user = {
+      id: 'usr_abc123',
+      email: 'test@example.com',
+      passwordHash: 'hash',
+      roles: [],
+      createdAt: new Date(),
+    }
+
+    expect(() => UserSchema.parse(user)).toThrow()
+  })
+
+  it('should reject invalid email', () => {
+    const user = {
+      id: 'usr_abc123',
+      email: 'not-an-email',
+      passwordHash: 'hash',
+      roles: ['admin'],
+      createdAt: new Date(),
+    }
+
+    expect(() => UserSchema.parse(user)).toThrow()
+  })
+
+  it('should default orgId to "default"', () => {
+    const user = {
+      id: 'usr_abc123',
+      email: 'test@example.com',
+      passwordHash: 'hash',
+      roles: ['admin'],
+      createdAt: new Date(),
+    }
+
+    const result = UserSchema.parse(user)
+    expect(result.orgId).toBe('default')
+  })
+})
+
+describe('ServiceAccountSchema', () => {
+  it('should validate a complete service account', () => {
+    const sa = {
+      id: 'sa_xyz789',
+      name: 'ci-pipeline',
+      apiKeyHash: '$argon2id$...',
+      keyPrefix: 'cat_sk_dflt_',
+      roles: ['operator'],
+      orgId: 'default',
+      expiresAt: new Date(Date.now() + 86400000), // 1 day from now
+      createdAt: new Date(),
+      createdBy: 'usr_admin123',
+    }
+
+    const result = ServiceAccountSchema.parse(sa)
+    expect(result.id).toBe('sa_xyz789')
+    expect(result.name).toBe('ci-pipeline')
+  })
+
+  it('should reject service account without sa_ prefix', () => {
+    const sa = {
+      id: 'invalid_id',
+      name: 'test',
+      apiKeyHash: 'hash',
+      keyPrefix: 'cat_sk_dflt_',
+      roles: [],
+      expiresAt: new Date(),
+      createdAt: new Date(),
+      createdBy: 'usr_admin',
+    }
+
+    expect(() => ServiceAccountSchema.parse(sa)).toThrow()
+  })
+
+  it('should reject invalid key prefix format', () => {
+    const sa = {
+      id: 'sa_xyz789',
+      name: 'test',
+      apiKeyHash: 'hash',
+      keyPrefix: 'invalid_prefix',
+      roles: [],
+      expiresAt: new Date(),
+      createdAt: new Date(),
+      createdBy: 'usr_admin',
+    }
+
+    expect(() => ServiceAccountSchema.parse(sa)).toThrow()
+  })
+
+  it('should reject name over 100 characters', () => {
+    const sa = {
+      id: 'sa_xyz789',
+      name: 'a'.repeat(101),
+      apiKeyHash: 'hash',
+      keyPrefix: 'cat_sk_dflt_',
+      roles: [],
+      expiresAt: new Date(),
+      createdAt: new Date(),
+      createdBy: 'usr_admin',
+    }
+
+    expect(() => ServiceAccountSchema.parse(sa)).toThrow()
+  })
+
+  it('should require expiresAt (max 1 year enforced elsewhere)', () => {
+    const sa = {
+      id: 'sa_xyz789',
+      name: 'test',
+      apiKeyHash: 'hash',
+      keyPrefix: 'cat_sk_dflt_',
+      roles: [],
+      createdAt: new Date(),
+      createdBy: 'usr_admin',
+      // missing expiresAt
+    }
+
+    expect(() => ServiceAccountSchema.parse(sa)).toThrow()
+  })
+})
+
+describe('BootstrapStateSchema', () => {
+  it('should validate bootstrap state', () => {
+    const state = {
+      tokenHash: '$argon2id$...',
+      expiresAt: new Date(Date.now() + 86400000),
+      used: false,
+    }
+
+    const result = BootstrapStateSchema.parse(state)
+    expect(result.used).toBe(false)
+    expect(result.createdAdminId).toBeUndefined()
+  })
+
+  it('should validate used bootstrap state with admin id', () => {
+    const state = {
+      tokenHash: '$argon2id$...',
+      expiresAt: new Date(),
+      used: true,
+      createdAdminId: 'usr_firstadmin',
+    }
+
+    const result = BootstrapStateSchema.parse(state)
+    expect(result.used).toBe(true)
+    expect(result.createdAdminId).toBe('usr_firstadmin')
+  })
+
+  it('should default used to false', () => {
+    const state = {
+      tokenHash: '$argon2id$...',
+      expiresAt: new Date(),
+    }
+
+    const result = BootstrapStateSchema.parse(state)
+    expect(result.used).toBe(false)
+  })
+
+  it('should reject createdAdminId without usr_ prefix', () => {
+    const state = {
+      tokenHash: '$argon2id$...',
+      expiresAt: new Date(),
+      used: true,
+      createdAdminId: 'invalid_id',
+    }
+
+    expect(() => BootstrapStateSchema.parse(state)).toThrow()
+  })
+})

--- a/packages/auth/tests/stores.test.ts
+++ b/packages/auth/tests/stores.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import {
+  InMemoryUserStore,
+  InMemoryServiceAccountStore,
+  InMemoryBootstrapStore,
+} from '../src/stores/memory.js'
+
+describe('InMemoryUserStore', () => {
+  let store: InMemoryUserStore
+
+  beforeEach(() => {
+    store = new InMemoryUserStore()
+  })
+
+  it('should create a user with generated id', async () => {
+    const user = await store.create({
+      email: 'test@example.com',
+      passwordHash: 'hash123',
+      roles: ['admin'],
+      orgId: 'default',
+    })
+
+    expect(user.id).toMatch(/^usr_/)
+    expect(user.email).toBe('test@example.com')
+    expect(user.createdAt).toBeInstanceOf(Date)
+  })
+
+  it('should find user by id', async () => {
+    const created = await store.create({
+      email: 'test@example.com',
+      passwordHash: 'hash',
+      roles: ['admin'],
+      orgId: 'default',
+    })
+
+    const found = await store.findById(created.id)
+    expect(found).not.toBeNull()
+    expect(found?.email).toBe('test@example.com')
+  })
+
+  it('should find user by email and org (case-insensitive)', async () => {
+    await store.create({
+      email: 'Test@Example.com',
+      passwordHash: 'hash',
+      roles: ['admin'],
+      orgId: 'default',
+    })
+
+    const found = await store.findByEmail('test@example.com', 'default')
+    expect(found).not.toBeNull()
+    expect(found?.email).toBe('test@example.com')
+  })
+
+  it('should return null for non-existent user', async () => {
+    const found = await store.findById('usr_nonexistent')
+    expect(found).toBeNull()
+  })
+
+  it('should update user', async () => {
+    const user = await store.create({
+      email: 'test@example.com',
+      passwordHash: 'hash',
+      roles: ['admin'],
+      orgId: 'default',
+    })
+
+    const updated = await store.update(user.id, { lastLoginAt: new Date() })
+    expect(updated.lastLoginAt).toBeInstanceOf(Date)
+  })
+
+  it('should delete user', async () => {
+    const user = await store.create({
+      email: 'test@example.com',
+      passwordHash: 'hash',
+      roles: ['admin'],
+      orgId: 'default',
+    })
+
+    await store.delete(user.id)
+    const found = await store.findById(user.id)
+    expect(found).toBeNull()
+  })
+
+  it('should list users by org', async () => {
+    await store.create({
+      email: 'user1@example.com',
+      passwordHash: 'hash',
+      roles: ['admin'],
+      orgId: 'org1',
+    })
+    await store.create({
+      email: 'user2@example.com',
+      passwordHash: 'hash',
+      roles: ['admin'],
+      orgId: 'org2',
+    })
+
+    const org1Users = await store.list('org1')
+    expect(org1Users).toHaveLength(1)
+    expect(org1Users[0].email).toBe('user1@example.com')
+  })
+})
+
+describe('InMemoryServiceAccountStore', () => {
+  let store: InMemoryServiceAccountStore
+
+  beforeEach(() => {
+    store = new InMemoryServiceAccountStore()
+  })
+
+  it('should create a service account with generated id', async () => {
+    const sa = await store.create({
+      name: 'ci-bot',
+      apiKeyHash: 'hash123',
+      keyPrefix: 'cat_sk_dflt_',
+      roles: ['operator'],
+      orgId: 'default',
+      expiresAt: new Date(Date.now() + 86400000),
+      createdBy: 'usr_admin',
+    })
+
+    expect(sa.id).toMatch(/^sa_/)
+    expect(sa.name).toBe('ci-bot')
+  })
+
+  it('should find service account by prefix', async () => {
+    await store.create({
+      name: 'ci-bot',
+      apiKeyHash: 'hash',
+      keyPrefix: 'cat_sk_dflt_',
+      roles: ['operator'],
+      orgId: 'default',
+      expiresAt: new Date(Date.now() + 86400000),
+      createdBy: 'usr_admin',
+    })
+
+    const found = await store.findByPrefix('cat_sk_dflt_')
+    expect(found).not.toBeNull()
+    expect(found?.name).toBe('ci-bot')
+  })
+
+  it('should find service account by name', async () => {
+    await store.create({
+      name: 'ci-bot',
+      apiKeyHash: 'hash',
+      keyPrefix: 'cat_sk_dflt_',
+      roles: ['operator'],
+      orgId: 'default',
+      expiresAt: new Date(Date.now() + 86400000),
+      createdBy: 'usr_admin',
+    })
+
+    const found = await store.findByName('ci-bot', 'default')
+    expect(found).not.toBeNull()
+  })
+
+  it('should return null for non-existent prefix', async () => {
+    const found = await store.findByPrefix('cat_sk_fake_')
+    expect(found).toBeNull()
+  })
+})
+
+describe('InMemoryBootstrapStore', () => {
+  let store: InMemoryBootstrapStore
+
+  beforeEach(() => {
+    store = new InMemoryBootstrapStore()
+  })
+
+  it('should return null when no state set', async () => {
+    const state = await store.get()
+    expect(state).toBeNull()
+  })
+
+  it('should set and get bootstrap state', async () => {
+    await store.set({
+      tokenHash: 'hash123',
+      expiresAt: new Date(Date.now() + 86400000),
+      used: false,
+    })
+
+    const state = await store.get()
+    expect(state).not.toBeNull()
+    expect(state?.tokenHash).toBe('hash123')
+    expect(state?.used).toBe(false)
+  })
+
+  it('should mark as used with admin id', async () => {
+    await store.set({
+      tokenHash: 'hash123',
+      expiresAt: new Date(Date.now() + 86400000),
+      used: false,
+    })
+
+    await store.markUsed('usr_firstadmin')
+
+    const state = await store.get()
+    expect(state?.used).toBe(true)
+    expect(state?.createdAdminId).toBe('usr_firstadmin')
+  })
+})


### PR DESCRIPTION
- UserStore, ServiceAccountStore, BootstrapStore interfaces
- InMemory implementations for testing
- Comprehensive tests for all store operations
- Tests for model Zod schemas