### PR TITLE
feat(telemetry): add LogTape sinks for console and OTEL log export

### DIFF
--- a/packages/telemetry/src/sinks/console.ts
+++ b/packages/telemetry/src/sinks/console.ts
@@ -1,0 +1,23 @@
+/**
+ * @catalyst/telemetry — Console sink
+ *
+ * Wraps LogTape's getConsoleSink() with PII sanitization so that
+ * sensitive data (passwords, tokens, emails) never reaches stdout,
+ * even during local development.
+ */
+
+import { getConsoleSink } from '@logtape/logtape'
+import type { Sink } from '@logtape/logtape'
+import { sanitizeAttributes } from '../sanitizers'
+
+export function createConsoleSink(): Sink {
+  const inner = getConsoleSink()
+
+  return (record) => {
+    if (record.properties && Object.keys(record.properties).length > 0) {
+      const sanitized = sanitizeAttributes(record.properties as Record<string, unknown>)
+      record = { ...record, properties: sanitized }
+    }
+    inner(record)
+  }
+}

--- a/packages/telemetry/src/sinks/otel.test.ts
+++ b/packages/telemetry/src/sinks/otel.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import {
+  InMemoryLogRecordExporter,
+  LoggerProvider,
+  SimpleLogRecordProcessor,
+} from '@opentelemetry/sdk-logs'
+import { resourceFromAttributes } from '@opentelemetry/resources'
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
+import { configure, getLogger, reset } from '@logtape/logtape'
+import { createOtelSink, shutdownLoggerProvider } from './otel'
+
+function createTestLoggerProvider() {
+  const exporter = new InMemoryLogRecordExporter()
+  const loggerProvider = new LoggerProvider({
+    resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: 'test' }),
+    processors: [new SimpleLogRecordProcessor(exporter)],
+  })
+  return { exporter, loggerProvider }
+}
+
+async function setupLogtape(sinkFn: ReturnType<typeof createOtelSink>) {
+  await configure({
+    sinks: { otel: sinkFn },
+    loggers: [{ category: ['test'], sinks: ['otel'], lowestLevel: 'debug' }],
+  })
+}
+
+describe('otel sink', () => {
+  afterEach(async () => {
+    await reset()
+    await shutdownLoggerProvider()
+  })
+
+  describe('log record emission', () => {
+    it('emits a log record through the sink', async () => {
+      const { exporter, loggerProvider } = createTestLoggerProvider()
+      const sink = createOtelSink({ loggerProvider })
+      await setupLogtape(sink)
+
+      const logger = getLogger(['test'])
+      logger.info('hello world')
+
+      const records = exporter.getFinishedLogRecords()
+      expect(records.length).toBe(1)
+      expect(records[0].body).toBe('hello world')
+    })
+  })
+
+  describe('severity mapping', () => {
+    it('maps debug to severityNumber 5', async () => {
+      const { exporter, loggerProvider } = createTestLoggerProvider()
+      const sink = createOtelSink({ loggerProvider })
+      await setupLogtape(sink)
+
+      getLogger(['test']).debug('debug msg')
+
+      const records = exporter.getFinishedLogRecords()
+      expect(records.length).toBe(1)
+      expect(records[0].severityNumber).toBe(5)
+    })
+
+    it('maps info to severityNumber 9', async () => {
+      const { exporter, loggerProvider } = createTestLoggerProvider()
+      const sink = createOtelSink({ loggerProvider })
+      await setupLogtape(sink)
+
+      getLogger(['test']).info('info msg')
+
+      const records = exporter.getFinishedLogRecords()
+      expect(records[0].severityNumber).toBe(9)
+    })
+
+    it('maps warning to severityNumber 13', async () => {
+      const { exporter, loggerProvider } = createTestLoggerProvider()
+      const sink = createOtelSink({ loggerProvider })
+      await setupLogtape(sink)
+
+      getLogger(['test']).warn('warn msg')
+
+      const records = exporter.getFinishedLogRecords()
+      expect(records[0].severityNumber).toBe(13)
+    })
+
+    it('maps error to severityNumber 17', async () => {
+      const { exporter, loggerProvider } = createTestLoggerProvider()
+      const sink = createOtelSink({ loggerProvider })
+      await setupLogtape(sink)
+
+      getLogger(['test']).error('error msg')
+
+      const records = exporter.getFinishedLogRecords()
+      expect(records[0].severityNumber).toBe(17)
+    })
+  })
+
+  describe('PII sanitization', () => {
+    it('redacts sensitive keys in log properties', async () => {
+      const { exporter, loggerProvider } = createTestLoggerProvider()
+      const sink = createOtelSink({ loggerProvider })
+      await setupLogtape(sink)
+
+      getLogger(['test']).info('login attempt', { password: 'secret123', username: 'alice' })
+
+      const records = exporter.getFinishedLogRecords()
+      expect(records.length).toBe(1)
+      expect(records[0].attributes['password']).toBe('[REDACTED]')
+      expect(records[0].attributes['username']).toBe('alice')
+    })
+
+    it('scrubs email addresses in log properties', async () => {
+      const { exporter, loggerProvider } = createTestLoggerProvider()
+      const sink = createOtelSink({ loggerProvider })
+      await setupLogtape(sink)
+
+      getLogger(['test']).info('user action', { email: 'alice@example.com' })
+
+      const records = exporter.getFinishedLogRecords()
+      expect(records[0].attributes['email']).toBe('[EMAIL]')
+    })
+  })
+
+  describe('resilience', () => {
+    it('does not throw when no loggerProvider is given', async () => {
+      // createOtelSink with no provider should still return a usable sink
+      const sink = createOtelSink()
+      await setupLogtape(sink)
+
+      // Logging should not throw even without a backend
+      getLogger(['test']).info('no provider')
+    })
+  })
+})

--- a/packages/telemetry/src/sinks/otel.ts
+++ b/packages/telemetry/src/sinks/otel.ts
@@ -1,0 +1,47 @@
+/**
+ * @catalyst/telemetry — OTEL log sink
+ *
+ * Bridges LogTape → OpenTelemetry Logs SDK via @logtape/otel.
+ * Applies PII sanitization to log properties before export.
+ */
+
+import type { LoggerProvider } from '@opentelemetry/sdk-logs'
+import type { Sink } from '@logtape/logtape'
+import { getOpenTelemetrySink } from '@logtape/otel'
+import { sanitizeAttributes } from '../sanitizers'
+
+interface OtelSinkOptions {
+  loggerProvider?: LoggerProvider
+}
+
+let _loggerProvider: LoggerProvider | null = null
+
+/**
+ * Create a LogTape sink that forwards log records to OTEL via @logtape/otel,
+ * with PII sanitization applied to log properties.
+ */
+export function createOtelSink(opts?: OtelSinkOptions): Sink {
+  if (opts?.loggerProvider) {
+    _loggerProvider = opts.loggerProvider
+  }
+
+  const otelSink = getOpenTelemetrySink({
+    loggerProvider: opts?.loggerProvider,
+  })
+
+  return (record) => {
+    // Sanitize structured properties before forwarding to OTEL
+    if (record.properties && Object.keys(record.properties).length > 0) {
+      const sanitized = sanitizeAttributes(record.properties as Record<string, unknown>)
+      record = { ...record, properties: sanitized }
+    }
+    otelSink(record)
+  }
+}
+
+export async function shutdownLoggerProvider(): Promise<void> {
+  if (!_loggerProvider) return
+  const p = _loggerProvider
+  _loggerProvider = null
+  await p.shutdown()
+}


### PR DESCRIPTION
Add createConsoleSink (thin wrapper around LogTape getConsoleSink) and
createOtelSink (bridges LogTape to OTEL Logs SDK via @logtape/otel with
PII sanitization applied to log properties before export).