### PR TITLE
chore: in the middle of solving a container integrations issue that blew up

### DIFF
--- a/packages/orchestrator/Dockerfile
+++ b/packages/orchestrator/Dockerfile
@@ -15,4 +15,4 @@ RUN bun install
 ENV PORT=3000
 EXPOSE 3000
 
-CMD ["bun", "run", "src/index.ts"]
+CMD ["bun", "run", "src/next/index.ts"]

--- a/packages/orchestrator/src/next/mock-connection-pool.ts
+++ b/packages/orchestrator/src/next/mock-connection-pool.ts
@@ -1,0 +1,32 @@
+import { CatalystNodeBus, ConnectionPool, type PublicApi } from './orchestrator.js'
+import type { RpcStub } from 'capnweb'
+
+export class MockConnectionPool extends ConnectionPool {
+    private nodes = new Map<string, CatalystNodeBus>()
+
+    constructor() {
+        super('ws')
+    }
+
+    registerNode(bus: CatalystNodeBus) {
+        // Use type casting to access internal config for test discovery
+        const nameStr = (bus as unknown as { config: { node: { name: string } } }).config.node.name
+        this.nodes.set(nameStr, bus)
+    }
+
+    override get(endpoint: string) {
+        // Map ws://node-a to node-a.somebiz.local.io etc
+        const targetNode = Array.from(this.nodes.values()).find((bus) => {
+            const nodeInfo = (bus as unknown as { config: { node: { name: string } } }).config.node
+            return endpoint.includes(nodeInfo.name.split('.')[0]) || endpoint.includes(nodeInfo.name)
+        })
+
+        return {
+            getIBGPClient: async (token: string) => {
+                if (!targetNode) return { success: false, error: 'Node not found' }
+                return targetNode.publicApi().getIBGPClient(token)
+            },
+            updateConfig: async () => ({ success: true }),
+        } as unknown as RpcStub<PublicApi>
+    }
+}

--- a/packages/orchestrator/src/next/orchestrator.gateway.test.ts
+++ b/packages/orchestrator/src/next/orchestrator.gateway.test.ts
@@ -32,9 +32,9 @@ class MockConnectionPool extends ConnectionPool {
           this.calls.push({ endpoint, config })
           return { success: true }
         }),
-        getPeerConnection: mock(async () => ({
+        getIBGPClient: mock(async () => ({
           success: true,
-          connection: {
+          client: {
             update: mock(async () => ({ success: true })),
             open: mock(async () => ({ success: true })),
           },

--- a/packages/orchestrator/src/next/orchestrator.topology.test.ts
+++ b/packages/orchestrator/src/next/orchestrator.topology.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { CatalystNodeBus, ConnectionPool, type PublicApi } from './orchestrator.js'
+import type { PeerInfo, RouteTable } from './routing/state.js'
+import { newRouteTable } from './routing/state.js'
+import { Actions } from './action-types.js'
+import type { RpcStub } from 'capnweb'
+
+const ADMIN_AUTH = { userId: 'admin', roles: ['*'] }
+
+import { MockConnectionPool } from './mock-connection-pool.js'
+
+describe('Orchestrator Topology Tests', () => {
+    let pool: MockConnectionPool
+    let nodeA: CatalystNodeBus
+    let nodeB: CatalystNodeBus
+    let nodeC: CatalystNodeBus
+
+    const infoA: PeerInfo = {
+        name: 'node-a.somebiz.local.io',
+        endpoint: 'ws://node-a',
+        domains: ['somebiz.local.io'],
+    }
+    const infoB: PeerInfo = {
+        name: 'node-b.somebiz.local.io',
+        endpoint: 'ws://node-b',
+        domains: ['somebiz.local.io'],
+    }
+    const infoC: PeerInfo = {
+        name: 'node-c.somebiz.local.io',
+        endpoint: 'ws://node-c',
+        domains: ['somebiz.local.io'],
+    }
+
+    beforeEach(() => {
+        pool = new MockConnectionPool()
+
+        const createNode = (info: PeerInfo) => {
+            const bus = new CatalystNodeBus({
+                config: { node: info, ibgp: { secret: 'secret' } },
+                connectionPool: { pool },
+                state: newRouteTable(),
+            })
+            pool.registerNode(bus)
+            return bus
+        }
+
+        nodeA = createNode(infoA)
+        nodeB = createNode(infoB)
+        nodeC = createNode(infoC)
+    })
+
+    it('Linear Topology: A <-> B <-> C propagation and withdrawal', async () => {
+        const netA = (await nodeA.publicApi().getNetworkClient('secret') as any).client
+        const netB = (await nodeB.publicApi().getNetworkClient('secret') as any).client
+        const netC = (await nodeC.publicApi().getNetworkClient('secret') as any).client
+
+        const dataA = (await nodeA.publicApi().getDataCustodianClient('secret') as any).client
+
+        // 1. Peer A to B
+        await netA.addPeer(infoB)
+        await netB.addPeer(infoA)
+
+        // 2. Peer B to C
+        await netB.addPeer(infoC)
+        await netC.addPeer(infoB)
+
+        // 3. A adds local route
+        const routeA = { name: 'service-a', protocol: 'http' as const, endpoint: 'http://a:8080' }
+        await dataA.addRoute(routeA)
+
+        // Wait for propagation (async side-effects)
+        await new Promise((r) => setTimeout(r, 100))
+
+        // Check B learned it
+        const stateB = (nodeB as unknown as { state: RouteTable }).state
+        expect(stateB.internal.routes.some((r) => r.name === 'service-a')).toBe(true)
+
+        // Check C learned it
+        const stateC = (nodeC as unknown as { state: RouteTable }).state
+        const routeOnC = stateC.internal.routes.find((r) => r.name === 'service-a')
+        expect(routeOnC).toBeDefined()
+        expect(routeOnC?.nodePath).toEqual(['node-b.somebiz.local.io', 'node-a.somebiz.local.io'])
+
+        // 4. A withdraws route
+        await dataA.removeRoute(routeA)
+        await new Promise((r) => setTimeout(r, 100))
+
+        // B and C should have removed it
+        expect((nodeB as unknown as { state: RouteTable }).state.internal.routes.some((r) => r.name === 'service-a')).toBe(false)
+        expect((nodeC as unknown as { state: RouteTable }).state.internal.routes.some((r) => r.name === 'service-a')).toBe(false)
+    })
+
+    it('Initial Sync: B learns A, then C connects to B -> C should learn A', async () => {
+        const netA = (await nodeA.publicApi().getNetworkClient('secret') as any).client
+        const netB = (await nodeB.publicApi().getNetworkClient('secret') as any).client
+        const netC = (await nodeC.publicApi().getNetworkClient('secret') as any).client
+
+        const dataA = (await nodeA.publicApi().getDataCustodianClient('secret') as any).client
+
+        // 1. B Peers with A
+        await netA.addPeer(infoB)
+        await netB.addPeer(infoA)
+
+        // Wait for peering to establish
+        if ((nodeA as unknown as { lastNotificationPromise?: Promise<void> }).lastNotificationPromise) {
+            await (nodeA as unknown as { lastNotificationPromise?: Promise<void> }).lastNotificationPromise
+        }
+        if ((nodeB as unknown as { lastNotificationPromise?: Promise<void> }).lastNotificationPromise) {
+            await (nodeB as unknown as { lastNotificationPromise?: Promise<void> }).lastNotificationPromise
+        }
+
+        // 2. A adds route
+        const routeA = { name: 'service-a', protocol: 'http' as const, endpoint: 'http://a:8080' }
+        await dataA.addRoute(routeA)
+
+        // Wait for propagation
+        if ((nodeA as unknown as { lastNotificationPromise?: Promise<void> }).lastNotificationPromise) {
+            await (nodeA as unknown as { lastNotificationPromise?: Promise<void> }).lastNotificationPromise
+        }
+
+        // Give B time to process the update received from A
+        if ((nodeB as unknown as { lastNotificationPromise?: Promise<void> }).lastNotificationPromise) {
+            await (nodeB as unknown as { lastNotificationPromise?: Promise<void> }).lastNotificationPromise
+        }
+
+        expect((nodeB as unknown as { state: RouteTable }).state.internal.routes.some((r) => r.name === 'service-a')).toBe(true)
+
+        // 3. NOW C connects to B
+        await netB.addPeer(infoC)
+        await netC.addPeer(infoB)
+
+        await new Promise((r) => setTimeout(r, 100))
+
+        // 4. C should learn A's route via B (Initial Sync)
+        const stateC = (nodeC as unknown as { state: RouteTable }).state
+        const hasA = stateC.internal.routes.some((r) => r.name === 'service-a')
+
+        // THIS IS EXPECTED TO FAIL CURRENTLY based on my audit
+        expect(hasA).toBe(true)
+    })
+
+    it('Withdrawal on Disconnect: A <-> B <-> C. A disconnects from B -> C should remove A', async () => {
+        const netA = (await nodeA.publicApi().getNetworkClient('secret') as any).client
+        const netB = (await nodeB.publicApi().getNetworkClient('secret') as any).client
+        const netC = (await nodeC.publicApi().getNetworkClient('secret') as any).client
+
+        const dataA = (await nodeA.publicApi().getDataCustodianClient('secret') as any).client
+
+        // 1. Setup A <-> B <-> C
+        await netA.addPeer(infoB)
+        await netB.addPeer(infoA)
+        await netB.addPeer(infoC)
+        await netC.addPeer(infoB)
+
+        // 2. A adds route
+        const routeA = { name: 'service-a', protocol: 'http' as const, endpoint: 'http://a:8080' }
+        await dataA.addRoute(routeA)
+        await new Promise((r) => setTimeout(r, 100))
+
+        expect((nodeC as unknown as { state: RouteTable }).state.internal.routes.some((r) => r.name === 'service-a')).toBe(true)
+
+        // 3. B disconnects from A (or A from B)
+        // We simulate A closing the connection to B
+        await netA.removePeer({ name: infoB.name })
+
+        // nodeA.LocalPeerDelete triggers nodeB.InternalProtocolClose
+        await new Promise((r) => setTimeout(r, 150))
+
+        // 4. C should have removed A's route because B told it to
+        const hasAOnC = (nodeC as unknown as { state: RouteTable }).state.internal.routes.some((r) => r.name === 'service-a')
+        expect(hasAOnC).toBe(false)
+    })
+
+    it('Loop Prevention: A -> B -> C -> A', async () => {
+        const netA = (await nodeA.publicApi().getNetworkClient('secret') as any).client
+        const netB = (await nodeB.publicApi().getNetworkClient('secret') as any).client
+        const netC = (await nodeC.publicApi().getNetworkClient('secret') as any).client
+
+        const dataA = (await nodeA.publicApi().getDataCustodianClient('secret') as any).client
+
+        // A -> B
+        await netA.addPeer(infoB)
+        await netB.addPeer(infoA)
+
+        // B -> C
+        await netB.addPeer(infoC)
+        await netC.addPeer(infoB)
+
+        // C -> A
+        await netC.addPeer(infoA)
+        await netA.addPeer(infoC)
+
+        // A adds route
+        const routeA = { name: 'loop-test', protocol: 'http' as const, endpoint: 'http://a:8080' }
+        await dataA.addRoute(routeA)
+
+        await new Promise((r) => setTimeout(r, 150))
+
+        // A should have it in local
+        expect((nodeA as unknown as { state: RouteTable }).state.local.routes.some((r) => r.name === 'loop-test')).toBe(true)
+
+        // A should NOT have it in internal (despite C offering it)
+        expect((nodeA as unknown as { state: RouteTable }).state.internal.routes.some((r) => r.name === 'loop-test')).toBe(false)
+    })
+})

--- a/packages/orchestrator/src/next/orchestrator.ts
+++ b/packages/orchestrator/src/next/orchestrator.ts
@@ -16,10 +16,15 @@ import {
 } from 'capnweb'
 
 export interface PublicApi {
-  getManagerConnection(): PeerManager
-  getPeerConnection(
-    secret: string
-  ): { success: true; connection: PeerConnection } | { success: false; error: string }
+  getNetworkClient(
+    token: string
+  ): Promise<{ success: true; client: NetworkClient } | { success: false; error: string }>
+  getDataCustodianClient(
+    token: string
+  ): Promise<{ success: true; client: DataCustodian } | { success: false; error: string }>
+  getIBGPClient(
+    token: string
+  ): Promise<{ success: true; client: IBGPClient } | { success: false; error: string }>
   getInspector(): Inspector
   dispatch(
     action: Action,
@@ -33,22 +38,22 @@ export interface Inspector {
   listRoutes(): Promise<{ local: DataChannelDefinition[]; internal: InternalRoute[] }>
 }
 
-export interface PeerManager {
-  addPeer(
-    peer: PeerInfo,
-    auth?: AuthContext
-  ): Promise<{ success: true } | { success: false; error: string }>
-  updatePeer(
-    peer: PeerInfo,
-    auth?: AuthContext
-  ): Promise<{ success: true } | { success: false; error: string }>
+export interface NetworkClient {
+  addPeer(peer: PeerInfo): Promise<{ success: true } | { success: false; error: string }>
+  updatePeer(peer: PeerInfo): Promise<{ success: true } | { success: false; error: string }>
   removePeer(
-    peer: Pick<PeerInfo, 'name'>,
-    auth?: AuthContext
+    peer: Pick<PeerInfo, 'name'>
   ): Promise<{ success: true } | { success: false; error: string }>
 }
 
-export interface PeerConnection {
+export interface DataCustodian {
+  addRoute(route: DataChannelDefinition): Promise<{ success: true } | { success: false; error: string }>
+  removeRoute(
+    route: DataChannelDefinition
+  ): Promise<{ success: true } | { success: false; error: string }>
+}
+
+export interface IBGPClient {
   open(peer: PeerInfo): Promise<{ success: true } | { success: false; error: string }>
   close(
     peer: PeerInfo,
@@ -104,10 +109,15 @@ export interface OrchestratorConfig {
   }
 }
 
+const NETWORK_MGMT_AUTH: AuthContext = { userId: 'network:mgmt', roles: ['network custodian'] }
+const DATA_MGMT_AUTH: AuthContext = { userId: 'data:mgmt', roles: ['data custodian'] }
+const PEER_AUTH: AuthContext = { userId: 'peer:authenticated', roles: ['network peers'] }
+
 export class CatalystNodeBus extends RpcTarget {
   private state: RouteTable
   private connectionPool: ConnectionPool
   private config: OrchestratorConfig
+  public lastNotificationPromise?: Promise<void>
 
   constructor(opts: {
     state?: RouteTable
@@ -149,6 +159,7 @@ export class CatalystNodeBus extends RpcTarget {
     sentAction: Action,
     auth?: AuthContext
   ): Promise<{ success: true } | { success: false; error: string }> {
+    console.log(`[${this.config.node.name}] dispatch called. Auth provided:`, JSON.stringify(auth))
     // Validate and default to anonymous context
     const resolvedAuth: AuthContext = auth
       ? AuthContextSchema.parse(auth)
@@ -158,12 +169,27 @@ export class CatalystNodeBus extends RpcTarget {
       : { userId: 'anonymous', roles: [] }
 
     const prevState = this.state
+    console.log(`[${this.config.node.name}] Dispatching action: ${sentAction.action}`)
+
+    // Log detailed data for route creation to debug
+    if (sentAction.action === Actions.LocalRouteCreate) {
+      console.log(`[${this.config.node.name}] Route Create Data:`, JSON.stringify(sentAction.data))
+    }
+
     const result = await this.handleAction(sentAction, this.state, resolvedAuth)
     if (result.success) {
       this.state = result.state
-      // Fire notifications/side-effects after state update
-      await this.handleNotify(sentAction, result.state, prevState, resolvedAuth)
+      // Fire and forget side effects to avoid deadlocks in distributed calls
+
+      // Note: Hono's waitUntil is not available here easily as we are in the core class.
+      // The catch below handles unhandled rejections for the side effect chain.
+      // Ideally in a serverless evironment we would use ctx.waitUntil.
+      this.lastNotificationPromise = this.handleNotify(sentAction, this.state, prevState, resolvedAuth).catch((e) => {
+        console.error(`[${this.config.node.name}] Error in handleNotify for ${sentAction.action}:`, e)
+      })
       return { success: true }
+    } else {
+      console.error(`[${this.config.node.name}] Action failed: ${sentAction.action}`, result.error)
     }
     return result
   }
@@ -174,12 +200,12 @@ export class CatalystNodeBus extends RpcTarget {
     auth: AuthContext
   ): Promise<{ success: true; state: RouteTable } | { success: false; error: string }> {
     // Permission check - single enforcement point
-    const requiredPermission = getRequiredPermission(action)
-    if (!hasPermission(auth.roles, requiredPermission)) {
-      console.error(
-        `[CatalystNodeBus] Permission denied: action:${action} roles:${auth.roles} required:${requiredPermission}`
-      )
-      return { success: false, error: `Permission denied: ${requiredPermission}` }
+    const permission = getRequiredPermission(action)
+    if (!permission) {
+      return { success: false, error: `Unauthorized action: ${action.action}` }
+    }
+    if (!hasPermission(auth.roles, permission, auth.permissions)) {
+      return { success: false, error: `Permission denied: ${permission}` }
     }
 
     switch (action.action) {
@@ -223,18 +249,12 @@ export class CatalystNodeBus extends RpcTarget {
             peers: peerList.map((p) =>
               p.name === action.data.name
                 ? {
-                    ...p,
-                    endpoint: action.data.endpoint,
-                    domains: action.data.domains,
-                    connectionStatus: 'initializing',
-                    lastConnected: undefined,
-                  }
-                    ...p,
-                    endpoint: action.data.endpoint,
-                    domains: action.data.domains,
-                    connectionStatus: 'initializing',
-                    lastConnected: undefined,
-                  }
+                  ...p,
+                  endpoint: action.data.endpoint,
+                  domains: action.data.domains,
+                  connectionStatus: 'initializing',
+                  lastConnected: undefined,
+                }
                 : p
             ),
           },
@@ -341,12 +361,14 @@ export class CatalystNodeBus extends RpcTarget {
         break
       }
       case Actions.InternalProtocolUpdate: {
-        const peerInfo = action.data.peerInfo
+        const { peerInfo, update } = action.data
+        console.log(`[${this.config.node.name}] InternalProtocolUpdate: received ${update.updates.length} updates from ${peerInfo.name}`)
+        const sourcePeerName = peerInfo.name
         let currentInternalRoutes = [...state.internal.routes]
 
-        for (const update of action.data.update.updates) {
-          if (update.action === 'add') {
-            const nodePath = update.nodePath ?? []
+        for (const u of update.updates) {
+          if (u.action === 'add') {
+            const nodePath = u.nodePath ?? []
 
             // Loop Prevention
             if (nodePath.includes(this.config.node.name)) {
@@ -356,21 +378,19 @@ export class CatalystNodeBus extends RpcTarget {
               continue
             }
 
-            const routeToAdd = {
-              ...update.route,
-              peer: peerInfo,
-              peerName: peerInfo.name,
-              nodePath,
-            }
-
             // Remove existing if any (upsert)
             currentInternalRoutes = currentInternalRoutes.filter(
-              (r) => !(r.name === update.route.name && r.peerName === peerInfo.name)
+              (r) => !(r.name === u.route.name && r.peerName === sourcePeerName)
             )
-            currentInternalRoutes.push(routeToAdd)
-          } else if (update.action === 'remove') {
+            currentInternalRoutes.push({
+              ...u.route,
+              peerName: sourcePeerName,
+              peer: peerInfo,
+              nodePath: nodePath,
+            })
+          } else if (u.action === 'remove') {
             currentInternalRoutes = currentInternalRoutes.filter(
-              (r) => !(r.name === update.route.name && r.peerName === peerInfo.name)
+              (r) => r.name !== u.route.name || r.peerName !== sourcePeerName
             )
           }
         }
@@ -393,7 +413,7 @@ export class CatalystNodeBus extends RpcTarget {
     return { success: true, state }
   }
 
-  private async syncGateway() {
+  private async handleGraphqlConfiguration() {
     const gatewayEndpoint = this.config.gqlGatewayConfig?.endpoint
     if (!gatewayEndpoint) return
 
@@ -433,10 +453,7 @@ export class CatalystNodeBus extends RpcTarget {
     }
   }
 
-  /**
-   * Handle side effects after state changes.
-   */
-  async handleNotify(
+  async handleBGPNotify(
     action: Action,
     _state: RouteTable,
     prevState: RouteTable,
@@ -446,13 +463,18 @@ export class CatalystNodeBus extends RpcTarget {
       case Actions.LocalPeerCreate: {
         // Perform side effect: Try to open connection
         try {
+          console.log(`[${this.config.node.name}] LocalPeerCreate: attempting connection to ${action.data.name} at ${action.data.endpoint}`)
           const stub = this.connectionPool.get(action.data.endpoint)
           if (stub) {
-            const connectionResult = await stub.getPeerConnection('secret')
+            const connectionResult = await stub.getIBGPClient(
+              this.config.ibgp?.secret || 'valid-secret'
+            )
+
             if (connectionResult.success) {
-              const result = await connectionResult.connection.open(this.config.node)
+              const result = await connectionResult.client.open(this.config.node)
 
               if (result.success) {
+                console.log(`[${this.config.node.name}] Successfully opened connection to ${action.data.name}`)
                 // Dispatch connected action with inherited auth
                 await this.dispatch(
                   {
@@ -480,97 +502,129 @@ export class CatalystNodeBus extends RpcTarget {
         break
       }
       case Actions.InternalProtocolOpen: {
-        // Sync existing local routes back to the new peer
-        for (const route of _state.local.routes) {
+        console.log(`[${this.config.node.name}] InternalProtocolOpen: sync request from ${action.data.peerInfo.name}`)
+        // Sync existing routes (local AND internal) back to the new peer
+        const allRoutes = [
+          ..._state.local.routes.map((r) => ({
+            action: 'add' as const,
+            route: r,
+            nodePath: [this.config.node.name],
+          })),
+          ..._state.internal.routes
+            .filter((r) => !r.nodePath.includes(action.data.peerInfo.name))
+            .map((r) => ({
+              action: 'add' as const,
+              route: r,
+              nodePath: [this.config.node.name, ...r.nodePath],
+            })),
+        ]
+
+        if (allRoutes.length > 0) {
           try {
             const stub = this.connectionPool.get(action.data.peerInfo.endpoint)
             if (stub) {
-              const connectionResult = await stub.getPeerConnection('secret')
+              const connectionResult = await stub.getIBGPClient(
+                this.config.ibgp?.secret || 'valid-secret'
+              )
               if (connectionResult.success) {
-                await connectionResult.connection.update(this.config.node, {
-                  updates: [{ action: 'add', route, nodePath: [this.config.node.name] }],
+                await connectionResult.client.update(this.config.node, {
+                  updates: allRoutes,
                 })
               }
             }
           } catch (e) {
             console.error(
-              `[${this.config.node.name}] Failed to sync route back to ${action.data.peerInfo.name}`,
+              `[${this.config.node.name}] Failed to sync routes back to ${action.data.peerInfo.name}`,
               e
             )
             console.error(
-              `[${this.config.node.name}] Failed to sync route back to ${action.data.peerInfo.name}`,
+              `[${this.config.node.name}] Failed to sync routes back to ${action.data.peerInfo.name}`,
               e
             )
           }
         }
-        await this.syncGateway()
         break
       }
       case Actions.InternalProtocolConnected: {
-        // Sync existing local routes to the new peer
-        for (const route of _state.local.routes) {
+        // Sync existing routes (local AND internal) to the new peer
+        const allRoutes = [
+          ..._state.local.routes.map((r) => ({
+            action: 'add' as const,
+            route: r,
+            nodePath: [this.config.node.name],
+          })),
+          ..._state.internal.routes
+            .filter((r) => !r.nodePath.includes(action.data.peerInfo.name))
+            .map((r) => ({
+              action: 'add' as const,
+              route: r,
+              nodePath: [this.config.node.name, ...r.nodePath],
+            })),
+        ]
+
+        if (allRoutes.length > 0) {
           try {
             const stub = this.connectionPool.get(action.data.peerInfo.endpoint)
             if (stub) {
-              const connectionResult = await stub.getPeerConnection('secret')
+              const connectionResult = await stub.getIBGPClient(
+                this.config.ibgp?.secret || 'valid-secret'
+              )
               if (connectionResult.success) {
-                await connectionResult.connection.update(this.config.node, {
-                  updates: [{ action: 'add', route, nodePath: [this.config.node.name] }],
+                await connectionResult.client.update(this.config.node, {
+                  updates: allRoutes,
                 })
               }
             }
           } catch (e) {
             console.error(
-              `[${this.config.node.name}] Failed to sync route to ${action.data.peerInfo.name}`,
+              `[${this.config.node.name}] Failed to sync routes to ${action.data.peerInfo.name}`,
               e
             )
             console.error(
-              `[${this.config.node.name}] Failed to sync route to ${action.data.peerInfo.name}`,
+              `[${this.config.node.name}] Failed to sync routes to ${action.data.peerInfo.name}`,
               e
             )
           }
         }
-        await this.syncGateway()
         break
       }
       case Actions.LocalPeerDelete: {
-        // Use prevState to find the peer info that was just deleted
+        // 1. Close connection to the deleted peer
         const peer = prevState.internal.peers.find((p) => p.name === action.data.name)
         if (peer) {
           try {
             const stub = this.connectionPool.get(peer.endpoint)
             if (stub) {
-              const connectionResult = await stub.getPeerConnection('secret')
+              const connectionResult = await stub.getIBGPClient(
+                this.config.ibgp?.secret || 'valid-secret'
+              )
               if (connectionResult.success) {
-                await connectionResult.connection.close(this.config.node, 1000, 'Peer removed')
+                await connectionResult.client.close(this.config.node, 1000, 'Peer removed')
               }
             }
           } catch (e) {
-            console.error(
-              `[${this.config.node.name}] Failed to close connection to ${peer.name}`,
-              e
-            )
-            console.error(
-              `[${this.config.node.name}] Failed to close connection to ${peer.name}`,
-              e
-            )
+            console.error(`[${this.config.node.name}] Failed to close connection to ${peer.name}`, e)
           }
         }
+
+        // 2. Propagate removal of routes learned FROM this peer to OTHER peers
+        await this.propagateWithdrawalsForPeer(action.data.name, prevState, _state)
         break
       }
       case Actions.LocalRouteCreate: {
-        for (const peer of _state.internal.peers.filter(
-          (p) => p.connectionStatus === 'connected'
-        )) {
-        for (const peer of _state.internal.peers.filter(
-          (p) => p.connectionStatus === 'connected'
-        )) {
+        // Broadcast to all connected internal peers
+        const connectedPeers = _state.internal.peers.filter((p) => p.connectionStatus === 'connected')
+        console.log(`[${this.config.node.name}] LocalRouteCreate: ${action.data.name}, broadcasting to ${connectedPeers.length} peers.`)
+        for (const peer of connectedPeers) {
           try {
             const stub = this.connectionPool.get(peer.endpoint)
             if (stub) {
-              const connectionResult = await stub.getPeerConnection('secret')
+              console.log(`[${this.config.node.name}] Pushing local route ${action.data.name} to ${peer.name}`)
+              const connectionResult = await stub.getIBGPClient(
+                this.config.ibgp?.secret || 'valid-secret'
+              )
               if (connectionResult.success) {
-                await connectionResult.connection.update(this.config.node, {
+                await connectionResult.client.update(this.config.node, {
                   updates: [
                     { action: 'add', route: action.data, nodePath: [this.config.node.name] },
                   ],
@@ -581,7 +635,6 @@ export class CatalystNodeBus extends RpcTarget {
             console.error(`[${this.config.node.name}] Failed to broadcast route to ${peer.name}`, e)
           }
         }
-        await this.syncGateway()
         break
       }
       case Actions.LocalRouteDelete: {
@@ -594,9 +647,11 @@ export class CatalystNodeBus extends RpcTarget {
           try {
             const stub = this.connectionPool.get(peer.endpoint)
             if (stub) {
-              const connectionResult = await stub.getPeerConnection('secret')
+              const connectionResult = await stub.getIBGPClient(
+                this.config.ibgp?.secret || 'valid-secret'
+              )
               if (connectionResult.success) {
-                await connectionResult.connection.update(this.config.node, {
+                await connectionResult.client.update(this.config.node, {
                   updates: [{ action: 'remove', route: action.data }],
                 })
               }
@@ -612,7 +667,6 @@ export class CatalystNodeBus extends RpcTarget {
             )
           }
         }
-        await this.syncGateway()
         break
       }
       case Actions.InternalProtocolUpdate: {
@@ -621,13 +675,28 @@ export class CatalystNodeBus extends RpcTarget {
           (p) => p.connectionStatus === 'connected' && p.name !== sourcePeerName
         )) {
           try {
+            // Filter out updates that have a loop (including the local node,
+            // as we should have already dropped them, and the target peer,
+            // as they would drop it anyway).
+            const safeUpdates = action.data.update.updates.filter((u) => {
+              if (u.action === 'remove') return true
+              const path = u.nodePath ?? []
+              if (path.includes(this.config.node.name)) return false
+              if (path.includes(peer.name)) return false
+              return true
+            })
+
+            if (safeUpdates.length === 0) continue
+
             const stub = this.connectionPool.get(peer.endpoint)
             if (stub) {
-              const connectionResult = await stub.getPeerConnection('secret')
+              const connectionResult = await stub.getIBGPClient(
+                this.config.ibgp?.secret || 'valid-secret'
+              )
               if (connectionResult.success) {
                 // Prepend my FQDN to the path of propagated updates
                 const updatesWithPrepend = {
-                  updates: action.data.update.updates.map((u) => {
+                  updates: safeUpdates.map((u) => {
                     if (u.action === 'add') {
                       return {
                         ...u,
@@ -637,7 +706,7 @@ export class CatalystNodeBus extends RpcTarget {
                     return u
                   }),
                 }
-                await connectionResult.connection.update(this.config.node, updatesWithPrepend)
+                await connectionResult.client.update(this.config.node, updatesWithPrepend)
               }
             }
           } catch (e) {
@@ -651,56 +720,149 @@ export class CatalystNodeBus extends RpcTarget {
             )
           }
         }
-        await this.syncGateway()
         break
       }
       case Actions.InternalProtocolClose: {
-        await this.syncGateway()
+        await this.propagateWithdrawalsForPeer(action.data.peerInfo.name, prevState, _state)
         break
+      }
+    }
+  }
+
+  /**
+   * Handle side effects after state changes.
+   */
+  async handleNotify(
+    action: Action,
+    _state: RouteTable,
+    prevState: RouteTable,
+    auth: AuthContext
+  ): Promise<void> {
+    await this.handleBGPNotify(action, _state, prevState, auth)
+    await this.handleGraphqlConfiguration()
+  }
+
+  private async propagateWithdrawalsForPeer(
+    peerName: string,
+    prevState: RouteTable,
+    newState: RouteTable
+  ) {
+    const removedRoutes = prevState.internal.routes.filter((r) => r.peerName === peerName)
+    if (removedRoutes.length === 0) return
+
+    console.log(
+      `[${this.config.node.name}] Propagating withdrawal of ${removedRoutes.length} routes from ${peerName}`
+    )
+
+    for (const peer of newState.internal.peers.filter(
+      (p) => p.connectionStatus === 'connected' && p.name !== peerName
+    )) {
+      try {
+        const stub = this.connectionPool.get(peer.endpoint)
+        if (stub) {
+          const connectionResult = await stub.getIBGPClient(
+            this.config.ibgp?.secret || 'valid-secret'
+          )
+
+          if (connectionResult.success) {
+            await connectionResult.client.update(this.config.node, {
+              updates: removedRoutes.map((r) => ({ action: 'remove' as const, route: r })),
+            })
+          }
+        }
+      } catch (e) {
+        console.error(
+          `[${this.config.node.name}] Failed to propagate withdrawal to ${peer.name}`,
+          e
+        )
       }
     }
   }
 
   publicApi(): PublicApi {
     return {
-      getManagerConnection: (): PeerManager => {
-        return {
-          addPeer: async (peer: PeerInfo, auth?: AuthContext) => {
-            return this.dispatch({ action: Actions.LocalPeerCreate, data: peer }, auth)
-          },
-          updatePeer: async (peer: PeerInfo, auth?: AuthContext) => {
-            return this.dispatch({ action: Actions.LocalPeerUpdate, data: peer }, auth)
-          },
-          removePeer: async (peer: Pick<PeerInfo, 'name'>, auth?: AuthContext) => {
-            return this.dispatch({ action: Actions.LocalPeerDelete, data: peer }, auth)
-          },
-        }
-      },
-      getPeerConnection: (
-        secret: string
-      ): { success: true; connection: PeerConnection } | { success: false; error: string } => {
-        // Validate PSK
+      getNetworkClient: async (
+        token: string
+      ): Promise<{ success: true; client: NetworkClient } | { success: false; error: string }> => {
+        // TODO: Parse token to extract authorization context
         const expectedSecret = this.config?.ibgp?.secret
-        if (!expectedSecret || !isSecretValid(secret, expectedSecret)) {
-          return { success: false, error: 'Invalid secret' }
+        if (!expectedSecret || !isSecretValid(token, expectedSecret)) {
+          return { success: false, error: 'Invalid management token' }
         }
 
-        // Create peer auth context with ibgp permissions
-        const peerAuth: AuthContext = {
-          userId: 'peer:authenticated',
-          roles: ['ibgp:connect', 'ibgp:disconnect', 'ibgp:update'],
+        const auth: AuthContext = {
+          userId: 'networkmgmt',
+          roles: ['networkcustodian'],
+          permissions: ['peer:create', 'peer:update', 'peer:delete'],
         }
 
         return {
           success: true,
-          connection: {
+          client: {
+            addPeer: async (peer: PeerInfo) => {
+              return this.dispatch({ action: Actions.LocalPeerCreate, data: peer }, auth)
+            },
+            updatePeer: async (peer: PeerInfo) => {
+              return this.dispatch({ action: Actions.LocalPeerUpdate, data: peer }, auth)
+            },
+            removePeer: async (peer: Pick<PeerInfo, 'name'>) => {
+              return this.dispatch({ action: Actions.LocalPeerDelete, data: peer }, auth)
+            },
+          },
+        }
+      },
+      getDataCustodianClient: async (
+        token: string
+      ): Promise<{ success: true; client: DataCustodian } | { success: false; error: string }> => {
+        // TODO: Parse token to extract authorization context
+        const expectedSecret = this.config?.ibgp?.secret
+        if (!expectedSecret || !isSecretValid(token, expectedSecret)) {
+          return { success: false, error: 'Invalid management token' }
+        }
+
+        const auth: AuthContext = {
+          userId: 'datamgmt',
+          roles: ['datacustodian'],
+          permissions: ['route:create', 'route:delete'],
+        }
+
+        return {
+          success: true,
+          client: {
+            addRoute: async (route: DataChannelDefinition) => {
+              return this.dispatch({ action: Actions.LocalRouteCreate, data: route }, auth)
+            },
+            removeRoute: async (route: DataChannelDefinition) => {
+              return this.dispatch({ action: Actions.LocalRouteDelete, data: route }, auth)
+            },
+          },
+        }
+      },
+      getIBGPClient: async (
+        token: string
+      ): Promise<{ success: true; client: IBGPClient } | { success: false; error: string }> => {
+        // TODO: Parse token to extract authorization context
+        const expectedSecret = this.config?.ibgp?.secret
+        if (!expectedSecret || !isSecretValid(token, expectedSecret)) {
+          return { success: false, error: 'Invalid secret' }
+        }
+
+        const auth: AuthContext = {
+          userId: 'ibgppeer',
+          roles: ['networkpeer'],
+          permissions: ['ibgp:connect', 'ibgp:disconnect', 'ibgp:update'],
+        }
+
+        return {
+          success: true,
+          client: {
             open: async (peer: PeerInfo) => {
               return this.dispatch(
                 {
                   action: Actions.InternalProtocolOpen,
                   data: { peerInfo: peer },
                 },
-                peerAuth
+                auth
               )
             },
             close: async (peer: PeerInfo, code: number, reason?: string) => {
@@ -709,7 +871,7 @@ export class CatalystNodeBus extends RpcTarget {
                   action: Actions.InternalProtocolClose,
                   data: { peerInfo: peer, code, reason },
                 },
-                peerAuth
+                auth
               )
             },
             update: async (peer: PeerInfo, update: z.infer<typeof UpdateMessageSchema>) => {
@@ -721,7 +883,7 @@ export class CatalystNodeBus extends RpcTarget {
                     update: update,
                   },
                 },
-                peerAuth
+                auth
               )
             },
           },
@@ -742,3 +904,4 @@ export class CatalystNodeBus extends RpcTarget {
     }
   }
 }
+

--- a/packages/orchestrator/src/next/peering.orchestrator.topology.container.test.ts
+++ b/packages/orchestrator/src/next/peering.orchestrator.topology.container.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import {
+    GenericContainer,
+    Wait,
+    Network,
+    type StartedTestContainer,
+    type StartedNetwork,
+} from 'testcontainers'
+import path from 'path'
+import { spawnSync } from 'node:child_process'
+import { newWebSocketRpcSession } from 'capnweb'
+import type { PublicApi } from './orchestrator.js'
+
+describe('Orchestrator Peering Container Tests', () => {
+    const TIMEOUT = 600000 // 10 minutes
+
+    let network: StartedNetwork
+    let nodeA: StartedTestContainer
+    let nodeB: StartedTestContainer
+
+    const orchestratorImage = 'localhost/catalyst-node:next-topology-e2e'
+    const repoRoot = path.resolve(__dirname, '../../../../')
+    const skipTests =
+        !process.env.DOCKER_HOST && !process.env.DOCKER_SOCK && !process.env.PODMAN_VAR_LINK
+
+    beforeAll(async () => {
+        if (skipTests) {
+            console.warn('Skipping container tests: Podman runtime not detected')
+            return
+        }
+
+        // Check if image exists
+        const checkImage = spawnSync('podman', ['image', 'exists', orchestratorImage])
+        if (checkImage.status !== 0) {
+            console.log('Building Orchestrator image for Topology tests...')
+            const orchestratorBuild = spawnSync(
+                'podman',
+                ['build', '-f', 'packages/orchestrator/Dockerfile', '-t', orchestratorImage, '.'],
+                { cwd: repoRoot, stdio: 'inherit' }
+            )
+            if (orchestratorBuild.status !== 0) throw new Error('Podman build orchestrator failed')
+        } else {
+            console.log(`Using existing image: ${orchestratorImage}`)
+        }
+
+        network = await new Network().start()
+
+        const startNode = async (name: string, alias: string) => {
+            console.log(`Starting node ${name}...`)
+            const container = await new GenericContainer(orchestratorImage)
+                .withNetwork(network)
+                .withNetworkAliases(alias)
+                .withExposedPorts(3000)
+                .withCommand(['sh', '-c', 'bun run src/next/index.ts'])
+                .withEnvironment({
+                    PORT: '3000',
+                    CATALYST_NODE_ID: name,
+                    CATALYST_PEERING_ENDPOINT: `ws://${alias}:3000/rpc`,
+                    CATALYST_DOMAINS: 'somebiz.local.io',
+                    CATALYST_PEERING_SECRET: 'valid-secret',
+                })
+                .withWaitStrategy(Wait.forLogMessage('NEXT_ORCHESTRATOR_STARTED'))
+                .withLogConsumer(
+                    (stream: { on(event: string, listener: (line: string) => void): void; pipe(dest: any): void }) => {
+                        // Pipe directly to stdout/stderr to ensure capture
+                        // @ts-expect-error - stream types are fuzzy
+                        if (stream.pipe) stream.pipe(process.stdout)
+
+                        stream.on('line', (line: string) => {
+                            process.stdout.write(`[${name}] ${line}\n`)
+                        })
+                        stream.on('err', (line: string) => process.stderr.write(`[${name}] ERR: ${line}\n`))
+                    }
+                )
+                .start()
+            console.log(`Node ${name} started and healthy.`)
+            return container
+        }
+
+        nodeA = await startNode('node-a.somebiz.local.io', 'node-a')
+        nodeB = await startNode('node-b.somebiz.local.io', 'node-b')
+
+        console.log('All nodes started.')
+    }, TIMEOUT)
+
+    afterAll(async () => {
+        if (nodeA) await nodeA.stop()
+        if (nodeB) await nodeB.stop()
+        if (network) await network.stop()
+    })
+
+    const getClient = (node: StartedTestContainer) => {
+        const port = node.getMappedPort(3000)
+        return newWebSocketRpcSession<PublicApi>(`ws://127.0.0.1:${port}/rpc`)
+    }
+
+    it(
+        'Simple Peering: A <-> B propagation',
+        async () => {
+            if (skipTests) return
+
+            const clientA = getClient(nodeA)
+            const clientB = getClient(nodeB)
+
+            const adminAuth = { userId: 'admin', roles: ['*'] }
+
+            // 1. Linear Peering: A <-> B
+            console.log('Establishing peering A <-> B')
+            const netAResult = await clientA.getNetworkClient('valid-secret')
+            const netBResult = await clientB.getNetworkClient('valid-secret')
+
+            if (!netAResult.success || !netBResult.success) {
+                throw new Error('Failed to get network client')
+            }
+
+            const netA = netAResult.client
+            const netB = netBResult.client
+
+            // Setup B to accept A first, then A connects to B
+            await netB.addPeer({
+                name: 'node-a.somebiz.local.io',
+                endpoint: 'ws://node-a:3000/rpc',
+                domains: ['somebiz.local.io']
+            })
+            await netA.addPeer({
+                name: 'node-b.somebiz.local.io',
+                endpoint: 'ws://node-b:3000/rpc',
+                domains: ['somebiz.local.io']
+            })
+
+            // Wait for handshake
+            console.log('Waiting for peering A <-> B to resolve...')
+            const waitForConnected = async (client: any, peerName: string) => {
+                for (let i = 0; i < 20; i++) {
+                    const peers = await client.getInspector().listPeers()
+                    const peer = peers.find((p: any) => p.name === peerName)
+                    if (peer && peer.connectionStatus === 'connected') return
+                    await new Promise(r => setTimeout(r, 500))
+                }
+                throw new Error(`Peer ${peerName} failed to connect`)
+            }
+            await waitForConnected(clientA, 'node-b.somebiz.local.io')
+            await waitForConnected(clientB, 'node-a.somebiz.local.io')
+
+            // 2. A adds a local route
+            console.log('Node A adding local route')
+            const dataAResult = await clientA.getDataCustodianClient('valid-secret')
+            if (!dataAResult.success) throw new Error('Failed to get data client')
+
+            const routeResult = await dataAResult.client.addRoute({
+                name: 'service-a', protocol: 'http', endpoint: 'http://a:8080'
+            })
+
+            if (!routeResult.success) {
+                console.error('Route create failed:', routeResult)
+                throw new Error(`Route create failed: ${routeResult.error || 'Unknown error'}`)
+            }
+
+            // Check B learned it
+            let learnedOnB = false
+            for (let i = 0; i < 40; i++) {
+                const inspector = await clientB.getInspector()
+                const routes = await inspector.listRoutes()
+                if (routes.internal.some(r => r.name === 'service-a')) {
+                    learnedOnB = true
+                    break
+                }
+                await new Promise(r => setTimeout(r, 500))
+            }
+            expect(learnedOnB).toBe(true)
+        },
+        TIMEOUT
+    )
+})

--- a/packages/orchestrator/src/next/peering.orchestrator.topology.test.ts
+++ b/packages/orchestrator/src/next/peering.orchestrator.topology.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { CatalystNodeBus } from './orchestrator.js'
+import type { PeerInfo, RouteTable } from './routing/state.js'
+import { newRouteTable } from './routing/state.js'
+import { Actions } from './action-types.js'
+import { MockConnectionPool } from './mock-connection-pool.js'
+
+const ADMIN_AUTH = { userId: 'admin', roles: ['*'] }
+
+describe('Orchestrator Peering Tests (Mocked Container Logic)', () => {
+    let pool: MockConnectionPool
+    let nodeA: CatalystNodeBus
+    let nodeB: CatalystNodeBus
+
+    const infoA: PeerInfo = {
+        name: 'node-a.somebiz.local.io',
+        endpoint: 'ws://node-a',
+        domains: ['somebiz.local.io'],
+    }
+    const infoB: PeerInfo = {
+        name: 'node-b.somebiz.local.io',
+        endpoint: 'ws://node-b',
+        domains: ['somebiz.local.io'],
+    }
+
+    beforeEach(() => {
+        pool = new MockConnectionPool()
+
+        const createNode = (info: PeerInfo) => {
+            const bus = new CatalystNodeBus({
+                config: { node: info, ibgp: { secret: 'secret' } },
+                connectionPool: { pool },
+                state: newRouteTable(),
+            })
+            pool.registerNode(bus)
+            return bus
+        }
+
+        nodeA = createNode(infoA)
+        nodeB = createNode(infoB)
+    })
+
+    const waitForNotification = async (node: CatalystNodeBus) => {
+        if ((node as unknown as { lastNotificationPromise?: Promise<void> }).lastNotificationPromise) {
+            await (node as unknown as { lastNotificationPromise?: Promise<void> }).lastNotificationPromise
+        }
+    }
+
+    it('Simple Peering: A <-> B propagation', async () => {
+        // 1. Establish Peering
+        const apiA = nodeA.publicApi()
+        const apiB = nodeB.publicApi()
+
+        const netAResult = await apiA.getNetworkClient('secret')
+        const netBResult = await apiB.getNetworkClient('secret')
+
+        expect(netAResult.success).toBe(true)
+        expect(netBResult.success).toBe(true)
+
+        const netA = (netAResult as any).client
+        const netB = (netBResult as any).client
+
+        console.log('Node B adding peer A')
+        await netB.addPeer(infoA)
+
+        console.log('Node A adding peer B')
+        await netA.addPeer(infoB)
+
+        // Wait for handshake
+        await waitForNotification(nodeA)
+        await waitForNotification(nodeB)
+
+        // Additional wait to ensure bidirectional sync
+        await new Promise(r => setTimeout(r, 50))
+
+        // Verify connection status
+        const stateA = (nodeA as unknown as { state: RouteTable }).state
+        const peerB = stateA.internal.peers.find(p => p.name === infoB.name)
+        expect(peerB?.connectionStatus).toBe('connected')
+
+        const stateB = (nodeB as unknown as { state: RouteTable }).state
+        const peerA = stateB.internal.peers.find(p => p.name === infoA.name)
+        expect(peerA?.connectionStatus).toBe('connected')
+
+        // 2. A adds a local route
+        console.log('Node A adding local route')
+        const routeA = { name: 'service-a', protocol: 'http' as const, endpoint: 'http://a:8080' }
+        const dataA = (await apiA.getDataCustodianClient('secret') as any).client
+        await dataA.addRoute(routeA)
+
+        // Wait for propagation
+        await waitForNotification(nodeA)
+        await waitForNotification(nodeB)
+        await new Promise(r => setTimeout(r, 50))
+
+        // Check B learned it
+        const stateB_After = (nodeB as unknown as { state: RouteTable }).state
+        const learnedRoute = stateB_After.internal.routes.find(r => r.name === 'service-a')
+
+        expect(learnedRoute).toBeDefined()
+        expect(learnedRoute?.nodePath).toEqual(['node-a.somebiz.local.io'])
+    })
+})

--- a/packages/orchestrator/src/next/transit.orchestrator.topology.container.test.ts
+++ b/packages/orchestrator/src/next/transit.orchestrator.topology.container.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import {
+    GenericContainer,
+    Wait,
+    Network,
+    type StartedTestContainer,
+    type StartedNetwork,
+} from 'testcontainers'
+import path from 'path'
+import { spawnSync } from 'node:child_process'
+import { newWebSocketRpcSession } from 'capnweb'
+import type { PublicApi } from './orchestrator.js'
+
+describe('Orchestrator Transit Container Tests', () => {
+    const TIMEOUT = 600000 // 10 minutes
+
+    let network: StartedNetwork
+    let nodeA: StartedTestContainer
+    let nodeB: StartedTestContainer
+    let nodeC: StartedTestContainer
+
+    const orchestratorImage = 'localhost/catalyst-node:next-topology-e2e'
+    const repoRoot = path.resolve(__dirname, '../../../../')
+    const skipTests =
+        !process.env.DOCKER_HOST && !process.env.DOCKER_SOCK && !process.env.PODMAN_VAR_LINK
+
+    beforeAll(async () => {
+        if (skipTests) {
+            console.warn('Skipping container tests: Podman runtime not detected')
+            return
+        }
+
+        // Check if image exists
+        const checkImage = spawnSync('podman', ['image', 'exists', orchestratorImage])
+        if (checkImage.status !== 0) {
+            console.log('Building Orchestrator image for Topology tests...')
+            const orchestratorBuild = spawnSync(
+                'podman',
+                ['build', '-f', 'packages/orchestrator/Dockerfile', '-t', orchestratorImage, '.'],
+                { cwd: repoRoot, stdio: 'inherit' }
+            )
+            if (orchestratorBuild.status !== 0) throw new Error('Podman build orchestrator failed')
+        } else {
+            console.log(`Using existing image: ${orchestratorImage}`)
+        }
+
+        network = await new Network().start()
+
+        const startNode = async (name: string, alias: string) => {
+            console.log(`Starting node ${name}...`)
+            const container = await new GenericContainer(orchestratorImage)
+                .withNetwork(network)
+                .withNetworkAliases(alias)
+                .withExposedPorts(3000)
+                .withCommand(['sh', '-c', 'bun run src/next/index.ts'])
+                .withEnvironment({
+                    PORT: '3000',
+                    CATALYST_NODE_ID: name,
+                    CATALYST_PEERING_ENDPOINT: `ws://${alias}:3000/rpc`,
+                    CATALYST_DOMAINS: 'somebiz.local.io',
+                    CATALYST_PEERING_SECRET: 'valid-secret',
+                })
+                .withWaitStrategy(Wait.forHttp('/health', 3000))
+                .withLogConsumer(
+                    (stream: { on(event: string, listener: (line: string) => void): void }) => {
+                        stream.on('line', (line: string) => {
+                            process.stdout.write(`[${name}] ${line}\n`)
+                        })
+                        stream.on('err', (line: string) => process.stderr.write(`[${name}] ERR: ${line}\n`))
+                    }
+                )
+                .start()
+            console.log(`Node ${name} started and healthy.`)
+            return container
+        }
+
+        nodeA = await startNode('node-a.somebiz.local.io', 'node-a')
+        nodeB = await startNode('node-b.somebiz.local.io', 'node-b')
+        nodeC = await startNode('node-c.somebiz.local.io', 'node-c')
+
+        console.log('All nodes started.')
+    }, TIMEOUT)
+
+    afterAll(async () => {
+        if (nodeA) await nodeA.stop()
+        if (nodeB) await nodeB.stop()
+        if (nodeC) await nodeC.stop()
+        if (network) await network.stop()
+    })
+
+    const getClient = (node: StartedTestContainer) => {
+        const port = node.getMappedPort(3000)
+        return newWebSocketRpcSession<PublicApi>(`ws://127.0.0.1:${port}/rpc`)
+    }
+
+    it(
+        'Transit Topology: A <-> B <-> C propagation, sync, and withdrawal',
+        async () => {
+            if (skipTests) return
+
+            const clientA = getClient(nodeA)
+            const clientB = getClient(nodeB)
+            const clientC = getClient(nodeC)
+
+            const adminAuth = { userId: 'admin', roles: ['*'] }
+
+            // 1. Linear Peering: A <-> B and B <-> C
+            console.log('Establishing peering A <-> B')
+            const netAResult = await clientA.getNetworkClient('valid-secret')
+            const netBResult = await clientB.getNetworkClient('valid-secret')
+            const netCResult = await clientC.getNetworkClient('valid-secret')
+
+            if (!netAResult.success || !netBResult.success || !netCResult.success) {
+                throw new Error('Failed to get network client')
+            }
+
+            const netA = netAResult.client
+            const netB = netBResult.client
+            const netC = netCResult.client
+
+            // Setup B to accept A first, then A connects to B (Ensures A->B capability)
+            await netB.addPeer({
+                name: 'node-a.somebiz.local.io',
+                endpoint: 'ws://node-a:3000/rpc',
+                domains: ['somebiz.local.io']
+            })
+            await netA.addPeer({
+                name: 'node-b.somebiz.local.io',
+                endpoint: 'ws://node-b:3000/rpc',
+                domains: ['somebiz.local.io']
+            })
+
+            // Wait for handshake
+            console.log('Waiting for peering A <-> B to resolve...')
+            const waitForConnected = async (client: any, peerName: string) => {
+                for (let i = 0; i < 20; i++) {
+                    const peers = await (await client.getInspector()).listPeers()
+                    const peer = peers.find((p: any) => p.name === peerName)
+                    if (peer && peer.connectionStatus === 'connected') return
+                    await new Promise(r => setTimeout(r, 500))
+                }
+                throw new Error(`Peer ${peerName} failed to connect`)
+            }
+            await waitForConnected(clientA, 'node-b.somebiz.local.io')
+            await waitForConnected(clientB, 'node-a.somebiz.local.io')
+
+            // 2. A adds a local route
+            console.log('Node A adding local route')
+            const dataAResult = await clientA.getDataCustodianClient('valid-secret')
+            if (!dataAResult.success) throw new Error('Failed to get data client')
+            await dataAResult.client.addRoute({
+                name: 'service-a', protocol: 'http', endpoint: 'http://a:8080'
+            })
+
+            // Check B learned it
+            let learnedOnB = false
+            for (let i = 0; i < 40; i++) {
+                const inspector = await clientB.getInspector()
+                const routes = await inspector.listRoutes()
+                if (routes.internal.some(r => r.name === 'service-a')) {
+                    learnedOnB = true
+                    break
+                }
+                await new Promise(r => setTimeout(r, 500))
+            }
+            expect(learnedOnB).toBe(true)
+
+            // 3. NOW peer B with C (Initial Sync test)
+            console.log('Establishing peering B <-> C')
+            // Setup C to accept B first, then B connects to C (Ensures B->C capability)
+            await netC.addPeer({
+                name: 'node-b.somebiz.local.io',
+                endpoint: 'ws://node-b:3000/rpc',
+                domains: ['somebiz.local.io']
+            })
+            await netB.addPeer({
+                name: 'node-c.somebiz.local.io',
+                endpoint: 'ws://node-c:3000/rpc',
+                domains: ['somebiz.local.io']
+            })
+
+            // Wait for B-C handshake and sync
+            await new Promise(r => setTimeout(r, 2000))
+
+            // 4. C should have learned about A's route via B
+            let learnedOnC = false
+            for (let i = 0; i < 10; i++) {
+                const inspector = await clientC.getInspector()
+                const routes = await inspector.listRoutes()
+                const routeA = routes.internal.find(r => r.name === 'service-a')
+                if (routeA) {
+                    learnedOnC = true
+                    // Verify nodePath: [B, A]
+                    expect(routeA.nodePath).toEqual(['node-b.somebiz.local.io', 'node-a.somebiz.local.io'])
+                    break
+                }
+                await new Promise(r => setTimeout(r, 500))
+            }
+            expect(learnedOnC).toBe(true)
+
+            // 5. Withdrawal Propagation: A deletes route -> B and C should remove it
+            console.log('Node A deleting route')
+            await (await clientA.getDataCustodianClient('valid-secret') as any).client.removeRoute({
+                name: 'service-a', protocol: 'http', endpoint: 'http://a:8080'
+            })
+
+            let removedOnC = false
+            for (let i = 0; i < 10; i++) {
+                const inspector = await clientC.getInspector()
+                const routes = await inspector.listRoutes()
+                if (!routes.internal.some(r => r.name === 'service-a')) {
+                    removedOnC = true
+                    break
+                }
+                await new Promise(r => setTimeout(r, 500))
+            }
+            expect(removedOnC).toBe(true)
+
+            // 6. Topology Withdrawal: Disconnect A-B -> B should tell C to remove A's routes
+            console.log('Re-adding route and then disconnecting A-B')
+            await (await clientA.getDataCustodianClient('valid-secret') as any).client.addRoute({
+                name: 'service-a-v2', protocol: 'http', endpoint: 'http://a:8080'
+            })
+
+            // Wait for it to reach C
+            await new Promise(r => setTimeout(r, 2000))
+
+            await netA.removePeer({ name: 'node-b.somebiz.local.io' })
+
+            let disconnectedWithdrawalOnC = false
+            for (let i = 0; i < 10; i++) {
+                const inspector = await clientC.getInspector()
+                const routes = await inspector.listRoutes()
+                if (!routes.internal.some(r => r.name === 'service-a-v2')) {
+                    disconnectedWithdrawalOnC = true
+                    break
+                }
+                await new Promise(r => setTimeout(r, 500))
+            }
+            expect(disconnectedWithdrawalOnC).toBe(true)
+        },
+        TIMEOUT
+    )
+})

--- a/packages/orchestrator/src/next/transit.orchestrator.topology.test.ts
+++ b/packages/orchestrator/src/next/transit.orchestrator.topology.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { CatalystNodeBus } from './orchestrator.js'
+import type { PeerInfo, RouteTable } from './routing/state.js'
+import { newRouteTable } from './routing/state.js'
+import { Actions } from './action-types.js'
+import { MockConnectionPool } from './mock-connection-pool.js'
+
+const ADMIN_AUTH = { userId: 'admin', roles: ['*'] }
+
+describe('Orchestrator Transit Tests (Mocked Container Logic)', () => {
+    let pool: MockConnectionPool
+    let nodeA: CatalystNodeBus
+    let nodeB: CatalystNodeBus
+    let nodeC: CatalystNodeBus
+
+    const infoA: PeerInfo = {
+        name: 'node-a.somebiz.local.io',
+        endpoint: 'ws://node-a',
+        domains: ['somebiz.local.io'],
+    }
+    const infoB: PeerInfo = {
+        name: 'node-b.somebiz.local.io',
+        endpoint: 'ws://node-b',
+        domains: ['somebiz.local.io'],
+    }
+    const infoC: PeerInfo = {
+        name: 'node-c.somebiz.local.io',
+        endpoint: 'ws://node-c',
+        domains: ['somebiz.local.io'],
+    }
+
+    beforeEach(() => {
+        pool = new MockConnectionPool()
+
+        const createNode = (info: PeerInfo) => {
+            const bus = new CatalystNodeBus({
+                config: { node: info, ibgp: { secret: 'secret' } },
+                connectionPool: { pool },
+                state: newRouteTable(),
+            })
+            pool.registerNode(bus)
+            return bus
+        }
+
+        nodeA = createNode(infoA)
+        nodeB = createNode(infoB)
+        nodeC = createNode(infoC)
+    })
+
+    const waitForNotification = async (node: CatalystNodeBus) => {
+        if ((node as unknown as { lastNotificationPromise?: Promise<void> }).lastNotificationPromise) {
+            await (node as unknown as { lastNotificationPromise?: Promise<void> }).lastNotificationPromise
+        }
+    }
+
+    it('Transit: A <-> B <-> C propagation', async () => {
+        // 1. Establish Peering A <-> B
+        const netA = (await nodeA.publicApi().getNetworkClient('secret') as any).client
+        const netB = (await nodeB.publicApi().getNetworkClient('secret') as any).client
+        const netC = (await nodeC.publicApi().getNetworkClient('secret') as any).client
+
+        await netB.addPeer(infoA)
+        await netA.addPeer(infoB)
+
+        await waitForNotification(nodeA)
+        await waitForNotification(nodeB)
+        await new Promise(r => setTimeout(r, 50))
+
+        // 2. Establish Peering B <-> C
+        await netC.addPeer(infoB)
+        await netB.addPeer(infoC)
+
+        await waitForNotification(nodeB)
+        await waitForNotification(nodeC)
+        await new Promise(r => setTimeout(r, 50))
+
+        // 3. A adds local route
+        console.log('Node A adding local route')
+        const routeA = { name: 'service-a', protocol: 'http' as const, endpoint: 'http://a:8080' }
+        const dataA = (await nodeA.publicApi().getDataCustodianClient('secret') as any).client
+        await dataA.addRoute(routeA)
+
+        // Wait for propagation to B and then C
+        await waitForNotification(nodeA)
+        await waitForNotification(nodeB)
+        await waitForNotification(nodeC)
+        // Extra padding for chained events
+        await new Promise(r => setTimeout(r, 100))
+
+        // Check C learned it via B
+        const stateC = (nodeC as unknown as { state: RouteTable }).state
+        const learnedRoute = stateC.internal.routes.find(r => r.name === 'service-a')
+
+        expect(learnedRoute).toBeDefined()
+        expect(learnedRoute?.nodePath).toEqual(['node-b.somebiz.local.io', 'node-a.somebiz.local.io'])
+
+        // 4. Withdrawal Propagation
+        console.log('Node A deleting route')
+        await (await nodeA.publicApi().getDataCustodianClient('secret') as any).client.removeRoute(routeA)
+
+        await waitForNotification(nodeA)
+        await waitForNotification(nodeB)
+        await waitForNotification(nodeC)
+        await new Promise(r => setTimeout(r, 100))
+
+        const stateC_AfterWithdraw = (nodeC as unknown as { state: RouteTable }).state
+        const hasRoute = stateC_AfterWithdraw.internal.routes.some(r => r.name === 'service-a')
+        expect(hasRoute).toBe(false)
+
+        // 5. Disconnect Propagation
+        // Re-add route
+        await (await nodeA.publicApi().getDataCustodianClient('secret') as any).client.addRoute(routeA)
+        await waitForNotification(nodeA)
+        await waitForNotification(nodeB)
+        await waitForNotification(nodeC)
+        await new Promise(r => setTimeout(r, 100))
+
+        // Verify C has it again
+        expect((nodeC as unknown as { state: RouteTable }).state.internal.routes.some(r => r.name === 'service-a')).toBe(true)
+
+        // Disconnect A from B
+        console.log('Disconnecting A from B')
+        await netA.removePeer({ name: infoB.name })
+
+        // This triggers B to close session, which triggers B to update C
+        await waitForNotification(nodeA)
+        // Wait for B's reaction
+        await new Promise(r => setTimeout(r, 200))
+
+        const stateC_AfterDisconnect = (nodeC as unknown as { state: RouteTable }).state
+        const hasRouteFinal = stateC_AfterDisconnect.internal.routes.some(r => r.name === 'service-a')
+        expect(hasRouteFinal).toBe(false)
+    })
+})

--- a/packages/orchestrator/src/next/types.ts
+++ b/packages/orchestrator/src/next/types.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 export const AuthContextSchema = z.object({
   userId: z.string(),
   roles: z.array(z.string()),
+  permissions: z.array(z.string()).optional(),
 })
 export type AuthContext = z.infer<typeof AuthContextSchema>
 


### PR DESCRIPTION
### TL;DR

Refactored the orchestrator's API to use client-based interfaces and improved BGP route propagation with proper topology support.

### What changed?

- Restructured the public API to use dedicated client interfaces (`NetworkClient`, `DataCustodian`, `IBGPClient`) instead of direct method access
- Improved permission handling with explicit role-based access control
- Enhanced BGP route propagation to properly handle transit routes through intermediate nodes
- Added comprehensive topology tests for various network configurations (linear, mesh)
- Fixed route withdrawal propagation when peers disconnect
- Added proper loop prevention in route advertisements
- Updated the Dockerfile to use the new entry point (`src/next/index.ts`)
- Created a `MockConnectionPool` for testing complex topologies

### How to test?

1. Run the new topology tests:
   ```
   cd packages/orchestrator
   bun test src/next/orchestrator.topology.test.ts
   ```

2. For container-based tests (requires Podman):
   ```
   bun test src/next/transit.orchestrator.topology.container.test.ts
   ```

3. Verify the new client interfaces:
   ```typescript
   const netClient = await orchestrator.getNetworkClient('valid-secret')
   await netClient.client.addPeer({
     name: 'peer-b.example.com',
     endpoint: 'ws://peer-b:3000/rpc',
     domains: ['example.com']
   })
   ```

### Why make this change?

This refactoring improves the orchestrator's architecture by:
1. Providing clearer API boundaries with dedicated client interfaces
2. Fixing critical issues in route propagation across multi-node topologies
3. Enhancing security with proper permission checks
4. Adding comprehensive test coverage for complex network scenarios
5. Ensuring proper route withdrawal when nodes disconnect from the network