### PR TITLE
chore: renaming DataCustodian API to DataChannel

### DIFF
--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -20,9 +20,9 @@ export interface PublicApi {
   getNetworkClient(
     token: string
   ): Promise<{ success: true; client: NetworkClient } | { success: false; error: string }>
-  getDataCustodianClient(
+  getDataChannelClient(
     token: string
-  ): Promise<{ success: true; client: DataCustodian } | { success: false; error: string }>
+  ): Promise<{ success: true; client: DataChannel } | { success: false; error: string }>
   getIBGPClient(
     token: string
   ): Promise<{ success: true; client: IBGPClient } | { success: false; error: string }>
@@ -41,7 +41,7 @@ export interface NetworkClient {
   listPeers(): Promise<PeerRecord[]>
 }
 
-export interface DataCustodian {
+export interface DataChannel {
   addRoute(
     route: DataChannelDefinition
   ): Promise<{ success: true } | { success: false; error: string }>
@@ -833,9 +833,9 @@ export class CatalystNodeBus extends RpcTarget {
           },
         }
       },
-      getDataCustodianClient: async (
+      getDataChannelClient: async (
         token: string
-      ): Promise<{ success: true; client: DataCustodian } | { success: false; error: string }> => {
+      ): Promise<{ success: true; client: DataChannel } | { success: false; error: string }> => {
         // TODO: Parse token to extract authorization context
         const expectedSecret = this.config?.ibgp?.secret
         if (!expectedSecret || !isSecretValid(token, expectedSecret)) {

--- a/packages/orchestrator/tests/orchestrator.gateway.container.test.ts
+++ b/packages/orchestrator/tests/orchestrator.gateway.container.test.ts
@@ -202,7 +202,7 @@ describe.skipIf(skipTests)('Orchestrator Gateway Container Tests', () => {
 
       // 2. A adds a GraphQL route
       console.log('Adding GraphQL route to A...')
-      const dataAResult = await clientA.getDataCustodianClient('valid-secret')
+      const dataAResult = await clientA.getDataChannelClient('valid-secret')
       if (!dataAResult.success) throw new Error(`Failed to get data client: ${dataAResult.error}`)
 
       await dataAResult.client.addRoute({

--- a/packages/orchestrator/tests/orchestrator.test.ts
+++ b/packages/orchestrator/tests/orchestrator.test.ts
@@ -120,7 +120,7 @@ describe.skipIf(skipTests)('Orchestrator Container Tests (Next)', () => {
       await new Promise((r) => setTimeout(r, 2000))
 
       // A adds a route
-      const dataAResult = await clientA.getDataCustodianClient('valid-secret')
+      const dataAResult = await clientA.getDataChannelClient('valid-secret')
       if (!dataAResult.success) throw new Error(`Failed to get data client: ${dataAResult.error}`)
 
       await dataAResult.client.addRoute({
@@ -132,7 +132,7 @@ describe.skipIf(skipTests)('Orchestrator Container Tests (Next)', () => {
       // Check B learned it
       let learnedOnB = false
       for (let i = 0; i < 20; i++) {
-        const dataBResult = await clientB.getDataCustodianClient('valid-secret')
+        const dataBResult = await clientB.getDataChannelClient('valid-secret')
         if (!dataBResult.success) throw new Error('Failed to get data client B')
         const routes = await dataBResult.client.listRoutes()
         if (routes.internal.some((r) => r.name === 'service-a')) {
@@ -180,7 +180,7 @@ describe.skipIf(skipTests)('Orchestrator Container Tests (Next)', () => {
       // Verify node C learned service-a via node B
       let learnedOnC = false
       for (let i = 0; i < 20; i++) {
-        const dataCResult = await clientC.getDataCustodianClient('valid-secret')
+        const dataCResult = await clientC.getDataChannelClient('valid-secret')
         if (!dataCResult.success) throw new Error('Failed to get data client C')
         const routes = await dataCResult.client.listRoutes()
         const routeA = routes.internal.find((r) => r.name === 'service-a')

--- a/packages/orchestrator/tests/orchestrator.topology.test.ts
+++ b/packages/orchestrator/tests/orchestrator.topology.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'bun:test'
-import { CatalystNodeBus, type NetworkClient, type DataCustodian } from '../src/orchestrator.js'
+import { CatalystNodeBus, type NetworkClient, type DataChannel } from '../src/orchestrator.js'
 import type { PeerInfo, RouteTable } from '../src/routing/state.js'
 import { newRouteTable } from '../src/routing/state.js'
 
@@ -66,9 +66,9 @@ describe('Orchestrator Topology Tests', () => {
     ).client
 
     const dataA = (
-      (await nodeA.publicApi().getDataCustodianClient('secret')) as {
+      (await nodeA.publicApi().getDataChannelClient('secret')) as {
         success: true
-        client: DataCustodian
+        client: DataChannel
       }
     ).client
 
@@ -135,9 +135,9 @@ describe('Orchestrator Topology Tests', () => {
     ).client
 
     const dataA = (
-      (await nodeA.publicApi().getDataCustodianClient('secret')) as {
+      (await nodeA.publicApi().getDataChannelClient('secret')) as {
         success: true
-        client: DataCustodian
+        client: DataChannel
       }
     ).client
 
@@ -212,9 +212,9 @@ describe('Orchestrator Topology Tests', () => {
     ).client
 
     const dataA = (
-      (await nodeA.publicApi().getDataCustodianClient('secret')) as {
+      (await nodeA.publicApi().getDataChannelClient('secret')) as {
         success: true
-        client: DataCustodian
+        client: DataChannel
       }
     ).client
 
@@ -270,9 +270,9 @@ describe('Orchestrator Topology Tests', () => {
     ).client
 
     const dataA = (
-      (await nodeA.publicApi().getDataCustodianClient('secret')) as {
+      (await nodeA.publicApi().getDataChannelClient('secret')) as {
         success: true
-        client: DataCustodian
+        client: DataChannel
       }
     ).client
 

--- a/packages/orchestrator/tests/peering.orchestrator.topology.container.test.ts
+++ b/packages/orchestrator/tests/peering.orchestrator.topology.container.test.ts
@@ -152,7 +152,7 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
 
       // 2. A adds a local route
       console.log('Node A adding local route')
-      const dataAResult = await clientA.getDataCustodianClient('valid-secret')
+      const dataAResult = await clientA.getDataChannelClient('valid-secret')
       if (!dataAResult.success) throw new Error('Failed to get data client')
 
       const routeResult = await dataAResult.client.addRoute({
@@ -169,7 +169,7 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
       // Check B learned it
       let learnedOnB = false
       for (let i = 0; i < 40; i++) {
-        const dataBResult = await clientB.getDataCustodianClient('valid-secret')
+        const dataBResult = await clientB.getDataChannelClient('valid-secret')
         if (!dataBResult.success) throw new Error('Failed to get data client B')
         const routes = await dataBResult.client.listRoutes()
         if (routes.internal.some((r) => r.name === 'service-a')) {

--- a/packages/orchestrator/tests/peering.orchestrator.topology.test.ts
+++ b/packages/orchestrator/tests/peering.orchestrator.topology.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'bun:test'
-import { CatalystNodeBus, type NetworkClient, type DataCustodian } from '../src/orchestrator.js'
+import { CatalystNodeBus, type NetworkClient, type DataChannel } from '../src/orchestrator.js'
 import type { PeerInfo, RouteTable } from '../src/routing/state.js'
 import { newRouteTable } from '../src/routing/state.js'
 import { MockConnectionPool } from './mock-connection-pool.js'
@@ -83,7 +83,7 @@ describe('Orchestrator Peering Tests (Mocked Container Logic)', () => {
     console.log('Node A adding local route')
     const routeA = { name: 'service-a', protocol: 'http' as const, endpoint: 'http://a:8080' }
     const dataA = (
-      (await apiA.getDataCustodianClient('secret')) as { success: true; client: DataCustodian }
+      (await apiA.getDataChannelClient('secret')) as { success: true; client: DataChannel }
     ).client
     await dataA.addRoute(routeA)
 

--- a/packages/orchestrator/tests/transit.orchestrator.topology.test.ts
+++ b/packages/orchestrator/tests/transit.orchestrator.topology.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'bun:test'
-import { CatalystNodeBus, type NetworkClient, type DataCustodian } from '../src/orchestrator.js'
+import { CatalystNodeBus, type NetworkClient, type DataChannel } from '../src/orchestrator.js'
 import type { PeerInfo, RouteTable } from '../src/routing/state.js'
 import { newRouteTable } from '../src/routing/state.js'
 import { MockConnectionPool } from './mock-connection-pool.js'
@@ -90,9 +90,9 @@ describe('Orchestrator Transit Tests (Mocked Container Logic)', () => {
     console.log('Node A adding local route')
     const routeA = { name: 'service-a', protocol: 'http' as const, endpoint: 'http://a:8080' }
     const dataA = (
-      (await nodeA.publicApi().getDataCustodianClient('secret')) as {
+      (await nodeA.publicApi().getDataChannelClient('secret')) as {
         success: true
-        client: DataCustodian
+        client: DataChannel
       }
     ).client
     await dataA.addRoute(routeA)
@@ -114,9 +114,9 @@ describe('Orchestrator Transit Tests (Mocked Container Logic)', () => {
     // 4. Withdrawal Propagation
     console.log('Node A deleting route')
     await (
-      (await nodeA.publicApi().getDataCustodianClient('secret')) as {
+      (await nodeA.publicApi().getDataChannelClient('secret')) as {
         success: true
-        client: DataCustodian
+        client: DataChannel
       }
     ).client.removeRoute(routeA)
 
@@ -132,9 +132,9 @@ describe('Orchestrator Transit Tests (Mocked Container Logic)', () => {
     // 5. Disconnect Propagation
     // Re-add route
     await (
-      (await nodeA.publicApi().getDataCustodianClient('secret')) as {
+      (await nodeA.publicApi().getDataChannelClient('secret')) as {
         success: true
-        client: DataCustodian
+        client: DataChannel
       }
     ).client.addRoute(routeA)
     await waitForNotification(nodeA)


### PR DESCRIPTION
### TL;DR

Renamed `DataCustodian` to `DataChannel` throughout the codebase to better reflect its purpose.

### What changed?

- Renamed the `DataCustodian` interface to `DataChannel` to better align with its functionality
- Updated the `getDataCustodianClient` method to `getDataChannelClient` in the `PublicApi` interface
- Updated all references to these names across test files and implementation code

### How to test?

1. Run the existing test suite to ensure all functionality works as expected
2. Verify that all client code using the API properly calls `getDataChannelClient` instead of the old method name
3. Check that type definitions are properly updated in consuming code

### Why make this change?

The term "DataChannel" more accurately describes the component's role in the system architecture. This naming better reflects that this interface is responsible for managing data routing channels between nodes rather than just custodial functions. This change improves code readability and makes the API more intuitive for developers.