### PR TITLE
feat(telemetry): add logger configuration and W3C trace propagation

### DIFF
--- a/packages/telemetry/src/logger.test.ts
+++ b/packages/telemetry/src/logger.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { context, trace } from '@opentelemetry/api'
+import {
+  InMemoryLogRecordExporter,
+  LoggerProvider,
+  SimpleLogRecordProcessor,
+} from '@opentelemetry/sdk-logs'
+import {
+  InMemorySpanExporter,
+  NodeTracerProvider,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-node'
+import { resourceFromAttributes } from '@opentelemetry/resources'
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
+import { initLogger, getLogger, shutdownLogger } from './logger'
+
+function createTestProviders() {
+  const resource = resourceFromAttributes({ [ATTR_SERVICE_NAME]: 'test' })
+
+  const logExporter = new InMemoryLogRecordExporter()
+  const loggerProvider = new LoggerProvider({
+    resource,
+    processors: [new SimpleLogRecordProcessor(logExporter)],
+  })
+
+  const spanExporter = new InMemorySpanExporter()
+  const tracerProvider = new NodeTracerProvider({
+    resource,
+    spanProcessors: [new SimpleSpanProcessor(spanExporter)],
+  })
+  tracerProvider.register()
+
+  return { logExporter, loggerProvider, spanExporter, tracerProvider }
+}
+
+describe('logger', () => {
+  afterEach(async () => {
+    await shutdownLogger()
+    trace.disable()
+  })
+
+  describe('initLogger', () => {
+    it('configures LogTape with OTEL sink', async () => {
+      const { logExporter, loggerProvider } = createTestProviders()
+      await initLogger({ loggerProvider, enableConsole: false })
+
+      const logger = getLogger('test-module')
+      logger.info('hello from logger')
+
+      const records = logExporter.getFinishedLogRecords()
+      expect(records.length).toBe(1)
+      expect(records[0].body).toBe('hello from logger')
+    })
+  })
+
+  describe('getLogger', () => {
+    it('returns a logger for a single category', async () => {
+      const { loggerProvider } = createTestProviders()
+      await initLogger({ loggerProvider, enableConsole: false })
+
+      const logger = getLogger('gateway')
+      expect(logger).toBeDefined()
+      expect(typeof logger.info).toBe('function')
+    })
+
+    it('returns a logger for nested categories', async () => {
+      const { logExporter, loggerProvider } = createTestProviders()
+      await initLogger({ loggerProvider, enableConsole: false })
+
+      const logger = getLogger('gateway', 'federation')
+      logger.info('nested log')
+
+      const records = logExporter.getFinishedLogRecords()
+      expect(records.length).toBe(1)
+      // Category should include both segments
+      expect(records[0].attributes['category']).toEqual(['gateway', 'federation'])
+    })
+  })
+
+  describe('trace context injection', () => {
+    it('includes traceId and spanId when logging within an active span', async () => {
+      const { logExporter, loggerProvider } = createTestProviders()
+      await initLogger({ loggerProvider, enableConsole: false })
+
+      const tracer = trace.getTracer('test')
+      const span = tracer.startSpan('test-op')
+      const ctx = trace.setSpan(context.active(), span)
+
+      context.with(ctx, () => {
+        const logger = getLogger('test')
+        logger.info('inside span')
+      })
+      span.end()
+
+      const records = logExporter.getFinishedLogRecords()
+      expect(records.length).toBe(1)
+
+      const spanCtx = span.spanContext()
+      expect(records[0].spanContext?.traceId).toBe(spanCtx.traceId)
+      expect(records[0].spanContext?.spanId).toBe(spanCtx.spanId)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles undefined properties without throwing', async () => {
+      const { loggerProvider } = createTestProviders()
+      await initLogger({ loggerProvider, enableConsole: false })
+
+      const logger = getLogger('test')
+      logger.info('value is {value}', { value: undefined })
+    })
+
+    it('handles empty string messages', async () => {
+      const { logExporter, loggerProvider } = createTestProviders()
+      await initLogger({ loggerProvider, enableConsole: false })
+
+      const logger = getLogger('test')
+      logger.info('')
+
+      const records = logExporter.getFinishedLogRecords()
+      expect(records.length).toBe(1)
+    })
+  })
+})

--- a/packages/telemetry/src/logger.ts
+++ b/packages/telemetry/src/logger.ts
@@ -1,0 +1,70 @@
+/**
+ * @catalyst/telemetry — Logger configuration
+ *
+ * Configures LogTape with console and OTEL sinks.
+ * All loggers use getLogger(name, ...subcategories) for consistent categories.
+ */
+
+import { configure, getLogger as logtapeGetLogger, reset } from '@logtape/logtape'
+import type { Logger } from '@logtape/logtape'
+import { createConsoleSink } from './sinks/console'
+import { createOtelSink, shutdownLoggerProvider } from './sinks/otel'
+import type { LoggerProvider } from '@opentelemetry/sdk-logs'
+
+interface LoggerOptions {
+  loggerProvider?: LoggerProvider
+  logLevel?: 'debug' | 'info' | 'warning' | 'error' | 'fatal'
+  enableConsole?: boolean
+}
+
+let initialized = false
+
+export async function initLogger(opts?: LoggerOptions): Promise<void> {
+  if (initialized) {
+    console.warn('[telemetry] Logger already initialized, ignoring duplicate initLogger call')
+    return
+  }
+
+  const sinks: Record<string, ReturnType<typeof createOtelSink>> = {}
+  const sinkNames: string[] = []
+
+  if (opts?.enableConsole !== false) {
+    sinks['console'] = createConsoleSink()
+    sinkNames.push('console')
+  }
+
+  if (opts?.loggerProvider) {
+    sinks['otel'] = createOtelSink({ loggerProvider: opts.loggerProvider })
+    sinkNames.push('otel')
+  }
+
+  await configure({
+    sinks,
+    loggers: [
+      // Suppress LogTape meta logger from OTEL sink to avoid internal noise
+      {
+        category: ['logtape', 'meta'],
+        sinks: opts?.enableConsole !== false ? ['console'] : [],
+        lowestLevel: 'warning',
+      },
+      {
+        category: [],
+        sinks: sinkNames,
+        lowestLevel: opts?.logLevel ?? 'info',
+      },
+    ],
+  })
+
+  initialized = true
+}
+
+export function getLogger(name: string, ...subcategories: string[]): Logger {
+  return logtapeGetLogger([name, ...subcategories])
+}
+
+export async function shutdownLogger(): Promise<void> {
+  if (!initialized) return
+  initialized = false
+  await reset()
+  await shutdownLoggerProvider()
+}

--- a/packages/telemetry/src/propagation/w3c.test.ts
+++ b/packages/telemetry/src/propagation/w3c.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { context, propagation, trace } from '@opentelemetry/api'
+import {
+  NodeTracerProvider,
+  SimpleSpanProcessor,
+  InMemorySpanExporter,
+} from '@opentelemetry/sdk-trace-node'
+import { W3CTraceContextPropagator } from '@opentelemetry/core'
+import { resourceFromAttributes } from '@opentelemetry/resources'
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
+import { injectTraceHeaders, extractTraceContext, getTraceId, getSpanId } from './w3c'
+
+function setupTracer() {
+  const exporter = new InMemorySpanExporter()
+  const provider = new NodeTracerProvider({
+    resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: 'test' }),
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  })
+  provider.register()
+  propagation.setGlobalPropagator(new W3CTraceContextPropagator())
+  return { exporter, provider }
+}
+
+describe('w3c propagation', () => {
+  afterEach(() => {
+    trace.disable()
+    propagation.disable()
+  })
+
+  describe('injectTraceHeaders', () => {
+    it('adds traceparent to a headers object', () => {
+      setupTracer()
+      const tracer = trace.getTracer('test')
+      const span = tracer.startSpan('inject-test')
+      const ctx = trace.setSpan(context.active(), span)
+
+      const headers: Record<string, string> = {}
+      injectTraceHeaders(ctx, headers)
+      span.end()
+
+      expect(headers['traceparent']).toBeDefined()
+      expect(headers['traceparent']).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/)
+    })
+
+    it('uses active context when none provided', () => {
+      setupTracer()
+      const tracer = trace.getTracer('test')
+      const span = tracer.startSpan('inject-test')
+      const ctx = trace.setSpan(context.active(), span)
+
+      const headers: Record<string, string> = {}
+      context.with(ctx, () => {
+        injectTraceHeaders(undefined, headers)
+      })
+      span.end()
+
+      expect(headers['traceparent']).toBeDefined()
+    })
+  })
+
+  describe('extractTraceContext', () => {
+    it('extracts context from inbound traceparent header', () => {
+      setupTracer()
+      const tracer = trace.getTracer('test')
+      const span = tracer.startSpan('source')
+      const spanCtx = span.spanContext()
+
+      // Build a valid traceparent
+      const traceparent = `00-${spanCtx.traceId}-${spanCtx.spanId}-01`
+      span.end()
+
+      const extractedCtx = extractTraceContext({ traceparent })
+      const extractedSpan = trace.getSpan(extractedCtx)
+
+      expect(extractedSpan).toBeDefined()
+      expect(extractedSpan!.spanContext().traceId).toBe(spanCtx.traceId)
+    })
+  })
+
+  describe('getTraceId', () => {
+    it('returns the active span traceId', () => {
+      setupTracer()
+      const tracer = trace.getTracer('test')
+      const span = tracer.startSpan('trace-id-test')
+      const ctx = trace.setSpan(context.active(), span)
+
+      let traceId: string | undefined
+      context.with(ctx, () => {
+        traceId = getTraceId()
+      })
+      span.end()
+
+      expect(traceId).toBe(span.spanContext().traceId)
+      expect(traceId).toMatch(/^[0-9a-f]{32}$/)
+    })
+
+    it('returns undefined when no active span', () => {
+      expect(getTraceId()).toBeUndefined()
+    })
+  })
+
+  describe('getSpanId', () => {
+    it('returns the active span spanId', () => {
+      setupTracer()
+      const tracer = trace.getTracer('test')
+      const span = tracer.startSpan('span-id-test')
+      const ctx = trace.setSpan(context.active(), span)
+
+      let spanId: string | undefined
+      context.with(ctx, () => {
+        spanId = getSpanId()
+      })
+      span.end()
+
+      expect(spanId).toBe(span.spanContext().spanId)
+      expect(spanId).toMatch(/^[0-9a-f]{16}$/)
+    })
+
+    it('returns undefined when no active span', () => {
+      expect(getSpanId()).toBeUndefined()
+    })
+  })
+})

--- a/packages/telemetry/src/propagation/w3c.ts
+++ b/packages/telemetry/src/propagation/w3c.ts
@@ -1,0 +1,53 @@
+/**
+ * @catalyst/telemetry — W3C Trace Context propagation helpers
+ *
+ * Convenience wrappers around @opentelemetry/api propagation for
+ * injecting/extracting trace context in HTTP headers.
+ */
+
+import { context, propagation, trace } from '@opentelemetry/api'
+import type { Context } from '@opentelemetry/api'
+
+const INVALID_TRACE_ID = '00000000000000000000000000000000'
+const INVALID_SPAN_ID = '0000000000000000'
+
+/**
+ * Inject trace context headers (traceparent, tracestate) into a carrier object.
+ * Uses the active context if none is provided.
+ */
+export function injectTraceHeaders(
+  ctx: Context | undefined,
+  carrier: Record<string, string>
+): void {
+  propagation.inject(ctx ?? context.active(), carrier)
+}
+
+/**
+ * Extract trace context from inbound headers.
+ * Returns a Context that can be used with context.with() to propagate the trace.
+ */
+export function extractTraceContext(headers: Record<string, string>): Context {
+  return propagation.extract(context.active(), headers)
+}
+
+/**
+ * Get the trace ID of the currently active span.
+ * Returns undefined if no span is active or the trace ID is invalid.
+ */
+export function getTraceId(): string | undefined {
+  const span = trace.getActiveSpan()
+  if (!span) return undefined
+  const traceId = span.spanContext().traceId
+  return traceId === INVALID_TRACE_ID ? undefined : traceId
+}
+
+/**
+ * Get the span ID of the currently active span.
+ * Returns undefined if no span is active or the span ID is invalid.
+ */
+export function getSpanId(): string | undefined {
+  const span = trace.getActiveSpan()
+  if (!span) return undefined
+  const spanId = span.spanContext().spanId
+  return spanId === INVALID_SPAN_ID ? undefined : spanId
+}


### PR DESCRIPTION
# Add logging and trace context propagation utilities to telemetry package

Add initLogger/getLogger/shutdownLogger wrapping LogTape with console and OTEL sinks, meta logger suppressed from OTEL to avoid noise.

Add W3C propagation helpers: injectTraceHeaders, extractTraceContext, getTraceId, getSpanId for trace context across service boundaries.