### PR TITLE
chore: removing tests comment that is outdated

### DIFF
--- a/packages/orchestrator/tests/orchestrator.topology.test.ts
+++ b/packages/orchestrator/tests/orchestrator.topology.test.ts
@@ -183,11 +183,10 @@ describe('Orchestrator Topology Tests', () => {
 
     await new Promise((r) => setTimeout(r, 100))
 
-    // 4. C should learn A's route via B (Initial Sync)
+    // C should learn A's route via B (Initial Sync)
     const stateC = (nodeC as unknown as { state: RouteTable }).state
     const hasA = stateC.internal.routes.some((r) => r.name === 'service-a')
 
-    // THIS IS EXPECTED TO FAIL CURRENTLY based on my audit
     expect(hasA).toBe(true)
   })
 


### PR DESCRIPTION
### TL;DR

Fixed a test case for route propagation in the orchestrator topology.

### What changed?

- Removed a comment indicating that the test was expected to fail
- Simplified the step numbering in the test comments by removing "4." from the comment line

### How to test?

Run the orchestrator topology tests to verify that node C correctly learns node A's route via node B during initial sync.

### Why make this change?

The test was previously marked with a comment indicating it was expected to fail based on an audit. This change removes that expectation, suggesting that the underlying issue has been resolved and the test should now pass successfully.