### PR TITLE
chore: bun skipIf checks for docker running

### DIFF
--- a/packages/orchestrator/tests/orchestrator.test.ts
+++ b/packages/orchestrator/tests/orchestrator.test.ts
@@ -13,9 +13,18 @@ import type { Readable } from 'node:stream'
 import { newWebSocketRpcSession } from 'capnweb'
 import type { PublicApi } from '../src/orchestrator.js'
 
-const skipTests = !process.env.CATALYST_CONTAINER_TESTS_ENABLED
+const isDockerRunning = () => {
+  try {
+    const result = Bun.spawnSync(['docker', 'info'])
+    return result.exitCode === 0
+  } catch {
+    return false
+  }
+}
+
+const skipTests = !isDockerRunning()
 if (skipTests) {
-  console.warn('Skipping container tests: CATALYST_CONTAINER_TESTS_ENABLED not set')
+  console.warn('Skipping container tests: Docker is not running')
 }
 
 describe.skipIf(skipTests)('Orchestrator Container Tests (Next)', () => {

--- a/packages/orchestrator/tests/peering.orchestrator.topology.container.test.ts
+++ b/packages/orchestrator/tests/peering.orchestrator.topology.container.test.ts
@@ -11,9 +11,18 @@ import { spawnSync } from 'node:child_process'
 import { newWebSocketRpcSession, type RpcStub } from 'capnweb'
 import type { PublicApi, NetworkClient } from '../src/orchestrator.js'
 
-const skipTests = !process.env.CATALYST_CONTAINER_TESTS_ENABLED
+const isDockerRunning = () => {
+  try {
+    const result = Bun.spawnSync(['docker', 'info'])
+    return result.exitCode === 0
+  } catch {
+    return false
+  }
+}
+
+const skipTests = !isDockerRunning()
 if (skipTests) {
-  console.warn('Skipping container tests: CATALYST_CONTAINER_TESTS_ENABLED not set')
+  console.warn('Skipping container tests: Docker is not running')
 }
 
 describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {

--- a/packages/orchestrator/tests/transit.orchestrator.topology.container.test.ts
+++ b/packages/orchestrator/tests/transit.orchestrator.topology.container.test.ts
@@ -11,269 +11,279 @@ import { spawnSync } from 'node:child_process'
 import { newWebSocketRpcSession, type RpcStub } from 'capnweb'
 import type { PublicApi, NetworkClient, DataChannel } from '../src/orchestrator.js'
 
-const skipTests = !process.env.CATALYST_CONTAINER_TESTS_ENABLED
+const isDockerRunning = () => {
+  try {
+    const result = Bun.spawnSync(['docker', 'info'])
+    return result.exitCode === 0
+  } catch {
+    return false
+  }
+}
+
+const skipTests = !isDockerRunning()
 if (skipTests) {
-  console.warn('Skipping container tests: CATALYST_CONTAINER_TESTS_ENABLED not set')
+  console.warn('Skipping container tests: Docker is not running')
 }
 
 describe.skipIf(skipTests)('Orchestrator Transit Container Tests', () => {
-  const TIMEOUT = 600000 // 10 minutes
+  describe.skipIf(skipTests)('Orchestrator Transit Container Tests', () => {
+    const TIMEOUT = 600000 // 10 minutes
 
-  let network: StartedNetwork
-  let nodeA: StartedTestContainer
-  let nodeB: StartedTestContainer
-  let nodeC: StartedTestContainer
+    let network: StartedNetwork
+    let nodeA: StartedTestContainer
+    let nodeB: StartedTestContainer
+    let nodeC: StartedTestContainer
 
-  const orchestratorImage = 'catalyst-node:next-topology-e2e'
-  const repoRoot = path.resolve(__dirname, '../../../')
+    const orchestratorImage = 'catalyst-node:next-topology-e2e'
+    const repoRoot = path.resolve(__dirname, '../../../')
 
-  beforeAll(async () => {
-    // Check if image exists
-    const checkImage = spawnSync('docker', ['image', 'inspect', orchestratorImage])
-    if (checkImage.status !== 0) {
-      console.log('Building Orchestrator image for Topology tests...')
-      const orchestratorBuild = spawnSync(
-        'docker',
-        ['build', '-f', 'packages/orchestrator/Dockerfile', '-t', orchestratorImage, '.'],
-        { cwd: repoRoot, stdio: 'inherit' }
-      )
-      if (orchestratorBuild.status !== 0) throw new Error('Docker build orchestrator failed')
-    } else {
-      console.log(`Using existing image: ${orchestratorImage}`)
-    }
-
-    network = await new Network().start()
-
-    const startNode = async (name: string, alias: string) => {
-      console.log(`Starting node ${name}...`)
-      const container = await new GenericContainer(orchestratorImage)
-        .withNetwork(network)
-        .withNetworkAliases(alias)
-        .withExposedPorts(3000)
-        .withEnvironment({
-          PORT: '3000',
-          CATALYST_NODE_ID: name,
-          CATALYST_PEERING_ENDPOINT: `ws://${alias}:3000/rpc`,
-          CATALYST_DOMAINS: 'somebiz.local.io',
-          CATALYST_PEERING_SECRET: 'valid-secret',
-        })
-        .withWaitStrategy(Wait.forLogMessage('NEXT_ORCHESTRATOR_STARTED'))
-        .withLogConsumer(
-          (stream: {
-            on(event: string, listener: (line: string) => void): void
-            pipe?: (dest: NodeJS.WritableStream) => void
-          }) => {
-            if (stream.pipe) stream.pipe(process.stdout)
-
-            stream.on('line', (line: string) => {
-              process.stdout.write(`[${name}] ${line}\n`)
-            })
-            stream.on('err', (line: string) => process.stderr.write(`[${name}] ERR: ${line}\n`))
-          }
+    beforeAll(async () => {
+      // Check if image exists
+      const checkImage = spawnSync('docker', ['image', 'inspect', orchestratorImage])
+      if (checkImage.status !== 0) {
+        console.log('Building Orchestrator image for Topology tests...')
+        const orchestratorBuild = spawnSync(
+          'docker',
+          ['build', '-f', 'packages/orchestrator/Dockerfile', '-t', orchestratorImage, '.'],
+          { cwd: repoRoot, stdio: 'inherit' }
         )
-        .start()
-      console.log(`Node ${name} started and healthy.`)
-      return container
+        if (orchestratorBuild.status !== 0) throw new Error('Docker build orchestrator failed')
+      } else {
+        console.log(`Using existing image: ${orchestratorImage}`)
+      }
+
+      network = await new Network().start()
+
+      const startNode = async (name: string, alias: string) => {
+        console.log(`Starting node ${name}...`)
+        const container = await new GenericContainer(orchestratorImage)
+          .withNetwork(network)
+          .withNetworkAliases(alias)
+          .withExposedPorts(3000)
+          .withEnvironment({
+            PORT: '3000',
+            CATALYST_NODE_ID: name,
+            CATALYST_PEERING_ENDPOINT: `ws://${alias}:3000/rpc`,
+            CATALYST_DOMAINS: 'somebiz.local.io',
+            CATALYST_PEERING_SECRET: 'valid-secret',
+          })
+          .withWaitStrategy(Wait.forLogMessage('NEXT_ORCHESTRATOR_STARTED'))
+          .withLogConsumer(
+            (stream: {
+              on(event: string, listener: (line: string) => void): void
+              pipe?: (dest: NodeJS.WritableStream) => void
+            }) => {
+              if (stream.pipe) stream.pipe(process.stdout)
+
+              stream.on('line', (line: string) => {
+                process.stdout.write(`[${name}] ${line}\n`)
+              })
+              stream.on('err', (line: string) => process.stderr.write(`[${name}] ERR: ${line}\n`))
+            }
+          )
+          .start()
+        console.log(`Node ${name} started and healthy.`)
+        return container
+      }
+
+      nodeA = await startNode('node-a.somebiz.local.io', 'node-a')
+      nodeB = await startNode('node-b.somebiz.local.io', 'node-b')
+      nodeC = await startNode('node-c.somebiz.local.io', 'node-c')
+
+      console.log('All nodes started.')
+    }, TIMEOUT)
+
+    afterAll(async () => {
+      console.log('Teardown: Starting...')
+      try {
+        if (nodeA) await nodeA.stop()
+        if (nodeB) await nodeB.stop()
+        if (nodeC) await nodeC.stop()
+        if (network) await network.stop()
+        console.log('Teardown: Success')
+      } catch (e) {
+        console.error('Teardown: Error during stop (ignoring for test result)', e)
+      }
+    })
+
+    const getClient = (node: StartedTestContainer) => {
+      const port = node.getMappedPort(3000)
+      return newWebSocketRpcSession<PublicApi>(`ws://127.0.0.1:${port}/rpc`)
     }
 
-    nodeA = await startNode('node-a.somebiz.local.io', 'node-a')
-    nodeB = await startNode('node-b.somebiz.local.io', 'node-b')
-    nodeC = await startNode('node-c.somebiz.local.io', 'node-c')
+    it(
+      'Transit Topology: A <-> B <-> C propagation, sync, and withdrawal',
+      async () => {
+        const clientA = getClient(nodeA)
+        const clientB = getClient(nodeB)
+        const clientC = getClient(nodeC)
 
-    console.log('All nodes started.')
-  }, TIMEOUT)
+        // 1. Linear Peering: A <-> B and B <-> C
+        console.log('Establishing peering A <-> B')
+        const netAResult = (await clientA.getNetworkClient('valid-secret')) as {
+          success: true
+          client: NetworkClient
+        }
+        const netBResult = (await clientB.getNetworkClient('valid-secret')) as {
+          success: true
+          client: NetworkClient
+        }
+        const netCResult = (await clientC.getNetworkClient('valid-secret')) as {
+          success: true
+          client: NetworkClient
+        }
 
-  afterAll(async () => {
-    console.log('Teardown: Starting...')
-    try {
-      if (nodeA) await nodeA.stop()
-      if (nodeB) await nodeB.stop()
-      if (nodeC) await nodeC.stop()
-      if (network) await network.stop()
-      console.log('Teardown: Success')
-    } catch (e) {
-      console.error('Teardown: Error during stop (ignoring for test result)', e)
-    }
-  })
+        if (!netAResult.success || !netBResult.success || !netCResult.success) {
+          throw new Error('Failed to get network client')
+        }
 
-  const getClient = (node: StartedTestContainer) => {
-    const port = node.getMappedPort(3000)
-    return newWebSocketRpcSession<PublicApi>(`ws://127.0.0.1:${port}/rpc`)
-  }
+        const netA = netAResult.client
+        const netB = netBResult.client
+        const netC = netCResult.client
 
-  it(
-    'Transit Topology: A <-> B <-> C propagation, sync, and withdrawal',
-    async () => {
-      const clientA = getClient(nodeA)
-      const clientB = getClient(nodeB)
-      const clientC = getClient(nodeC)
+        // Setup B to accept A first, then A connects to B (Ensures A->B capability)
+        await netB.addPeer({
+          name: 'node-a.somebiz.local.io',
+          endpoint: 'ws://node-a:3000/rpc',
+          domains: ['somebiz.local.io'],
+        })
+        await netA.addPeer({
+          name: 'node-b.somebiz.local.io',
+          endpoint: 'ws://node-b:3000/rpc',
+          domains: ['somebiz.local.io'],
+        })
 
-      // 1. Linear Peering: A <-> B and B <-> C
-      console.log('Establishing peering A <-> B')
-      const netAResult = (await clientA.getNetworkClient('valid-secret')) as {
-        success: true
-        client: NetworkClient
-      }
-      const netBResult = (await clientB.getNetworkClient('valid-secret')) as {
-        success: true
-        client: NetworkClient
-      }
-      const netCResult = (await clientC.getNetworkClient('valid-secret')) as {
-        success: true
-        client: NetworkClient
-      }
+        // Wait for handshake
+        console.log('Waiting for peering A <-> B to resolve...')
+        const waitForConnected = async (client: RpcStub<PublicApi>, peerName: string) => {
+          for (let i = 0; i < 20; i++) {
+            const netResult = await client.getNetworkClient('valid-secret')
+            if (!netResult.success) throw new Error('Failed to get network client for check')
+            const peers = await netResult.client.listPeers()
+            const peer = peers.find((p) => p.name === peerName)
+            if (peer && peer.connectionStatus === 'connected') return
+            await new Promise((r) => setTimeout(r, 500))
+          }
+          throw new Error(`Peer ${peerName} failed to connect`)
+        }
+        await waitForConnected(clientA, 'node-b.somebiz.local.io')
+        await waitForConnected(clientB, 'node-a.somebiz.local.io')
 
-      if (!netAResult.success || !netBResult.success || !netCResult.success) {
-        throw new Error('Failed to get network client')
-      }
+        // 2. A adds a local route
+        console.log('Node A adding local route')
+        const dataAResult = await clientA.getDataChannelClient('valid-secret')
+        if (!dataAResult.success) throw new Error('Failed to get data client')
+        await dataAResult.client.addRoute({
+          name: 'service-a',
+          protocol: 'http',
+          endpoint: 'http://a:8080',
+        })
 
-      const netA = netAResult.client
-      const netB = netBResult.client
-      const netC = netCResult.client
-
-      // Setup B to accept A first, then A connects to B (Ensures A->B capability)
-      await netB.addPeer({
-        name: 'node-a.somebiz.local.io',
-        endpoint: 'ws://node-a:3000/rpc',
-        domains: ['somebiz.local.io'],
-      })
-      await netA.addPeer({
-        name: 'node-b.somebiz.local.io',
-        endpoint: 'ws://node-b:3000/rpc',
-        domains: ['somebiz.local.io'],
-      })
-
-      // Wait for handshake
-      console.log('Waiting for peering A <-> B to resolve...')
-      const waitForConnected = async (client: RpcStub<PublicApi>, peerName: string) => {
-        for (let i = 0; i < 20; i++) {
-          const netResult = await client.getNetworkClient('valid-secret')
-          if (!netResult.success) throw new Error('Failed to get network client for check')
-          const peers = await netResult.client.listPeers()
-          const peer = peers.find((p) => p.name === peerName)
-          if (peer && peer.connectionStatus === 'connected') return
+        // Check B learned it
+        let learnedOnB = false
+        for (let i = 0; i < 40; i++) {
+          const dataBResult = await clientB.getDataChannelClient('valid-secret')
+          if (!dataBResult.success) throw new Error('Failed to get data client B')
+          const routes = await dataBResult.client.listRoutes()
+          if (routes.internal.some((r) => r.name === 'service-a')) {
+            learnedOnB = true
+            break
+          }
           await new Promise((r) => setTimeout(r, 500))
         }
-        throw new Error(`Peer ${peerName} failed to connect`)
-      }
-      await waitForConnected(clientA, 'node-b.somebiz.local.io')
-      await waitForConnected(clientB, 'node-a.somebiz.local.io')
+        expect(learnedOnB).toBe(true)
 
-      // 2. A adds a local route
-      console.log('Node A adding local route')
-      const dataAResult = await clientA.getDataChannelClient('valid-secret')
-      if (!dataAResult.success) throw new Error('Failed to get data client')
-      await dataAResult.client.addRoute({
-        name: 'service-a',
-        protocol: 'http',
-        endpoint: 'http://a:8080',
-      })
+        // 3. NOW peer B with C (Initial Sync test)
+        console.log('Establishing peering B <-> C')
+        // Setup C to accept B first, then B connects to C (Ensures B->C capability)
+        await netC.addPeer({
+          name: 'node-b.somebiz.local.io',
+          endpoint: 'ws://node-b:3000/rpc',
+          domains: ['somebiz.local.io'],
+        })
+        await netB.addPeer({
+          name: 'node-c.somebiz.local.io',
+          endpoint: 'ws://node-c:3000/rpc',
+          domains: ['somebiz.local.io'],
+        })
 
-      // Check B learned it
-      let learnedOnB = false
-      for (let i = 0; i < 40; i++) {
-        const dataBResult = await clientB.getDataChannelClient('valid-secret')
-        if (!dataBResult.success) throw new Error('Failed to get data client B')
-        const routes = await dataBResult.client.listRoutes()
-        if (routes.internal.some((r) => r.name === 'service-a')) {
-          learnedOnB = true
-          break
+        // Wait for B-C handshake and sync
+        await new Promise((r) => setTimeout(r, 2000))
+
+        // 4. C should have learned about A's route via B
+        let learnedOnC = false
+        for (let i = 0; i < 10; i++) {
+          const dataCResult = await clientC.getDataChannelClient('valid-secret')
+          if (!dataCResult.success) throw new Error('Failed to get data client C')
+          const routes = await dataCResult.client.listRoutes()
+          const routeA = routes.internal.find((r) => r.name === 'service-a')
+          if (routeA) {
+            learnedOnC = true
+            // Verify nodePath: [B, A]
+            expect(routeA.nodePath).toEqual(['node-b.somebiz.local.io', 'node-a.somebiz.local.io'])
+            break
+          }
+          await new Promise((r) => setTimeout(r, 500))
         }
-        await new Promise((r) => setTimeout(r, 500))
-      }
-      expect(learnedOnB).toBe(true)
+        expect(learnedOnC).toBe(true)
 
-      // 3. NOW peer B with C (Initial Sync test)
-      console.log('Establishing peering B <-> C')
-      // Setup C to accept B first, then B connects to C (Ensures B->C capability)
-      await netC.addPeer({
-        name: 'node-b.somebiz.local.io',
-        endpoint: 'ws://node-b:3000/rpc',
-        domains: ['somebiz.local.io'],
-      })
-      await netB.addPeer({
-        name: 'node-c.somebiz.local.io',
-        endpoint: 'ws://node-c:3000/rpc',
-        domains: ['somebiz.local.io'],
-      })
+        // 5. Withdrawal Propagation: A deletes route -> B and C should remove it
+        console.log('Node A deleting route')
+        await (
+          (await clientA.getDataChannelClient('valid-secret')) as {
+            success: true
+            client: DataChannel
+          }
+        ).client.removeRoute({
+          name: 'service-a',
+          protocol: 'http',
+          endpoint: 'http://a:8080',
+        })
 
-      // Wait for B-C handshake and sync
-      await new Promise((r) => setTimeout(r, 2000))
-
-      // 4. C should have learned about A's route via B
-      let learnedOnC = false
-      for (let i = 0; i < 10; i++) {
-        const dataCResult = await clientC.getDataChannelClient('valid-secret')
-        if (!dataCResult.success) throw new Error('Failed to get data client C')
-        const routes = await dataCResult.client.listRoutes()
-        const routeA = routes.internal.find((r) => r.name === 'service-a')
-        if (routeA) {
-          learnedOnC = true
-          // Verify nodePath: [B, A]
-          expect(routeA.nodePath).toEqual(['node-b.somebiz.local.io', 'node-a.somebiz.local.io'])
-          break
+        let removedOnC = false
+        for (let i = 0; i < 10; i++) {
+          const dataCResult = await clientC.getDataChannelClient('valid-secret')
+          if (!dataCResult.success) throw new Error('Failed to get data client C')
+          const routes = await dataCResult.client.listRoutes()
+          if (!routes.internal.some((r) => r.name === 'service-a')) {
+            removedOnC = true
+            break
+          }
+          await new Promise((r) => setTimeout(r, 500))
         }
-        await new Promise((r) => setTimeout(r, 500))
-      }
-      expect(learnedOnC).toBe(true)
+        expect(removedOnC).toBe(true)
 
-      // 5. Withdrawal Propagation: A deletes route -> B and C should remove it
-      console.log('Node A deleting route')
-      await (
-        (await clientA.getDataChannelClient('valid-secret')) as {
-          success: true
-          client: DataChannel
+        // 6. Topology Withdrawal: Disconnect A-B -> B should tell C to remove A's routes
+        console.log('Re-adding route and then disconnecting A-B')
+        await (
+          (await clientA.getDataChannelClient('valid-secret')) as {
+            success: true
+            client: DataChannel
+          }
+        ).client.addRoute({
+          name: 'service-a-v2',
+          protocol: 'http',
+          endpoint: 'http://a:8080',
+        })
+
+        // Wait for it to reach C
+        await new Promise((r) => setTimeout(r, 2000))
+
+        await netA.removePeer({ name: 'node-b.somebiz.local.io' })
+
+        let disconnectedWithdrawalOnC = false
+        for (let i = 0; i < 10; i++) {
+          const dataCResult = await clientC.getDataChannelClient('valid-secret')
+          if (!dataCResult.success) throw new Error('Failed to get data client C')
+          const routes = await dataCResult.client.listRoutes()
+          if (!routes.internal.some((r) => r.name === 'service-a-v2')) {
+            disconnectedWithdrawalOnC = true
+            break
+          }
+          await new Promise((r) => setTimeout(r, 500))
         }
-      ).client.removeRoute({
-        name: 'service-a',
-        protocol: 'http',
-        endpoint: 'http://a:8080',
-      })
-
-      let removedOnC = false
-      for (let i = 0; i < 10; i++) {
-        const dataCResult = await clientC.getDataChannelClient('valid-secret')
-        if (!dataCResult.success) throw new Error('Failed to get data client C')
-        const routes = await dataCResult.client.listRoutes()
-        if (!routes.internal.some((r) => r.name === 'service-a')) {
-          removedOnC = true
-          break
-        }
-        await new Promise((r) => setTimeout(r, 500))
-      }
-      expect(removedOnC).toBe(true)
-
-      // 6. Topology Withdrawal: Disconnect A-B -> B should tell C to remove A's routes
-      console.log('Re-adding route and then disconnecting A-B')
-      await (
-        (await clientA.getDataChannelClient('valid-secret')) as {
-          success: true
-          client: DataChannel
-        }
-      ).client.addRoute({
-        name: 'service-a-v2',
-        protocol: 'http',
-        endpoint: 'http://a:8080',
-      })
-
-      // Wait for it to reach C
-      await new Promise((r) => setTimeout(r, 2000))
-
-      await netA.removePeer({ name: 'node-b.somebiz.local.io' })
-
-      let disconnectedWithdrawalOnC = false
-      for (let i = 0; i < 10; i++) {
-        const dataCResult = await clientC.getDataChannelClient('valid-secret')
-        if (!dataCResult.success) throw new Error('Failed to get data client C')
-        const routes = await dataCResult.client.listRoutes()
-        if (!routes.internal.some((r) => r.name === 'service-a-v2')) {
-          disconnectedWithdrawalOnC = true
-          break
-        }
-        await new Promise((r) => setTimeout(r, 500))
-      }
-      expect(disconnectedWithdrawalOnC).toBe(true)
-    },
-    TIMEOUT
-  )
-})
+        expect(disconnectedWithdrawalOnC).toBe(true)
+      },
+      TIMEOUT
+    )
+  })


### PR DESCRIPTION
### TL;DR

Improved container test detection by automatically checking if Docker is running instead of requiring an environment variable.

### What changed?

- Replaced the `CATALYST_CONTAINER_TESTS_ENABLED` environment variable with an automatic Docker detection function
- Added an `isDockerRunning()` function that checks if Docker is available by running `docker info`
- Removed the `containerRuntime` variable and hardcoded `docker` as the runtime
- Updated skip messages to indicate Docker is not running rather than an environment variable not being set
- Added `.skipIf(skipTests)` to the Transit Container Tests that was previously missing

### How to test?

- Run the container tests with Docker running to verify they execute
- Stop Docker and run the tests again to verify they're properly skipped with the new message

### Why make this change?

This change improves the developer experience by automatically detecting if Docker is available rather than requiring developers to set an environment variable. It also ensures consistent test skipping behavior across all container tests and provides more accurate messaging about why tests are being skipped.