### PR TITLE
chore: docs on testing and podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,47 +6,110 @@ Modeled after BGP, Catalyst Node brings decentralized routing to Layers 4-7, all
 
 ## Mission
 
-Traditional service meshes (like Istio/Linkerd) excel at managing traffic *within* a cluster or organization. Catalyst Node is built for the spaces *between* them. We aim to:
+Traditional service meshes (like Istio/Linkerd) excel at managing traffic _within_ a cluster or organization. Catalyst Node is built for the spaces _between_ them. We aim to:
 
-*   **Bridge Disparate Networks**: Connect on-prem datacenters, public clouds, and edge devices (even Raspberry Pis) into a unified service fabric.
-*   **Enable Organizational Peering**: Allow Organization A to securely expose specific services to Organization B via standard peering agreements, similar to how ISPs peer on the internet.
-*   **Run Anywhere**: Minimal resource footprint, suitable for small compute devices.
+- **Bridge Disparate Networks**: Connect on-prem datacenters, public clouds, and edge devices (even Raspberry Pis) into a unified service fabric.
+- **Enable Organizational Peering**: Allow Organization A to securely expose specific services to Organization B via standard peering agreements, similar to how ISPs peer on the internet.
+- **Run Anywhere**: Minimal resource footprint, suitable for small compute devices.
 
 ## Core Architecture
 
 Catalyst Node runs as a **Core Pod** containing 5 specialized containers:
 
 ### 1. Control Plane (The Orchestrator)
+
 The "brain" of the node.
-*   **Function**: Handles BGP peering, xDS configuration generation, and sidecar management.
-*   **Transport**: Uses `capnweb` RPC to coordinate with sidecars and other nodes.
+
+- **Function**: Handles BGP peering, xDS configuration generation, and sidecar management.
+- **Transport**: Uses `capnweb` RPC to coordinate with sidecars and other nodes.
 
 ### 2. Data Plane (Envoy Proxy)
+
 The "muscle" of the node.
-*   **Function**: High-performance edge router terminating TLS.
-*   **Operation**: Configured dynamically via **xDS** (REST) by the Orchestrator.
+
+- **Function**: High-performance edge router terminating TLS.
+- **Operation**: Configured dynamically via **xDS** (REST) by the Orchestrator.
 
 ### 3. Sidecars (Specialized Functions)
-*   **GraphQL Gateway**: TypeScript-based federation engine.
-*   **Auth Service**: Handles Key signing and JWKS.
-*   **OTEL Collector**: Central metrics sink for the pod.
+
+- **GraphQL Gateway**: TypeScript-based federation engine.
+- **Auth Service**: Handles Key signing and JWKS.
+- **OTEL Collector**: Central metrics sink for the pod.
 
 ## Key Features
 
-*   **Decentralized**: No single point of failure or control.
-*   **Plugin-Driven**: Extensible architecture for defining custom behaviors for routing, local services, and propagation.
-*   **Local Services**: Easily spin up and advertise local resources (e.g., VPN clients, GraphQL federations) as network services.
+- **Decentralized**: No single point of failure or control.
+- **Plugin-Driven**: Extensible architecture for defining custom behaviors for routing, local services, and propagation.
+- **Local Services**: Easily spin up and advertise local resources (e.g., VPN clients, GraphQL federations) as network services.
 
 ## Protocol Support
 
 We support a variety of protocols for service definitions. Currently, **GraphQL** receives first-class support for federation.
 
-| Protocol | Status | Notes |
-| :--- | :--- | :--- |
-| `tcp` | ✅ Stabilized | Generic TCP tunneling |
-| `udp` | ✅ Stabilized | Generic UDP tunneling |
-| `http` | 🚧 Beta | Generic HTTP proxying |
-| `http:graphql` | ✅ Live | Fully federated GraphQL support |
-| `http:gql` | ✅ Live | Alias for `http:graphql` |
-| `http:grpc` | 🗓️ Planned | gRPC transcoding and routing |
+| Protocol       | Status        | Notes                           |
+| :------------- | :------------ | :------------------------------ |
+| `tcp`          | ✅ Stabilized | Generic TCP tunneling           |
+| `udp`          | ✅ Stabilized | Generic UDP tunneling           |
+| `http`         | 🚧 Beta       | Generic HTTP proxying           |
+| `http:graphql` | ✅ Live       | Fully federated GraphQL support |
+| `http:gql`     | ✅ Live       | Alias for `http:graphql`        |
+| `http:grpc`    | 🗓️ Planned    | gRPC transcoding and routing    |
 
+## Testing
+
+Catalyst Node employs a multi-tiered testing strategy to ensure reliability across its distributed components. We primarily use `bun:test` as our test runner for its speed and native TypeScript support.
+
+### Test Categories
+
+#### 1. Unit Tests
+
+Low-level tests for individual modules and logic. These are fast and have no external dependencies.
+
+```bash
+# Run all unit tests in the repository
+bun test packages/**/*.test.ts --ignore "*.container.*"
+```
+
+#### 2. Local Topology Tests
+
+Simulate multi-node orchestration using mocks. These validate routing and synchronization logic WITHOUT needing a container runtime.
+
+```bash
+# Example: Run topology tests for the orchestrator
+bun test packages/orchestrator/src/next/*.topology.test.ts
+```
+
+#### 3. Container Integration Tests
+
+End-to-end tests that spin up actual node containers using Podman and `testcontainers`. These are used for validating network-level handshakes and gateway synchronization.
+
+```bash
+# Run container-based integration tests
+bun test packages/**/*.container.test.ts
+```
+
+### Podman Environment Setup
+
+Container-based tests are disabled by default to prevent environment-related failures. To enable them, you must configure your local Podman environment:
+
+1.  **Initialize Environment**:
+    Run the following command in your terminal to export the necessary socket paths and activation flags:
+
+    ```bash
+    source podman-env.sh
+    ```
+
+2.  **Verify Configuration**:
+    The script dynamically detects your Podman socket and sets `CATALYST_CONTAINER_TESTS_ENABLED=true`.
+
+> [!TIP]
+> You can add `source path/to/podman-env.sh` to your shell profile (~/.zshrc or ~/.bashrc) if you frequently run integration tests.
+
+### Running Tests by Package
+
+Each package in `packages/` contains its own test suite. You can run them individually:
+
+```bash
+cd packages/auth && bun test
+cd packages/orchestrator && bun test
+```


### PR DESCRIPTION
# Add comprehensive testing documentation to README

### TL;DR

Added detailed testing documentation to the README, including test categories, setup instructions, and commands for running different test types.

### What changed?

- Added a new "Testing" section to the README that explains the project's multi-tiered testing strategy
- Documented three test categories: Unit Tests, Local Topology Tests, and Container Integration Tests
- Included instructions for setting up the Podman environment for container-based tests
- Added code examples showing how to run different types of tests
- Improved markdown formatting throughout the document for better readability

### How to test?

Review the README to ensure the testing documentation is clear and follows the project's testing practices. Verify that the commands work by running:

```bash
# For unit tests
bun test packages/**/*.test.ts --ignore "*.container.*"

# For topology tests
bun test packages/orchestrator/src/next/*.topology.test.ts

# For container tests (after setting up Podman)
source podman-env.sh
bun test packages/**/*.container.test.ts
```

### Why make this change?

This documentation helps new contributors understand the testing approach and provides clear instructions for running different test types. The Podman setup instructions are particularly important as container tests are disabled by default to prevent environment-related failures.