### PR TITLE
fix(linting+container runtime): able to change container runtime for tests with ENV variable

### DIFF
--- a/packages/orchestrator/Dockerfile
+++ b/packages/orchestrator/Dockerfile
@@ -11,7 +11,8 @@ RUN rm -rf packages/orchestrator/node_modules
 
 # Install dependencies
 WORKDIR /app/packages/orchestrator
-RUN bun install
+RUN bun install --ignore-scripts --omit=dev
+
 ENV PORT=3000
 EXPOSE 3000
 

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "bun run --watch src/index.ts",
     "build": "tsc",
     "test": "bun test",
     "test:podman": "./src/next/test_with_podman.sh"

--- a/packages/orchestrator/src/next/orchestrator.container.test.ts
+++ b/packages/orchestrator/src/next/orchestrator.container.test.ts
@@ -1,161 +1,184 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
-import { GenericContainer, Wait, Network, type StartedTestContainer, type StartedNetwork } from 'testcontainers'
+import {
+  GenericContainer,
+  Wait,
+  Network,
+  type StartedTestContainer,
+  type StartedNetwork,
+} from 'testcontainers'
 import path from 'path'
 import { spawnSync } from 'node:child_process'
 import { newWebSocketRpcSession } from 'capnweb'
 import type { PublicApi } from './orchestrator.js'
+import type { InternalRoute } from './routing/state.js'
+
+const CONTAINER_RUNTIME = process.env.CONTAINER_RUNTIME || 'docker'
 
 describe('Orchestrator Container Tests (Next)', () => {
-    const TIMEOUT = 600000 // 10 minutes
+  const TIMEOUT = 600000 // 10 minutes
 
-    let network: StartedNetwork
-    let peerA: StartedTestContainer
-    let peerB: StartedTestContainer
-    let peerC: StartedTestContainer
+  let network: StartedNetwork
+  let peerA: StartedTestContainer
+  let peerB: StartedTestContainer
+  let peerC: StartedTestContainer
 
-    const imageName = 'localhost/catalyst-node:next-e2e'
-    const repoRoot = path.resolve(__dirname, '../../../../')
-    // Look for Podman socket or generic DOCKER_HOST/SOCK which Podman often populates
-    const skipTests = !process.env.DOCKER_HOST && !process.env.DOCKER_SOCK && !process.env.PODMAN_VAR_LINK
-
-    beforeAll(async () => {
-        if (skipTests) {
-            console.warn('Skipping container tests: Podman runtime not detected (DOCKER_HOST/DOCKER_SOCK/PODMAN_VAR_LINK not set)');
-            return
+  const imageName = 'localhost/catalyst-node:next-e2e'
+  const repoRoot = path.resolve(__dirname, '../../../../')
+  beforeAll(async () => {
+    // Check if image exists
+    const checkImage = spawnSync(CONTAINER_RUNTIME, ['image', 'exists', imageName])
+    if (checkImage.status !== 0) {
+      console.log(`Building Catalyst Node image with ${CONTAINER_RUNTIME}...`)
+      const buildResult = spawnSync(
+        CONTAINER_RUNTIME,
+        ['build', '-f', 'packages/orchestrator/Dockerfile', '-t', imageName, '.'],
+        {
+          cwd: repoRoot,
+          stdio: 'inherit',
         }
-        // Check if image exists
-        const checkImage = spawnSync('podman', ['image', 'exists', imageName])
-        if (checkImage.status !== 0) {
-            console.log('Building Catalyst Node image with Podman...')
-            const buildResult = spawnSync('podman', ['build', '-f', 'packages/orchestrator/Dockerfile', '-t', imageName, '.'], {
-                cwd: repoRoot,
-                stdio: 'inherit',
-            })
-            if (buildResult.status !== 0) throw new Error('Podman build failed')
-        }
-
-        network = await new Network().start()
-
-        const startNode = async (name: string, alias: string) => {
-            return await new GenericContainer(imageName)
-                .withNetwork(network)
-                .withNetworkAliases(alias)
-                .withExposedPorts(3000)
-                .withCommand(['sh', '-c', 'bun run src/next/index.ts'])
-                .withEnvironment({
-                    PORT: '3000',
-                    CATALYST_NODE_ID: name,
-                    CATALYST_PEERING_ENDPOINT: `ws://${alias}:3000/rpc`,
-                })
-                .withWaitStrategy(Wait.forLogMessage(/.*NEXT_ORCHESTRATOR_STARTED.*/))
-                .withLogConsumer(stream => {
-                    stream.on("line", line => console.log(`[${name}] ${line}`));
-                    stream.on("err", line => console.error(`[${name}] ERR: ${line}`));
-                })
-                .start()
-        }
-
-        peerA = await startNode('A', 'peer-a')
-        peerB = await startNode('B', 'peer-b')
-        peerC = await startNode('C', 'peer-c')
-
-        console.log('Nodes started')
-    }, TIMEOUT)
-
-    afterAll(async () => {
-        if (peerA) await peerA.stop()
-        if (peerB) await peerB.stop()
-        if (peerC) await peerC.stop()
-        if (network) await network.stop()
-    })
-
-    const getClient = (container: StartedTestContainer) => {
-        const port = container.getMappedPort(3000)
-        const url = `ws://127.0.0.1:${port}/rpc`
-        return newWebSocketRpcSession<PublicApi>(url)
+      )
+      if (buildResult.status !== 0) throw new Error(`${CONTAINER_RUNTIME} build failed`)
     }
 
-    it.skipIf(skipTests)('A <-> B: peering and route sync', async () => {
-        const clientA = getClient(peerA)
-        const mgmtA = clientA.getManagerConnection()
-        const clientB = getClient(peerB)
-        const mgmtB = clientB.getManagerConnection()
+    network = await new Network().start()
 
-        // 1. Configure BOTH nodes for peering
-        await mgmtB.addPeer({
-            name: 'A',
-            endpoint: 'ws://peer-a:3000/rpc',
-            domains: []
+    const startNode = async (name: string, alias: string) => {
+      return await new GenericContainer(imageName)
+        .withNetwork(network)
+        .withNetworkAliases(alias)
+        .withExposedPorts(3000)
+        .withCommand(['sh', '-c', 'bun run src/next/index.ts'])
+        .withEnvironment({
+          PORT: '3000',
+          CATALYST_NODE_ID: name,
+          CATALYST_PEERING_ENDPOINT: `ws://${alias}:3000/rpc`,
         })
-        await mgmtA.addPeer({
-            name: 'B',
-            endpoint: 'ws://peer-b:3000/rpc',
-            domains: []
+        .withWaitStrategy(Wait.forLogMessage(/.*NEXT_ORCHESTRATOR_STARTED.*/))
+        .withLogConsumer((stream) => {
+          stream.on('data', (line: string) => console.log(`[${name}] ${line.trimEnd()}`))
+          stream.on('error', (line: string) => console.error(`[${name}] ERR: ${line.trimEnd()}`))
         })
+        .start()
+    }
 
-        // Give it a moment for the handshake
-        await new Promise(r => setTimeout(r, 2000))
+    peerA = await startNode('A', 'peer-a')
+    peerB = await startNode('B', 'peer-b')
+    peerC = await startNode('C', 'peer-c')
 
-        // 2. A adds a local route
-        await clientA.dispatch({
-            action: 'local:route:create',
-            data: { name: 'service-a', endpoint: 'http://a:8080', protocol: 'http' }
-        })
+    console.log('Nodes started')
+  }, TIMEOUT)
 
-        // 3. Verify B sees the route
-        const inspectorB = clientB.getInspector()
+  afterAll(async () => {
+    if (peerA) await peerA.stop()
+    if (peerB) await peerB.stop()
+    if (peerC) await peerC.stop()
+    if (network) await network.stop()
+  })
 
-        let sawRoute = false
-        for (let i = 0; i < 20; i++) {
-            const routes = await inspectorB.listRoutes()
-            if (routes.internal.some((r: any) => r.name === 'service-a')) {
-                sawRoute = true
-                break
-            }
-            await new Promise(r => setTimeout(r, 500))
+  const getClient = (container: StartedTestContainer) => {
+    const port = container.getMappedPort(3000)
+    const url = `ws://127.0.0.1:${port}/rpc`
+    return newWebSocketRpcSession<PublicApi>(url)
+  }
+
+  it(
+    'A <-> B: peering and route sync',
+    async () => {
+      const clientA = getClient(peerA)
+      const mgmtA = clientA.getManagerConnection()
+      const clientB = getClient(peerB)
+      const mgmtB = clientB.getManagerConnection()
+
+      // 1. Configure BOTH nodes for peering
+      const resultB = await mgmtB.addPeer(
+        {
+          name: 'A',
+          endpoint: 'ws://peer-a:3000/rpc',
+          domains: [],
+        },
+        { userId: 'admin', roles: ['admin'] }
+      )
+      console.log('resultB:', resultB)
+      expect(resultB.success).toBe(true)
+      const resultA = await mgmtA.addPeer(
+        {
+          name: 'B',
+          endpoint: 'ws://peer-b:3000/rpc',
+          domains: [],
+        },
+        { userId: 'admin', roles: ['admin'] }
+      )
+      console.log('resultA:', resultA)
+      expect(resultA.success).toBe(true)
+      // Give it a moment for the handshake
+      await new Promise((r) => setTimeout(r, 2000))
+
+      // 2. A adds a local route
+      await clientA.dispatch({
+        action: 'local:route:create',
+        data: { name: 'service-a', endpoint: 'http://a:8080', protocol: 'http' },
+      })
+
+      // 3. Verify B sees the route
+      const inspectorB = clientB.getInspector()
+
+      let sawRoute = false
+      for (let i = 0; i < 20; i++) {
+        const routes = await inspectorB.listRoutes()
+        if (routes.internal.some((r: InternalRoute) => r.name === 'service-a')) {
+          sawRoute = true
+          break
         }
-        expect(sawRoute).toBe(true)
-    }, TIMEOUT)
+        await new Promise((r) => setTimeout(r, 500))
+      }
+      expect(sawRoute).toBe(true)
+    },
+    TIMEOUT
+  )
 
-    it.skipIf(skipTests)('A <-> B <-> C: transit route propagation', async () => {
-        const clientA = getClient(peerA)
-        const clientB = getClient(peerB)
-        const clientC = getClient(peerC)
+  it(
+    'A <-> B <-> C: transit route propagation',
+    async () => {
+      const clientA = getClient(peerA)
+      const clientB = getClient(peerB)
+      const clientC = getClient(peerC)
 
-        const mgmtA = clientA.getManagerConnection()
-        const mgmtB = clientB.getManagerConnection()
-        const mgmtC = clientC.getManagerConnection()
+      const mgmtA = clientA.getManagerConnection()
+      const mgmtB = clientB.getManagerConnection()
+      const mgmtC = clientC.getManagerConnection()
 
-        // Configure A-B peering (reciprocal)
-        await mgmtB.addPeer({ name: 'A', endpoint: 'ws://peer-a:3000/rpc', domains: [] })
-        await mgmtA.addPeer({ name: 'B', endpoint: 'ws://peer-b:3000/rpc', domains: [] })
+      // Configure A-B peering (reciprocal)
+      await mgmtB.addPeer({ name: 'A', endpoint: 'ws://peer-a:3000/rpc', domains: [] })
+      await mgmtA.addPeer({ name: 'B', endpoint: 'ws://peer-b:3000/rpc', domains: [] })
 
-        // Configure B-C peering (reciprocal)
-        await mgmtC.addPeer({ name: 'B', endpoint: 'ws://peer-b:3000/rpc', domains: [] })
-        await mgmtB.addPeer({ name: 'C', endpoint: 'ws://peer-c:3000/rpc', domains: [] })
+      // Configure B-C peering (reciprocal)
+      await mgmtC.addPeer({ name: 'B', endpoint: 'ws://peer-b:3000/rpc', domains: [] })
+      await mgmtB.addPeer({ name: 'C', endpoint: 'ws://peer-c:3000/rpc', domains: [] })
 
-        // Wait for peering
-        await new Promise(r => setTimeout(r, 2000))
+      // Wait for peering
+      await new Promise((r) => setTimeout(r, 2000))
 
-        // 1. A adds a local route
-        await clientA.dispatch({
-            action: 'local:route:create',
-            data: { name: 'service-transit', endpoint: 'http://a:9090', protocol: 'http' }
-        })
+      // 1. A adds a local route
+      await clientA.dispatch({
+        action: 'local:route:create',
+        data: { name: 'service-transit', endpoint: 'http://a:9090', protocol: 'http' },
+      })
 
-        // 2. Verify C sees it via B
-        const inspectorC = clientC.getInspector()
-        let sawTransit = false
-        for (let i = 0; i < 30; i++) {
-            const routes = await inspectorC.listRoutes()
-            const route = routes.internal.find((r: any) => r.name === 'service-transit')
-            if (route) {
-                expect(route.peerName).toBe('B') // Direct peer is B
-                sawTransit = true
-                break
-            }
-            await new Promise(r => setTimeout(r, 500))
+      // 2. Verify C sees it via B
+      const inspectorC = clientC.getInspector()
+      let sawTransit = false
+      for (let i = 0; i < 30; i++) {
+        const routes = await inspectorC.listRoutes()
+        const route = routes.internal.find((r: any) => r.name === 'service-transit')
+        if (route) {
+          expect(route.peerName).toBe('B') // Direct peer is B
+          sawTransit = true
+          break
         }
-        expect(sawTransit).toBe(true)
-    }, TIMEOUT)
+        await new Promise((r) => setTimeout(r, 500))
+      }
+      expect(sawTransit).toBe(true)
+    },
+    TIMEOUT
+  )
 })

--- a/packages/orchestrator/src/rpc/server.ts
+++ b/packages/orchestrator/src/rpc/server.ts
@@ -12,7 +12,7 @@ import { PluginPipeline } from '../plugins/pipeline.js'
 import { LoggerPlugin } from '../plugins/implementations/logger.js'
 import { GatewayIntegrationPlugin } from '../plugins/implementations/gateway.js'
 import { LocalRoutingTablePlugin } from '../plugins/implementations/local-routing.js'
-import { InternalBGPPlugin } from '../plugins/implementations/Internal-bgp.js'
+import { InternalBGPPlugin } from '../plugins/implementations/internal-bgp.js'
 import type { ListPeersResult, PeerInfo, UpdateMessage, IBGPScope } from './schema/peering.js'
 import {
   IBGPProtocolResource,
@@ -70,11 +70,11 @@ export class OrchestratorRpcServer extends RpcTarget {
     // V2 MIGRATION NOTE:
     // The architecture is moving towards a split State/Notification pipeline.
     // The integration would look like this:
-    
+
     // import { OrchestratorV2 } from '../next/orchestrator.js';
     // const v2 = new OrchestratorV2();
-    // return v2; 
-    
+    // return v2;
+
     // For now, this class maintains the V1 PluginPipeline compatibility.
     */
 

--- a/packages/orchestrator/tests/config.ibgp.plugins.unit.test.ts
+++ b/packages/orchestrator/tests/config.ibgp.plugins.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { InternalBGPPlugin } from '../src/plugins/implementations/Internal-bgp.js'
+import { InternalBGPPlugin } from '../src/plugins/implementations/internal-bgp.js'
 import { RouteTable } from '../src/state/route-table.js'
 import type { PluginContext } from '../src/plugins/types.js'
 import { IBGPConfigResource, IBGPConfigResourceAction } from '../src/rpc/schema/peering.js'

--- a/packages/orchestrator/tests/graphql.plugin.integration.test.ts
+++ b/packages/orchestrator/tests/graphql.plugin.integration.test.ts
@@ -9,6 +9,8 @@ import { resolve } from 'path'
 // Increase timeout for builds
 const TIMEOUT = 180_000
 
+const CONTAINER_RUNTIME = process.env.CONTAINER_RUNTIME || 'docker'
+
 describe('GraphQL Plugin E2E with Containers', () => {
   let network: StartedNetwork
   let gatewayContainer: StartedTestContainer
@@ -26,12 +28,12 @@ describe('GraphQL Plugin E2E with Containers', () => {
     // const examplesDir = join(repoRoot, 'packages/examples');
     // const gatewayDir = join(repoRoot, 'packages/gateway');
 
-    console.log('Building Podman images...')
+    console.log(`Building ${CONTAINER_RUNTIME} images...`)
 
     const buildBooks = async () => {
       await Bun.spawn(
         [
-          'podman',
+          CONTAINER_RUNTIME,
           'build',
           '-t',
           'books-service:test',
@@ -50,7 +52,7 @@ describe('GraphQL Plugin E2E with Containers', () => {
     const buildMovies = async () => {
       await Bun.spawn(
         [
-          'podman',
+          CONTAINER_RUNTIME,
           'build',
           '-t',
           'movies-service:test',
@@ -68,7 +70,15 @@ describe('GraphQL Plugin E2E with Containers', () => {
 
     const buildGateway = async () => {
       await Bun.spawn(
-        ['podman', 'build', '-t', 'gateway-service:test', '-f', 'packages/gateway/Dockerfile', '.'],
+        [
+          CONTAINER_RUNTIME,
+          'build',
+          '-t',
+          'gateway-service:test',
+          '-f',
+          'packages/gateway/Dockerfile',
+          '.',
+        ],
         {
           cwd: repoRoot,
           stdout: 'ignore',
@@ -78,7 +88,7 @@ describe('GraphQL Plugin E2E with Containers', () => {
     }
 
     await Promise.all([buildBooks(), buildMovies(), buildGateway()])
-    console.log('Podman images built successfully.')
+    console.log(`${CONTAINER_RUNTIME} images built successfully.`)
 
     console.log('Starting Containers...')
 

--- a/packages/orchestrator/tests/internal-bgp.plugin.unit.test.ts
+++ b/packages/orchestrator/tests/internal-bgp.plugin.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { InternalBGPPlugin } from '../src/plugins/implementations/Internal-bgp.js'
+import { InternalBGPPlugin } from '../src/plugins/implementations/internal-bgp.js'
 import { RouteTable } from '../src/state/route-table.js'
 import type { PluginContext } from '../src/plugins/types.js'
 import type { Action } from '../src/rpc/schema/index.js'

--- a/packages/orchestrator/tests/internal-peering.plugin.integration.test.ts
+++ b/packages/orchestrator/tests/internal-peering.plugin.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'bun:test'
 import type { PluginContext } from '../src/plugins/types.js'
 import { RouteTable } from '../src/state/route-table.js'
-import { InternalBGPPlugin } from '../src/plugins/implementations/Internal-bgp.js'
+import { InternalBGPPlugin } from '../src/plugins/implementations/internal-bgp.js'
 // import type { Action, ApplyActionResult } from '../src/rpc/schema/index.js';
 // import type { AuthContext } from '../src/plugins/types.js';
 

--- a/packages/orchestrator/tests/peering-e2e-ws.test.ts
+++ b/packages/orchestrator/tests/peering-e2e-ws.test.ts
@@ -7,6 +7,8 @@ import type { PublicApi, ManagementScope } from '../../cli/src/client.js'
 import type { LocalRoute } from '../src/rpc/schema/index.js'
 import type { AuthorizedPeer } from '../src/rpc/schema/peering.js'
 
+const CONTAINER_RUNTIME = process.env.CONTAINER_RUNTIME || 'docker'
+
 describe('Peering E2E Lifecycle (WebSocket Transport)', () => {
   const TIMEOUT = 300000 // 5 minutes
 
@@ -26,9 +28,9 @@ describe('Peering E2E Lifecycle (WebSocket Transport)', () => {
 
   beforeAll(async () => {
     // 1. Build Image
-    console.log('Building Podman image...')
+    console.log(`Building ${CONTAINER_RUNTIME} image...`)
     const buildProc = Bun.spawn(
-      ['podman', 'build', '-f', 'packages/orchestrator/Dockerfile', '-t', imageName, '.'],
+      [CONTAINER_RUNTIME, 'build', '-f', 'packages/orchestrator/Dockerfile', '-t', imageName, '.'],
       {
         cwd: repoRoot,
         stdout: 'inherit',
@@ -38,7 +40,7 @@ describe('Peering E2E Lifecycle (WebSocket Transport)', () => {
     await buildProc.exited
 
     if (buildProc.exitCode !== 0) {
-      throw new Error('Podman build failed')
+      throw new Error(`${CONTAINER_RUNTIME} build failed`)
     }
 
     // 2. Create Network
@@ -80,9 +82,9 @@ describe('Peering E2E Lifecycle (WebSocket Transport)', () => {
     portB = peerB.getMappedPort(3000)
     console.log(`Peer B started on port ${portB}`)
 
-      // Stream logs for debugging
-      ; (await peerA.logs()).pipe(process.stdout)
-      ; (await peerB.logs()).pipe(process.stdout)
+    // Stream logs for debugging
+    ;(await peerA.logs()).pipe(process.stdout)
+    ;(await peerB.logs()).pipe(process.stdout)
   }, TIMEOUT)
 
   afterAll(async () => {

--- a/packages/orchestrator/tests/peering-e2e.test.ts
+++ b/packages/orchestrator/tests/peering-e2e.test.ts
@@ -7,6 +7,8 @@ import type { PublicApi, ManagementScope } from '../../cli/src/client.js'
 import type { LocalRoute } from '../src/rpc/schema/index.js'
 import type { AuthorizedPeer } from '../src/rpc/schema/peering.js'
 
+const CONTAINER_RUNTIME = process.env.CONTAINER_RUNTIME || 'docker'
+
 describe('Peering E2E Lifecycle (Containerized)', () => {
   const TIMEOUT = 300000 // 5 minutes
 
@@ -26,9 +28,9 @@ describe('Peering E2E Lifecycle (Containerized)', () => {
 
   beforeAll(async () => {
     // 1. Build Image
-    console.log('Building Podman image...')
+    console.log(`Building ${CONTAINER_RUNTIME} image...`)
     const buildProc = Bun.spawn(
-      ['podman', 'build', '-f', 'packages/orchestrator/Dockerfile', '-t', imageName, '.'],
+      [CONTAINER_RUNTIME, 'build', '-f', 'packages/orchestrator/Dockerfile', '-t', imageName, '.'],
       {
         cwd: repoRoot,
         stdout: 'inherit',
@@ -38,7 +40,7 @@ describe('Peering E2E Lifecycle (Containerized)', () => {
     await buildProc.exited
 
     if (buildProc.exitCode !== 0) {
-      throw new Error('Podman build failed')
+      throw new Error(`${CONTAINER_RUNTIME} build failed`)
     }
 
     // 2. Create Network
@@ -78,9 +80,9 @@ describe('Peering E2E Lifecycle (Containerized)', () => {
     portB = peerB.getMappedPort(3000)
     console.log(`Peer B started on port ${portB}`)
 
-      // Stream logs for debugging
-      ; (await peerA.logs()).pipe(process.stdout)
-      ; (await peerB.logs()).pipe(process.stdout)
+    // Stream logs for debugging
+    ;(await peerA.logs()).pipe(process.stdout)
+    ;(await peerB.logs()).pipe(process.stdout)
   }, TIMEOUT)
 
   afterAll(async () => {


### PR DESCRIPTION
### TL;DR

Improved container testing infrastructure with Docker/Podman flexibility and optimized Docker build process.

### What changed?

- Added support for configurable container runtime by introducing `CONTAINER_RUNTIME` environment variable (defaults to "docker")
- Fixed case sensitivity issue by renaming `Internal-bgp.js` imports to `internal-bgp.js`
- Optimized Docker build by adding `--ignore-scripts --omit=dev` flags to `bun install` in Dockerfile
- Updated development script from `tsx watch` to `bun run --watch` in package.json
- Enhanced container tests with better error handling and logging
- Fixed authentication in container tests by adding proper auth context to RPC calls
- Improved code formatting and readability in test files

### How to test?

1. Run container tests with Docker (default):
   ```
   bun test
   ```

2. Run container tests with Podman:
   ```
   CONTAINER_RUNTIME=podman bun test
   ```

3. Verify that the orchestrator builds and runs correctly with the optimized Dockerfile:
   ```
   docker build -f packages/orchestrator/Dockerfile -t catalyst-node:test .
   docker run -p 3000:3000 catalyst-node:test
   ```

### Why make this change?

This change improves development and testing flexibility by allowing developers to use either Docker or Podman as their container runtime. It also optimizes the Docker build process by skipping unnecessary scripts and development dependencies, resulting in faster builds and smaller images. The case sensitivity fix for the BGP module ensures consistent behavior across different file systems and platforms.