### PR TITLE
feat(telemetry): add sanitizers and path normalization

### DIFF
--- a/packages/telemetry/src/normalize.test.ts
+++ b/packages/telemetry/src/normalize.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test'
+import { normalizePath } from './normalize'
+
+describe('normalizePath', () => {
+  describe('UUID normalization', () => {
+    it('replaces a UUID segment with :uuid', () => {
+      expect(normalizePath('/users/550e8400-e29b-41d4-a716-446655440000/orders')).toBe(
+        '/users/:uuid/orders'
+      )
+    })
+
+    it('replaces uppercase UUIDs', () => {
+      expect(normalizePath('/items/550E8400-E29B-41D4-A716-446655440000')).toBe('/items/:uuid')
+    })
+
+    it('replaces multiple UUIDs in one path', () => {
+      expect(
+        normalizePath(
+          '/orgs/550e8400-e29b-41d4-a716-446655440000/users/660e8400-e29b-41d4-a716-446655440001'
+        )
+      ).toBe('/orgs/:uuid/users/:uuid')
+    })
+  })
+
+  describe('numeric ID normalization', () => {
+    it('replaces a numeric segment with :id', () => {
+      expect(normalizePath('/items/12345')).toBe('/items/:id')
+    })
+
+    it('replaces multiple numeric segments', () => {
+      expect(normalizePath('/users/42/orders/99')).toBe('/users/:id/orders/:id')
+    })
+
+    it('does not replace non-numeric segments', () => {
+      expect(normalizePath('/users/alice')).toBe('/users/alice')
+    })
+  })
+
+  describe('passthrough', () => {
+    it('preserves /health unchanged', () => {
+      expect(normalizePath('/health')).toBe('/health')
+    })
+
+    it('preserves root path', () => {
+      expect(normalizePath('/')).toBe('/')
+    })
+
+    it('preserves static paths', () => {
+      expect(normalizePath('/api/v1/users')).toBe('/api/v1/users')
+    })
+  })
+
+  describe('mixed patterns', () => {
+    it('normalizes both UUID and numeric segments', () => {
+      expect(normalizePath('/users/550e8400-e29b-41d4-a716-446655440000/orders/42')).toBe(
+        '/users/:uuid/orders/:id'
+      )
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles empty string', () => {
+      expect(normalizePath('')).toBe('')
+    })
+
+    it('handles path without leading slash', () => {
+      expect(normalizePath('users/123')).toBe('users/:id')
+    })
+
+    it('handles trailing slash', () => {
+      expect(normalizePath('/users/123/')).toBe('/users/:id/')
+    })
+  })
+})

--- a/packages/telemetry/src/normalize.ts
+++ b/packages/telemetry/src/normalize.ts
@@ -1,0 +1,38 @@
+/**
+ * @catalyst/telemetry — Path normalization utilities
+ *
+ * Replaces dynamic path segments (UUIDs, numeric IDs) with placeholders
+ * to prevent high-cardinality metric labels.
+ */
+
+const UUID_PATTERN = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi
+const NUMERIC_SEGMENT_PATTERN = /^\d+$/
+
+/**
+ * Normalize an HTTP path by replacing dynamic segments with placeholders.
+ *
+ * - UUIDs → `:uuid`
+ * - Purely numeric segments → `:id`
+ * - All other segments pass through unchanged.
+ *
+ * @example
+ * normalizePath('/users/550e8400-e29b-41d4-a716-446655440000/orders')
+ * // → '/users/:uuid/orders'
+ *
+ * normalizePath('/items/12345')
+ * // → '/items/:id'
+ */
+export function normalizePath(path: string): string {
+  if (!path) return path
+
+  // Replace UUIDs first (they contain digits, so must come before numeric check)
+  let normalized = path.replace(UUID_PATTERN, ':uuid')
+
+  // Then replace remaining purely numeric segments
+  const segments = normalized.split('/')
+  normalized = segments
+    .map((segment) => (NUMERIC_SEGMENT_PATTERN.test(segment) ? ':id' : segment))
+    .join('/')
+
+  return normalized
+}

--- a/packages/telemetry/src/sanitizers.test.ts
+++ b/packages/telemetry/src/sanitizers.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'bun:test'
+import { sanitizeAttributes } from './sanitizers'
+
+describe('sanitizeAttributes', () => {
+  describe('sensitive key redaction', () => {
+    const sensitiveKeys = [
+      'password',
+      'token',
+      'secret',
+      'authorization',
+      'cookie',
+      'api_key',
+      'api-key',
+      'apikey',
+      'bearer',
+      'credential',
+      'private_key',
+      'private-key',
+    ]
+
+    for (const key of sensitiveKeys) {
+      it(`redacts key containing "${key}"`, () => {
+        const result = sanitizeAttributes({ [key]: 'sensitive-value' })
+        expect(result[key]).toBe('[REDACTED]')
+      })
+
+      it(`redacts key containing "${key}" case-insensitively`, () => {
+        const upperKey = `user.${key.toUpperCase()}`
+        const result = sanitizeAttributes({ [upperKey]: 'sensitive-value' })
+        expect(result[upperKey]).toBe('[REDACTED]')
+      })
+    }
+
+    it('redacts compound keys like "auth.token.value"', () => {
+      const result = sanitizeAttributes({ 'auth.token.value': 'abc123' })
+      expect(result['auth.token.value']).toBe('[REDACTED]')
+    })
+  })
+
+  describe('email scrubbing', () => {
+    it('replaces email addresses with [EMAIL]', () => {
+      const result = sanitizeAttributes({ 'user.email': 'alice@example.com' })
+      expect(result['user.email']).toBe('[EMAIL]')
+    })
+
+    it('replaces emails with plus addressing', () => {
+      const result = sanitizeAttributes({ contact: 'alice+tag@example.co.uk' })
+      expect(result.contact).toBe('[EMAIL]')
+    })
+
+    it('does not replace non-email strings containing @', () => {
+      const result = sanitizeAttributes({ mention: '@alice' })
+      expect(result.mention).toBe('@alice')
+    })
+
+    it('replaces inline emails embedded in strings', () => {
+      const result = sanitizeAttributes({
+        message: 'User alice@example.com logged in from 10.0.0.1',
+      })
+      expect(result.message).toBe('User [EMAIL] logged in from 10.0.0.1')
+    })
+
+    it('replaces multiple inline emails in one string', () => {
+      const result = sanitizeAttributes({
+        log: 'From alice@a.com to bob@b.com',
+      })
+      expect(result.log).toBe('From [EMAIL] to [EMAIL]')
+    })
+  })
+
+  describe('nested objects', () => {
+    it('recursively sanitizes nested objects', () => {
+      const result = sanitizeAttributes({
+        request: {
+          headers: { authorization: 'Bearer xxx' },
+          user: 'alice@example.com',
+        },
+      })
+      const nested = result.request as Record<string, unknown>
+      const headers = nested.headers as Record<string, unknown>
+      expect(headers.authorization).toBe('[REDACTED]')
+      expect(nested.user).toBe('[EMAIL]')
+    })
+
+    it('handles deeply nested objects', () => {
+      const result = sanitizeAttributes({
+        a: { b: { c: { secret: 'deep' } } },
+      })
+      const a = result.a as Record<string, unknown>
+      const b = a.b as Record<string, unknown>
+      const c = b.c as Record<string, unknown>
+      expect(c.secret).toBe('[REDACTED]')
+    })
+  })
+
+  describe('arrays', () => {
+    it('sanitizes email values in arrays', () => {
+      const result = sanitizeAttributes({
+        recipients: ['alice@example.com', 'bob@example.com'],
+      })
+      expect(result.recipients).toEqual(['[EMAIL]', '[EMAIL]'])
+    })
+
+    it('sanitizes mixed arrays', () => {
+      const result = sanitizeAttributes({
+        items: ['alice@example.com', 42, true, 'plain text'],
+      })
+      expect(result.items).toEqual(['[EMAIL]', 42, true, 'plain text'])
+    })
+
+    it('sanitizes nested objects inside arrays', () => {
+      const result = sanitizeAttributes({
+        users: [{ password: 'secret' }, { name: 'bob' }],
+      })
+      const users = result.users as Record<string, unknown>[]
+      expect(users[0].password).toBe('[REDACTED]')
+      expect(users[1].name).toBe('bob')
+    })
+  })
+
+  describe('non-sensitive passthrough', () => {
+    it('preserves non-sensitive string values', () => {
+      const result = sanitizeAttributes({ 'http.method': 'GET', 'http.route': '/users' })
+      expect(result['http.method']).toBe('GET')
+      expect(result['http.route']).toBe('/users')
+    })
+
+    it('preserves numeric values', () => {
+      const result = sanitizeAttributes({ 'http.status_code': 200 })
+      expect(result['http.status_code']).toBe(200)
+    })
+
+    it('preserves boolean values', () => {
+      const result = sanitizeAttributes({ 'cache.hit': true })
+      expect(result['cache.hit']).toBe(true)
+    })
+
+    it('passes through null and undefined', () => {
+      const result = sanitizeAttributes({ a: null, b: undefined })
+      expect(result.a).toBeNull()
+      expect(result.b).toBeUndefined()
+    })
+  })
+
+  describe('immutability', () => {
+    it('returns a new object', () => {
+      const input = { key: 'value' }
+      const result = sanitizeAttributes(input)
+      expect(result).not.toBe(input)
+    })
+
+    it('does not modify the input object', () => {
+      const input = { password: 'secret', name: 'alice' }
+      sanitizeAttributes(input)
+      expect(input.password).toBe('secret')
+      expect(input.name).toBe('alice')
+    })
+
+    it('does not modify nested input objects', () => {
+      const inner = { authorization: 'Bearer xxx' }
+      const input = { headers: inner }
+      sanitizeAttributes(input)
+      expect(inner.authorization).toBe('Bearer xxx')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles empty input', () => {
+      const result = sanitizeAttributes({})
+      expect(result).toEqual({})
+    })
+
+    it('handles input with no sensitive keys', () => {
+      const input = { method: 'GET', path: '/health' }
+      const result = sanitizeAttributes(input)
+      expect(result).toEqual(input)
+    })
+
+    it('prioritizes key redaction over email scrubbing', () => {
+      // If the key is "password" and value is an email, redact wins
+      const result = sanitizeAttributes({ password: 'admin@example.com' })
+      expect(result.password).toBe('[REDACTED]')
+    })
+  })
+})

--- a/packages/telemetry/src/sanitizers.ts
+++ b/packages/telemetry/src/sanitizers.ts
@@ -1,0 +1,59 @@
+/**
+ * @catalyst/telemetry — PII sanitization utilities
+ *
+ * Redacts sensitive attribute keys and scrubs email addresses
+ * from telemetry data before export.
+ *
+ * WHY recursive: OTEL span attributes are flat key-value pairs, but
+ * log properties (via LogTape) and custom attributes can contain nested
+ * objects and arrays. Flat-only sanitization creates a false sense of
+ * safety — nested PII passes through undetected.
+ */
+
+const SENSITIVE_KEY_PATTERN =
+  /password|token|secret|authorization|cookie|api[_-]?key|bearer|credential|private[_-]?key/i
+
+/**
+ * WHY inline pattern (no ^ $ anchors): Log messages commonly embed emails
+ * in strings like "User alice@example.com logged in". An anchored pattern
+ * only matches values that ARE an email, missing inline occurrences.
+ */
+const EMAIL_INLINE_PATTERN = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g
+
+/**
+ * Sanitize span/log attributes by redacting sensitive keys and scrubbing emails.
+ *
+ * - Keys matching sensitive patterns (case-insensitive) → `[REDACTED]`
+ * - String values containing email addresses → emails replaced with `[EMAIL]`
+ * - Nested objects → recursively sanitized
+ * - Arrays → elements sanitized individually
+ * - All other values pass through unchanged.
+ *
+ * Returns a new object; the input is not mutated.
+ */
+export function sanitizeAttributes(attrs: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(attrs)) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      result[key] = '[REDACTED]'
+    } else {
+      result[key] = sanitizeValue(value)
+    }
+  }
+
+  return result
+}
+
+function sanitizeValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.replace(EMAIL_INLINE_PATTERN, '[EMAIL]')
+  }
+  if (Array.isArray(value)) {
+    return value.map(sanitizeValue)
+  }
+  if (value !== null && typeof value === 'object') {
+    return sanitizeAttributes(value as Record<string, unknown>)
+  }
+  return value
+}


### PR DESCRIPTION
Add sanitizeAttributes() for PII redaction (sensitive keys, emails)
and normalizePath() for high-cardinality protection (UUIDs, numeric
IDs). Both are pure functions with table-driven tests.