### PR TITLE
chore: removing inspector api as its poorly named and scoped

### DIFF
--- a/packages/orchestrator/tests/orchestrator.test.ts
+++ b/packages/orchestrator/tests/orchestrator.test.ts
@@ -132,8 +132,9 @@ describe.skipIf(skipTests)('Orchestrator Container Tests (Next)', () => {
       // Check B learned it
       let learnedOnB = false
       for (let i = 0; i < 20; i++) {
-        const inspector = await clientB.getInspector()
-        const routes = await inspector.listRoutes()
+        const dataBResult = await clientB.getDataCustodianClient('valid-secret')
+        if (!dataBResult.success) throw new Error('Failed to get data client B')
+        const routes = await dataBResult.client.listRoutes()
         if (routes.internal.some((r) => r.name === 'service-a')) {
           learnedOnB = true
           break
@@ -179,8 +180,9 @@ describe.skipIf(skipTests)('Orchestrator Container Tests (Next)', () => {
       // Verify node C learned service-a via node B
       let learnedOnC = false
       for (let i = 0; i < 20; i++) {
-        const inspector = await clientC.getInspector()
-        const routes = await inspector.listRoutes()
+        const dataCResult = await clientC.getDataCustodianClient('valid-secret')
+        if (!dataCResult.success) throw new Error('Failed to get data client C')
+        const routes = await dataCResult.client.listRoutes()
         const routeA = routes.internal.find((r) => r.name === 'service-a')
         if (routeA) {
           learnedOnC = true

--- a/packages/orchestrator/tests/peering.orchestrator.topology.container.test.ts
+++ b/packages/orchestrator/tests/peering.orchestrator.topology.container.test.ts
@@ -138,7 +138,9 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
       console.log('Waiting for peering A <-> B to resolve...')
       const waitForConnected = async (client: RpcStub<PublicApi>, peerName: string) => {
         for (let i = 0; i < 20; i++) {
-          const peers = await (await client.getInspector()).listPeers()
+          const netResult = await client.getNetworkClient('valid-secret')
+          if (!netResult.success) throw new Error('Failed to get network client for check')
+          const peers = await netResult.client.listPeers()
           const peer = peers.find((p) => p.name === peerName)
           if (peer && peer.connectionStatus === 'connected') return
           await new Promise((r) => setTimeout(r, 500))
@@ -167,8 +169,9 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
       // Check B learned it
       let learnedOnB = false
       for (let i = 0; i < 40; i++) {
-        const inspector = await clientB.getInspector()
-        const routes = await inspector.listRoutes()
+        const dataBResult = await clientB.getDataCustodianClient('valid-secret')
+        if (!dataBResult.success) throw new Error('Failed to get data client B')
+        const routes = await dataBResult.client.listRoutes()
         if (routes.internal.some((r) => r.name === 'service-a')) {
           learnedOnB = true
           break

--- a/packages/orchestrator/tests/transit.orchestrator.topology.container.test.ts
+++ b/packages/orchestrator/tests/transit.orchestrator.topology.container.test.ts
@@ -147,7 +147,9 @@ describe.skipIf(skipTests)('Orchestrator Transit Container Tests', () => {
       console.log('Waiting for peering A <-> B to resolve...')
       const waitForConnected = async (client: RpcStub<PublicApi>, peerName: string) => {
         for (let i = 0; i < 20; i++) {
-          const peers = await (await client.getInspector()).listPeers()
+          const netResult = await client.getNetworkClient('valid-secret')
+          if (!netResult.success) throw new Error('Failed to get network client for check')
+          const peers = await netResult.client.listPeers()
           const peer = peers.find((p) => p.name === peerName)
           if (peer && peer.connectionStatus === 'connected') return
           await new Promise((r) => setTimeout(r, 500))
@@ -170,8 +172,9 @@ describe.skipIf(skipTests)('Orchestrator Transit Container Tests', () => {
       // Check B learned it
       let learnedOnB = false
       for (let i = 0; i < 40; i++) {
-        const inspector = await clientB.getInspector()
-        const routes = await inspector.listRoutes()
+        const dataBResult = await clientB.getDataCustodianClient('valid-secret')
+        if (!dataBResult.success) throw new Error('Failed to get data client B')
+        const routes = await dataBResult.client.listRoutes()
         if (routes.internal.some((r) => r.name === 'service-a')) {
           learnedOnB = true
           break
@@ -200,8 +203,9 @@ describe.skipIf(skipTests)('Orchestrator Transit Container Tests', () => {
       // 4. C should have learned about A's route via B
       let learnedOnC = false
       for (let i = 0; i < 10; i++) {
-        const inspector = await clientC.getInspector()
-        const routes = await inspector.listRoutes()
+        const dataCResult = await clientC.getDataCustodianClient('valid-secret')
+        if (!dataCResult.success) throw new Error('Failed to get data client C')
+        const routes = await dataCResult.client.listRoutes()
         const routeA = routes.internal.find((r) => r.name === 'service-a')
         if (routeA) {
           learnedOnC = true
@@ -228,8 +232,9 @@ describe.skipIf(skipTests)('Orchestrator Transit Container Tests', () => {
 
       let removedOnC = false
       for (let i = 0; i < 10; i++) {
-        const inspector = await clientC.getInspector()
-        const routes = await inspector.listRoutes()
+        const dataCResult = await clientC.getDataCustodianClient('valid-secret')
+        if (!dataCResult.success) throw new Error('Failed to get data client C')
+        const routes = await dataCResult.client.listRoutes()
         if (!routes.internal.some((r) => r.name === 'service-a')) {
           removedOnC = true
           break
@@ -258,8 +263,9 @@ describe.skipIf(skipTests)('Orchestrator Transit Container Tests', () => {
 
       let disconnectedWithdrawalOnC = false
       for (let i = 0; i < 10; i++) {
-        const inspector = await clientC.getInspector()
-        const routes = await inspector.listRoutes()
+        const dataCResult = await clientC.getDataCustodianClient('valid-secret')
+        if (!dataCResult.success) throw new Error('Failed to get data client C')
+        const routes = await dataCResult.client.listRoutes()
         if (!routes.internal.some((r) => r.name === 'service-a-v2')) {
           disconnectedWithdrawalOnC = true
           break


### PR DESCRIPTION
### TL;DR

Refactored the API by moving inspection methods to their respective client interfaces instead of using a separate Inspector interface.

### What changed?

- Removed the `getInspector()` method from the `PublicApi` interface
- Removed the `Inspector` interface entirely
- Added `listPeers()` method to the `NetworkClient` interface
- Added `listRoutes()` method to the `DataCustodian` interface
- Updated all test files to use the new API structure by calling the appropriate client methods instead of using the inspector

### How to test?

1. Run the existing test suite to verify all functionality works with the new API structure
2. Verify that clients can still access peer and route information through the appropriate client interfaces
3. Check that all tests pass with the updated method calls

### Why make this change?

This change improves the API design by placing inspection methods in their logically related interfaces rather than having a separate inspector. This creates a more intuitive API where network-related operations (including listing peers) are in the NetworkClient, and data-related operations (including listing routes) are in the DataCustodian. This organization makes the API more cohesive and easier to understand.