### PR TITLE
feat: back to docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,29 +81,23 @@ bun test packages/orchestrator/src/next/*.topology.test.ts
 
 #### 3. Container Integration Tests
 
-End-to-end tests that spin up actual node containers using Podman and `testcontainers`. These are used for validating network-level handshakes and gateway synchronization.
+End-to-end tests that spin up actual node containers using Docker and `testcontainers`. These are used for validating network-level handshakes and gateway synchronization.
 
 ```bash
 # Run container-based integration tests
 bun test packages/**/*.container.test.ts
 ```
 
-### Podman Environment Setup
+### Docker Environment Setup
 
-Container-based tests are disabled by default to prevent environment-related failures. To enable them, you must configure your local Podman environment:
+Container-based tests are disabled by default to prevent environment-related failures. To enable them, you must have a working Docker installation and set the following environment variable:
 
-1.  **Initialize Environment**:
-    Run the following command in your terminal to export the necessary socket paths and activation flags:
-
-    ```bash
-    source podman-env.sh
-    ```
-
-2.  **Verify Configuration**:
-    The script dynamically detects your Podman socket and sets `CATALYST_CONTAINER_TESTS_ENABLED=true`.
+```bash
+export CATALYST_CONTAINER_TESTS_ENABLED=true
+```
 
 > [!TIP]
-> You can add `source path/to/podman-env.sh` to your shell profile (~/.zshrc or ~/.bashrc) if you frequently run integration tests.
+> You can add `export CATALYST_CONTAINER_TESTS_ENABLED=true` to your shell profile (~/.zshrc or ~/.bashrc) if you frequently run integration tests.
 
 ### Running Tests by Package
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "catalyst-monorepo",
   "private": true,
   "scripts": {
-    "start:m0p2": "podman compose -f docker-compose/example.m0p2.compose.yaml up --build",
+    "start:m0p2": "docker compose -f docker-compose/example.m0p2.compose.yaml up --build",
     "cli": "bun packages/cli/src/index.ts",
     "prepare": "husky",
     "lint": "eslint .",

--- a/packages/auth/tests/container.test.ts
+++ b/packages/auth/tests/container.test.ts
@@ -20,7 +20,7 @@ describe('Auth Service Container', () => {
     console.log('Building Docker image from', repoRoot)
 
     const proc = Bun.spawn(
-      ['podman', 'build', '-t', 'auth-service:test', '-f', 'packages/auth/Dockerfile', '.'],
+      ['docker', 'build', '-t', 'auth-service:test', '-f', 'packages/auth/Dockerfile', '.'],
       {
         cwd: repoRoot,
         // stdout: 'inherit', // Uncomment for debugging build

--- a/packages/cli/tests/service.integration.test.ts
+++ b/packages/cli/tests/service.integration.test.ts
@@ -53,7 +53,7 @@ describe('CLI E2E with Containers', () => {
     const buildBooks = async () => {
       await Bun.spawn(
         [
-          'podman',
+          'docker',
           'build',
           '-t',
           'books-service:test',
@@ -72,7 +72,7 @@ describe('CLI E2E with Containers', () => {
     const buildMovies = async () => {
       await Bun.spawn(
         [
-          'podman',
+          'docker',
           'build',
           '-t',
           'movies-service:test',
@@ -90,7 +90,7 @@ describe('CLI E2E with Containers', () => {
 
     const buildGateway = async () => {
       await Bun.spawn(
-        ['podman', 'build', '-t', 'gateway-service:test', '-f', 'packages/gateway/Dockerfile', '.'],
+        ['docker', 'build', '-t', 'gateway-service:test', '-f', 'packages/gateway/Dockerfile', '.'],
         {
           cwd: repoRoot,
           stdout: 'ignore',
@@ -102,7 +102,7 @@ describe('CLI E2E with Containers', () => {
     const buildOrchestrator = async () => {
       await Bun.spawn(
         [
-          'podman',
+          'docker',
           'build',
           '-t',
           'orchestrator-service:test',

--- a/packages/gateway/tests/container.gateway.test.ts
+++ b/packages/gateway/tests/container.gateway.test.ts
@@ -28,7 +28,7 @@ describe('Gateway Container Integration', () => {
       if (skipTests) return
       const imageName = 'books-service:test'
       await Bun.spawn(
-        ['podman', 'build', '-t', imageName, '-f', 'packages/examples/Dockerfile.books', '.'],
+        ['docker', 'build', '-t', imageName, '-f', 'packages/examples/Dockerfile.books', '.'],
         {
           cwd: repoRoot,
           stdout: 'ignore',
@@ -48,7 +48,7 @@ describe('Gateway Container Integration', () => {
     const startMovies = async () => {
       const imageName = 'movies-service:test'
       await Bun.spawn(
-        ['podman', 'build', '-t', imageName, '-f', 'packages/examples/Dockerfile.movies', '.'],
+        ['docker', 'build', '-t', imageName, '-f', 'packages/examples/Dockerfile.movies', '.'],
         {
           cwd: repoRoot,
           stdout: 'ignore',
@@ -68,7 +68,7 @@ describe('Gateway Container Integration', () => {
     const startGateway = async () => {
       const imageName = 'gateway-service:test'
       await Bun.spawn(
-        ['podman', 'build', '-t', imageName, '-f', 'packages/gateway/Dockerfile', '.'],
+        ['docker', 'build', '-t', imageName, '-f', 'packages/gateway/Dockerfile', '.'],
         {
           cwd: repoRoot,
           stdout: 'ignore',

--- a/packages/gateway/tests/integration.graphql.test.ts
+++ b/packages/gateway/tests/integration.graphql.test.ts
@@ -23,7 +23,7 @@ describe('Gateway Integration', () => {
       const imageName = 'books-service:test'
       const dockerfile = 'packages/examples/Dockerfile.books'
       // Workaround for Bun tar-stream issue
-      const proc = Bun.spawn(['podman', 'build', '-t', imageName, '-f', dockerfile, '.'], {
+      const proc = Bun.spawn(['docker', 'build', '-t', imageName, '-f', dockerfile, '.'], {
         cwd: repoRoot,
         stdout: 'ignore',
         stderr: 'inherit',
@@ -41,7 +41,7 @@ describe('Gateway Integration', () => {
       const imageName = 'movies-service:test'
       const dockerfile = 'packages/examples/Dockerfile.movies'
       // Workaround for Bun tar-stream issue
-      const proc = Bun.spawn(['podman', 'build', '-t', imageName, '-f', dockerfile, '.'], {
+      const proc = Bun.spawn(['docker', 'build', '-t', imageName, '-f', dockerfile, '.'], {
         cwd: repoRoot,
         stdout: 'ignore',
         stderr: 'inherit',

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -7,8 +7,7 @@
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "build": "tsc",
-    "test": "bun test",
-    "test:podman": "./src/next/test_with_podman.sh"
+    "test": "bun test"
   },
   "dependencies": {
     "@hono/capnweb": "catalog:",

--- a/packages/orchestrator/tests/orchestrator.gateway.container.test.ts
+++ b/packages/orchestrator/tests/orchestrator.gateway.container.test.ts
@@ -22,35 +22,35 @@ describe('Orchestrator Gateway Container Tests', () => {
   let books: StartedTestContainer
   const peerBLogs: string[] = []
 
-  const orchestratorImage = 'localhost/catalyst-node:next-topology-e2e'
-  const gatewayImage = 'localhost/catalyst-gateway:test'
-  const booksImage = 'localhost/catalyst-example-books:test'
+  const orchestratorImage = 'catalyst-node:next-topology-e2e'
+  const gatewayImage = 'catalyst-gateway:test'
+  const booksImage = 'catalyst-example-books:test'
   const repoRoot = path.resolve(__dirname, '../../../')
   const skipTests = !process.env.CATALYST_CONTAINER_TESTS_ENABLED
 
   beforeAll(async () => {
     if (skipTests) {
-      console.warn('Skipping container tests: Podman runtime not detected')
+      console.warn('Skipping container tests: Docker runtime not detected')
       return
     }
 
     // Build images (rely on cache)
     console.log('Building Gateway image...')
-    spawnSync('podman', ['build', '-f', 'packages/gateway/Dockerfile', '-t', gatewayImage, '.'], {
+    spawnSync('docker', ['build', '-f', 'packages/gateway/Dockerfile', '-t', gatewayImage, '.'], {
       cwd: repoRoot,
       stdio: 'inherit',
     })
 
     console.log('Building Books service image...')
     spawnSync(
-      'podman',
+      'docker',
       ['build', '-f', 'packages/examples/Dockerfile.books', '-t', booksImage, '.'],
       { cwd: repoRoot, stdio: 'inherit' }
     )
 
     console.log('Building Orchestrator image...')
     spawnSync(
-      'podman',
+      'docker',
       ['build', '-f', 'packages/orchestrator/Dockerfile', '-t', orchestratorImage, '.'],
       { cwd: repoRoot, stdio: 'inherit' }
     )

--- a/packages/orchestrator/tests/peering.orchestrator.topology.container.test.ts
+++ b/packages/orchestrator/tests/peering.orchestrator.topology.container.test.ts
@@ -18,26 +18,26 @@ describe('Orchestrator Peering Container Tests', () => {
   let nodeA: StartedTestContainer
   let nodeB: StartedTestContainer
 
-  const orchestratorImage = 'localhost/catalyst-node:next-topology-e2e'
+  const orchestratorImage = 'catalyst-node:next-topology-e2e'
   const repoRoot = path.resolve(__dirname, '../../../')
   const skipTests = !process.env.CATALYST_CONTAINER_TESTS_ENABLED
 
   beforeAll(async () => {
     if (skipTests) {
-      console.warn('Skipping container tests: Podman runtime not detected')
+      console.warn('Skipping container tests: Docker runtime not detected')
       return
     }
 
     // Check if image exists
-    const checkImage = spawnSync('podman', ['image', 'exists', orchestratorImage])
+    const checkImage = spawnSync('docker', ['image', 'inspect', orchestratorImage])
     if (checkImage.status !== 0) {
       console.log('Building Orchestrator image for Topology tests...')
       const orchestratorBuild = spawnSync(
-        'podman',
+        'docker',
         ['build', '-f', 'packages/orchestrator/Dockerfile', '-t', orchestratorImage, '.'],
         { cwd: repoRoot, stdio: 'inherit' }
       )
-      if (orchestratorBuild.status !== 0) throw new Error('Podman build orchestrator failed')
+      if (orchestratorBuild.status !== 0) throw new Error('Docker build orchestrator failed')
     } else {
       console.log(`Using existing image: ${orchestratorImage}`)
     }

--- a/packages/orchestrator/tests/transit.orchestrator.topology.container.test.ts
+++ b/packages/orchestrator/tests/transit.orchestrator.topology.container.test.ts
@@ -19,26 +19,26 @@ describe('Orchestrator Transit Container Tests', () => {
   let nodeB: StartedTestContainer
   let nodeC: StartedTestContainer
 
-  const orchestratorImage = 'localhost/catalyst-node:next-topology-e2e'
+  const orchestratorImage = 'catalyst-node:next-topology-e2e'
   const repoRoot = path.resolve(__dirname, '../../../')
   const skipTests = !process.env.CATALYST_CONTAINER_TESTS_ENABLED
 
   beforeAll(async () => {
     if (skipTests) {
-      console.warn('Skipping container tests: Podman runtime not detected')
+      console.warn('Skipping container tests: Docker runtime not detected')
       return
     }
 
     // Check if image exists
-    const checkImage = spawnSync('podman', ['image', 'exists', orchestratorImage])
+    const checkImage = spawnSync('docker', ['image', 'inspect', orchestratorImage])
     if (checkImage.status !== 0) {
       console.log('Building Orchestrator image for Topology tests...')
       const orchestratorBuild = spawnSync(
-        'podman',
+        'docker',
         ['build', '-f', 'packages/orchestrator/Dockerfile', '-t', orchestratorImage, '.'],
         { cwd: repoRoot, stdio: 'inherit' }
       )
-      if (orchestratorBuild.status !== 0) throw new Error('Podman build orchestrator failed')
+      if (orchestratorBuild.status !== 0) throw new Error('Docker build orchestrator failed')
     } else {
       console.log(`Using existing image: ${orchestratorImage}`)
     }

--- a/podman-env.sh
+++ b/podman-env.sh
@@ -1,3 +1,0 @@
-export DOCKER_HOST=unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')
-export TESTCONTAINERS_RYUK_DISABLED=true
-export CATALYST_CONTAINER_TESTS_ENABLED=true


### PR DESCRIPTION
# Replace Podman with Docker for Container Tests

### TL;DR

Switch from Podman to Docker for all container-based integration tests.

### What changed?

- Replaced all `podman` commands with `docker` commands throughout the codebase
- Updated README documentation to reflect Docker usage instead of Podman
- Removed `podman-env.sh` script as it's no longer needed
- Updated image naming conventions to be Docker-compatible
- Simplified container test setup by using Docker's standard environment
- Changed the `start:m0p2` script to use Docker Compose instead of Podman Compose

### How to test?

1. Install Docker if not already installed
2. Set the environment variable: `export CATALYST_CONTAINER_TESTS_ENABLED=true`
3. Run container tests: `bun test packages/**/*.container.test.ts`

### Why make this change?

Docker provides better compatibility and is more widely used than Podman. This change simplifies the development environment setup and makes it easier for contributors to run container-based tests without requiring Podman-specific configuration.