### PR TITLE
chore(bun-types): standarize to bun 1.3.6 types and container images

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,13 +52,14 @@
       "version": "0.0.0",
       "dependencies": {
         "@hono/capnweb": "^0.1.0",
+        "argon2": "^0.44.0",
         "capnweb": "^0.4.0",
         "hono": "^4.11.3",
         "jose": "^6.0.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.5",
+        "@types/bun": "catalog:dev",
         "@types/node": "^20.11.0",
         "testcontainers": "^10.7.1",
         "typescript": "^5.3.3",
@@ -80,6 +81,7 @@
         "zod": "catalog:",
       },
       "devDependencies": {
+        "@types/bun": "catalog:dev",
         "@types/inquirer": "^9.0.7",
         "@types/node": "catalog:dev",
         "@types/ws": "^8.18.1",
@@ -202,7 +204,7 @@
   },
   "catalogs": {
     "dev": {
-      "@types/bun": "^1.3.5",
+      "@types/bun": "^1.3.6",
       "@types/node": "^25.0.3",
       "tsup": "^8.5.1",
       "tsx": "^4.7.1",
@@ -370,6 +372,8 @@
 
     "@envelop/types": ["@envelop/types@5.2.1", "", { "dependencies": { "@whatwg-node/promise-helpers": "^1.0.0", "tslib": "^2.5.0" } }, "sha512-CsFmA3u3c2QoLDTfEpGr4t25fjMU31nyvse7IzWTvb0ZycuPjMjb0fjlheh+PbhBYb9YLugnT2uY6Mwcg1o+Zg=="],
 
+    "@epic-web/invariant": ["@epic-web/invariant@1.0.0", "", {}, "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.27.2", "", { "os": "android", "cpu": "arm" }, "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA=="],
@@ -503,6 +507,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
+
+    "@phc/format": ["@phc/format@1.0.0", "", {}, "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -784,6 +790,8 @@
 
     "archiver-utils": ["archiver-utils@5.0.2", "", { "dependencies": { "glob": "^10.0.0", "graceful-fs": "^4.2.0", "is-stream": "^2.0.1", "lazystream": "^1.0.0", "lodash": "^4.17.15", "normalize-path": "^3.0.0", "readable-stream": "^4.0.0" } }, "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA=="],
 
+    "argon2": ["argon2@0.44.0", "", { "dependencies": { "@phc/format": "^1.0.0", "cross-env": "^10.0.0", "node-addon-api": "^8.5.0", "node-gyp-build": "^4.8.4" } }, "sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig=="],
+
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "array-ify": ["array-ify@1.0.0", "", {}, "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="],
@@ -903,6 +911,8 @@
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
     "crc32-stream": ["crc32-stream@6.0.0", "", { "dependencies": { "crc-32": "^1.2.0", "readable-stream": "^4.0.0" } }, "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g=="],
+
+    "cross-env": ["cross-env@10.1.0", "", { "dependencies": { "@epic-web/invariant": "^1.0.0", "cross-spawn": "^7.0.6" }, "bin": { "cross-env": "dist/bin/cross-env.js", "cross-env-shell": "dist/bin/cross-env-shell.js" } }, "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw=="],
 
     "cross-inspect": ["cross-inspect@1.0.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A=="],
 
@@ -1215,6 +1225,10 @@
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "node-addon-api": ["node-addon-api@8.5.0", "", {}, "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       "dev": {
         "typescript": "^5.9.3",
         "@types/node": "^25.0.3",
-        "@types/bun": "^1.3.5",
+        "@types/bun": "^1.3.6",
         "tsup": "^8.5.1",
         "tsx": "^4.7.1"
       },

--- a/packages/auth/Dockerfile
+++ b/packages/auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1 as base
+FROM oven/bun:1.3.6 as base
 WORKDIR /app
 
 # Install dependencies into temp directory

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -18,7 +18,7 @@
     "zod": "^4.0.0"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.6",
+    "@types/bun": "catalog:dev",
     "@types/node": "^20.11.0",
     "testcontainers": "^10.7.1",
     "typescript": "^5.3.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
     "@types/inquirer": "^9.0.7",
     "@types/node": "catalog:dev",
     "@types/ws": "^8.18.1",
+    "@types/bun": "catalog:dev",
     "testcontainers": "catalog:testing",
     "tsx": "catalog:dev",
     "typescript": "catalog:dev"

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,19 +1,14 @@
 {
-    "compilerOptions": {
-        "target": "ESNext",
-        "module": "ESNext",
-        "moduleResolution": "bundler",
-        "strict": true,
-        "skipLibCheck": true,
-        "outDir": "./dist",
-        "types": [
-            "node",
-            "bun-types"
-        ],
-        "allowImportingTsExtensions": true,
-        "noEmit": true
-    },
-    "include": [
-        "src/**/*"
-    ]
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "types": ["bun", "node"],
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
 }

--- a/packages/examples/Dockerfile.books
+++ b/packages/examples/Dockerfile.books
@@ -1,4 +1,4 @@
-FROM oven/bun:1
+FROM oven/bun:1.3.6
 
 WORKDIR /app
 

--- a/packages/examples/Dockerfile.movies
+++ b/packages/examples/Dockerfile.movies
@@ -1,4 +1,4 @@
-FROM oven/bun:1
+FROM oven/bun:1.3.6
 
 WORKDIR /app
 

--- a/packages/gateway/Dockerfile
+++ b/packages/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Runtime stage (use bun directly)
-FROM oven/bun:1
+FROM oven/bun:1.3.6
 WORKDIR /app
 
 # Copy root config

--- a/packages/orchestrator/Dockerfile
+++ b/packages/orchestrator/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1
+FROM oven/bun:1.3.6
 
 WORKDIR /app
 

--- a/packages/orchestrator/tsconfig.json
+++ b/packages/orchestrator/tsconfig.json
@@ -1,20 +1,15 @@
 {
-    "compilerOptions": {
-        "target": "ESNext",
-        "module": "ESNext",
-        "moduleResolution": "bundler",
-        "strict": true,
-        "skipLibCheck": true,
-        "outDir": "./dist",
-        "rootDir": "../../",
-        "types": [
-            "bun-types"
-        ],
-        "allowImportingTsExtensions": true,
-        "noEmit": true
-    },
-    "include": [
-        "src/**/*",
-        "tests/**/*"
-    ]
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "../../",
+    "types": ["bun"],
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
### TL;DR

Update Bun to version 1.3.6 across all packages and add argon2 dependency for authentication.

### What changed?

- Updated Bun version to 1.3.6 in all Dockerfiles
- Updated `@types/bun` to version 1.3.6 in the catalog
- Added argon2 v0.44.0 as a dependency for authentication
- Standardized TypeScript configurations to use "bun" instead of "bun-types"
- Added `@types/bun` as a dev dependency in the CLI package
- Fixed formatting in several tsconfig.json files

### How to test?

1. Build and run the Docker containers to verify they work with Bun 1.3.6
2. Test authentication functionality to ensure argon2 is working properly
3. Verify TypeScript compilation works correctly with the updated types

### Why make this change?

Updating to Bun 1.3.6 ensures we're using a consistent runtime version across all services. Adding argon2 provides secure password hashing capabilities for the authentication service. The TypeScript configuration changes improve consistency and ensure proper type checking across the codebase.