### PR TITLE
feat: moving graphql to next node

### DIFF
--- a/packages/orchestrator/src/next/index.ts
+++ b/packages/orchestrator/src/next/index.ts
@@ -27,6 +27,9 @@ const bus = new CatalystNodeBus({
     ibgp: {
       secret: process.env.CATALYST_PEERING_SECRET || 'valid-secret',
     },
+    gqlGatewayConfig: process.env.CATALYST_GQL_GATEWAY_ENDPOINT
+      ? { endpoint: process.env.CATALYST_GQL_GATEWAY_ENDPOINT }
+      : undefined,
   },
   connectionPool: { type: 'ws' },
 })

--- a/packages/orchestrator/src/next/orchestrator.gateway.container.test.ts
+++ b/packages/orchestrator/src/next/orchestrator.gateway.container.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import {
+  GenericContainer,
+  Wait,
+  Network,
+  type StartedTestContainer,
+  type StartedNetwork,
+} from 'testcontainers'
+import path from 'path'
+import { spawnSync } from 'node:child_process'
+import { newWebSocketRpcSession } from 'capnweb'
+import type { PublicApi } from './orchestrator.js'
+
+describe('Orchestrator Gateway Container Tests', () => {
+  const TIMEOUT = 600000 // 10 minutes
+
+  let network: StartedNetwork
+  let gateway: StartedTestContainer
+  let peerA: StartedTestContainer
+  let peerB: StartedTestContainer
+  const peerBLogs: string[] = []
+
+  const orchestratorImage = 'localhost/catalyst-node:next-e2e'
+  const gatewayImage = 'localhost/catalyst-gateway:test'
+  const repoRoot = path.resolve(__dirname, '../../../../')
+  const skipTests =
+    !process.env.DOCKER_HOST && !process.env.DOCKER_SOCK && !process.env.PODMAN_VAR_LINK
+
+  beforeAll(async () => {
+    if (skipTests) {
+      console.warn('Skipping container tests: Podman runtime not detected')
+      return
+    }
+
+    // Build images
+    console.log('Building Gateway image with Podman...')
+    const gatewayBuild = spawnSync(
+      'podman',
+      ['build', '-f', 'packages/gateway/Dockerfile', '-t', gatewayImage, '.'],
+      { cwd: repoRoot, stdio: 'inherit' }
+    )
+    if (gatewayBuild.status !== 0) throw new Error('Podman build gateway failed')
+
+    console.log('Building Orchestrator image with Podman...')
+    const orchestratorBuild = spawnSync(
+      'podman',
+      ['build', '-f', 'packages/orchestrator/Dockerfile', '-t', orchestratorImage, '.'],
+      { cwd: repoRoot, stdio: 'inherit' }
+    )
+    if (orchestratorBuild.status !== 0) throw new Error('Podman build orchestrator failed')
+
+    network = await new Network().start()
+
+    gateway = await new GenericContainer(gatewayImage)
+      .withNetwork(network)
+      .withNetworkAliases('gateway')
+      .withExposedPorts(4000)
+      .withWaitStrategy(Wait.forListeningPorts())
+      .withLogConsumer((stream) => {
+        stream.on('line', (line) => console.log(`[gateway] ${line}`))
+        stream.on('err', (line) => console.error(`[gateway] ERR: ${line}`))
+      })
+      .start()
+
+    const startNode = async (name: string, alias: string, gatewayEndpoint?: string) => {
+      return await new GenericContainer(orchestratorImage)
+        .withNetwork(network)
+        .withNetworkAliases(alias)
+        .withExposedPorts(3000)
+        .withCommand(['sh', '-c', 'bun run src/next/index.ts'])
+        .withEnvironment({
+          PORT: '3000',
+          CATALYST_NODE_ID: name,
+          CATALYST_PEERING_ENDPOINT: `ws://${alias}:3000/rpc`,
+          CATALYST_DOMAINS: 'somebiz.local.io',
+          CATALYST_PEERING_SECRET: 'valid-secret',
+          CATALYST_GQL_GATEWAY_ENDPOINT: gatewayEndpoint || '',
+        })
+        .withWaitStrategy(Wait.forListeningPorts())
+        .withLogConsumer(
+          (stream: { on(event: string, listener: (line: string) => void): void }) => {
+            stream.on('line', (line: string) => {
+              console.log(`[${name}] ${line}`)
+              if (name === 'peer-b.somebiz.local.io') {
+                peerBLogs.push(line)
+              }
+            })
+            stream.on('err', (line: string) => console.error(`[${name}] ERR: ${line}`))
+          }
+        )
+        .start()
+    }
+
+    peerA = await startNode('peer-a.somebiz.local.io', 'peer-a')
+    // peerB is configured with the gateway
+    peerB = await startNode('peer-b.somebiz.local.io', 'peer-b', 'ws://gateway:4000/api')
+
+    console.log('Containers started')
+  }, TIMEOUT)
+
+  afterAll(async () => {
+    if (peerA) await peerA.stop()
+    if (peerB) await peerB.stop()
+    if (gateway) await gateway.stop()
+    if (network) await network.stop()
+  })
+
+  it.skipIf(skipTests)(
+    'Mesh-wide GraphQL Sync: A -> B -> Gateway',
+    async () => {
+      const portA = peerA.getMappedPort(3000)
+      const clientA = newWebSocketRpcSession<PublicApi>(`ws://127.0.0.1:${portA}/rpc`)
+      const mgmtA = clientA.getManagerConnection()
+
+      const portB = peerB.getMappedPort(3000)
+      const clientB = newWebSocketRpcSession<PublicApi>(`ws://127.0.0.1:${portB}/rpc`)
+      const mgmtB = clientB.getManagerConnection()
+
+      // 1. Peer A and B
+      await mgmtB.addPeer({
+        name: 'peer-a.somebiz.local.io',
+        endpoint: 'ws://peer-a:3000/rpc',
+        domains: ['somebiz.local.io'],
+      })
+      await mgmtA.addPeer({
+        name: 'peer-b.somebiz.local.io',
+        endpoint: 'ws://peer-b:3000/rpc',
+        domains: ['somebiz.local.io'],
+      })
+
+      // Give it a moment for the handshake
+      await new Promise((r) => setTimeout(r, 2000))
+
+      // 2. A adds a GraphQL route
+      const adminAuth = { userId: 'admin', roles: ['*'] }
+      await clientA.dispatch(
+        {
+          action: 'local:route:create',
+          data: { name: 'books-mesh', endpoint: 'http://books:8080', protocol: 'http:graphql' },
+        },
+        adminAuth
+      )
+
+      // 3. Verify Gateway receives config update (check peerB logs for success or use gateway logs)
+      // Since we don't have an easy way to query the gateway state over HTTP in this test context
+      // without extra work, we can check node logs.
+
+      let sawSync = false
+      for (let i = 0; i < 20; i++) {
+        if (peerBLogs.some((l) => l.includes('Gateway sync successful'))) {
+          sawSync = true
+          break
+        }
+        await new Promise((r) => setTimeout(r, 500))
+      }
+
+      if (!sawSync) {
+        console.log('Peer B Logs during failure:', peerBLogs.join('\n'))
+      }
+      expect(sawSync).toBe(true)
+    },
+    TIMEOUT
+  )
+})

--- a/packages/orchestrator/src/next/orchestrator.gateway.test.ts
+++ b/packages/orchestrator/src/next/orchestrator.gateway.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, mock } from 'bun:test'
+import { Actions } from './action-types.js'
+import { CatalystNodeBus, ConnectionPool, type PublicApi } from './orchestrator.js'
+import type { RpcStub } from 'capnweb'
+import type { PeerInfo } from './routing/state.js'
+
+const MOCK_NODE: PeerInfo = {
+  name: 'node-a.somebiz.local.io',
+  endpoint: 'http://node-a:3000',
+  domains: ['somebiz.local.io'],
+}
+
+const GATEWAY_ENDPOINT = 'http://gateway:4000'
+
+interface GatewayService {
+  name: string
+  url: string
+}
+
+interface GatewayConfig {
+  services: GatewayService[]
+}
+
+class MockConnectionPool extends ConnectionPool {
+  public calls: { endpoint: string; config: GatewayConfig }[] = []
+  public mockStubs: Map<string, Record<string, unknown>> = new Map()
+
+  get(endpoint: string) {
+    if (!this.mockStubs.has(endpoint)) {
+      const stub = {
+        updateConfig: mock(async (config: GatewayConfig) => {
+          this.calls.push({ endpoint, config })
+          return { success: true }
+        }),
+        getPeerConnection: mock(async () => ({
+          success: true,
+          connection: {
+            update: mock(async () => ({ success: true })),
+            open: mock(async () => ({ success: true })),
+          },
+        })),
+      }
+      this.mockStubs.set(endpoint, stub as Record<string, unknown>)
+    }
+    return this.mockStubs.get(endpoint) as unknown as RpcStub<PublicApi>
+  }
+}
+
+const ADMIN_AUTH = { userId: 'admin', roles: ['*'] }
+
+describe('CatalystNodeBus > GraphQL Gateway Sync', () => {
+  let bus: CatalystNodeBus
+  let pool: MockConnectionPool
+
+  beforeEach(() => {
+    pool = new MockConnectionPool('http')
+    bus = new CatalystNodeBus({
+      config: {
+        node: MOCK_NODE,
+        ibgp: { secret: 'secret' },
+        gqlGatewayConfig: { endpoint: GATEWAY_ENDPOINT },
+      },
+      connectionPool: { pool },
+    })
+  })
+
+  it('should sync local GraphQL routes to gateway', async () => {
+    const route = {
+      name: 'books',
+      protocol: 'http:graphql' as const,
+      endpoint: 'http://books:8080',
+    }
+
+    await bus.dispatch(
+      {
+        action: Actions.LocalRouteCreate,
+        data: route,
+      },
+      ADMIN_AUTH
+    )
+
+    // Give some time for async handleNotify/syncGateway
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(pool.calls.length).toBe(1)
+    expect(pool.calls[0].endpoint).toBe(GATEWAY_ENDPOINT)
+    expect(pool.calls[0].config.services).toEqual([{ name: 'books', url: 'http://books:8080' }])
+  })
+
+  it('should NOT sync non-GraphQL routes', async () => {
+    const route = {
+      name: 'grpc-service',
+      protocol: 'http:grpc' as const,
+      endpoint: 'http://grpc:5000',
+    }
+
+    await bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: route,
+    })
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    // console.log('Calls:', JSON.stringify(pool.calls));
+    // It shouldn't trigger sync if no graphql routes exist
+    // Or it might trigger but find 0 routes.
+    // In my impl, I added a check: if (graphqlRoutes.length === 0) return
+    expect(pool.calls.length).toBe(0)
+  })
+
+  it('should sync mesh-wide GraphQL routes (local + internal)', async () => {
+    // 1. Add local route
+    await bus.dispatch(
+      {
+        action: Actions.LocalRouteCreate,
+        data: { name: 'local-books', protocol: 'http:graphql', endpoint: 'http://lb:8080' },
+      },
+      ADMIN_AUTH
+    )
+
+    // 2. Add internal route (from peer)
+    const peerInfo: PeerInfo = {
+      name: 'peer-b.somebiz.local.io',
+      endpoint: 'http://pb',
+      domains: [],
+    }
+    await bus.dispatch(
+      {
+        action: Actions.InternalProtocolUpdate,
+        data: {
+          peerInfo,
+          update: {
+            updates: [
+              {
+                action: 'add',
+                route: { name: 'remote-movies', protocol: 'http:gql', endpoint: 'http://rm:8080' },
+                nodePath: ['peer-b.somebiz.local.io'],
+              },
+            ],
+          },
+        },
+      },
+      ADMIN_AUTH
+    )
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    // Expect 2 calls (one for each action)
+    expect(pool.calls.length).toBe(2)
+    const lastSync = pool.calls[1].config.services
+    expect(lastSync).toHaveLength(2)
+    expect(lastSync).toContainEqual({ name: 'local-books', url: 'http://lb:8080' })
+    expect(lastSync).toContainEqual({ name: 'remote-movies', url: 'http://rm:8080' })
+  })
+})


### PR DESCRIPTION
### TL;DR

Added GraphQL Gateway integration to the Catalyst Node orchestrator, enabling automatic synchronization of GraphQL routes across the mesh network to a central gateway.

### What changed?

- Added configuration support for a GraphQL gateway endpoint in the orchestrator
- Implemented a `syncGateway()` method that collects all GraphQL routes and sends them to the gateway
- Added gateway sync calls after relevant state changes (route creation, deletion, peer updates)
- Created unit tests to verify gateway synchronization behavior
- Added container-based integration tests to validate the end-to-end flow between nodes and gateway

### How to test?

1. Set the `CATALYST_GQL_GATEWAY_ENDPOINT` environment variable to your gateway's endpoint
2. Create GraphQL routes on any node in the mesh using `local:route:create` with protocol `http:graphql`
3. Verify in logs that routes are synced to the gateway ("Gateway sync successful")
4. For integration testing, run the container tests which validate the full flow:
   ```
   cd packages/orchestrator

   bun test orchestrator.gateway.container.test.ts
   ```

### Why make this change?

This change enables a centralized GraphQL gateway to automatically receive configuration updates from the mesh network. When GraphQL services are added, removed, or modified on any node in the mesh, the gateway is automatically updated with the latest service configuration, providing a unified API endpoint for clients while maintaining the distributed nature of the mesh network.