### PR TITLE
feat(telemetry): add GraphQL Yoga telemetry plugin wrapping @envelop/opentelemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
       "@opentelemetry/core": "^2.5.0",
       "@opentelemetry/semantic-conventions": "^1.39.0",
       "@logtape/logtape": "^2.0.0",
-      "@logtape/otel": "^2.0.0"
+      "@logtape/otel": "^2.0.0",
+      "@envelop/opentelemetry": "^9.1.0"
     },
     "catalogs": {
       "dev": {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -30,15 +30,26 @@
     "@logtape/otel": "catalog:"
   },
   "peerDependencies": {
-    "hono": ">=4.0.0"
+    "hono": ">=4.0.0",
+    "graphql-yoga": ">=5.0.0",
+    "@envelop/opentelemetry": ">=9.0.0"
   },
   "peerDependenciesMeta": {
     "hono": {
       "optional": true
+    },
+    "graphql-yoga": {
+      "optional": true
+    },
+    "@envelop/opentelemetry": {
+      "optional": true
     }
   },
   "devDependencies": {
+    "@envelop/opentelemetry": "catalog:",
     "@types/bun": "catalog:dev",
+    "graphql": "catalog:",
+    "graphql-yoga": "catalog:",
     "hono": "catalog:",
     "typescript": "catalog:dev"
   }

--- a/packages/telemetry/src/middleware/yoga.test.ts
+++ b/packages/telemetry/src/middleware/yoga.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { propagation, trace } from '@opentelemetry/api'
+import {
+  InMemorySpanExporter,
+  NodeTracerProvider,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-node'
+import { W3CTraceContextPropagator } from '@opentelemetry/core'
+import { resourceFromAttributes } from '@opentelemetry/resources'
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
+import { createSchema, createYoga } from 'graphql-yoga'
+import { createYogaTelemetryPlugin } from './yoga'
+
+let currentProvider: NodeTracerProvider | null = null
+
+function setupTracer() {
+  const exporter = new InMemorySpanExporter()
+  const provider = new NodeTracerProvider({
+    resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: 'test' }),
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  })
+  provider.register()
+  propagation.setGlobalPropagator(new W3CTraceContextPropagator())
+  currentProvider = provider
+  return { exporter, provider }
+}
+
+const testSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Query {
+      hello: String!
+      fail: String!
+    }
+  `,
+  resolvers: {
+    Query: {
+      hello: () => 'world',
+      fail: () => {
+        throw new Error('resolver error')
+      },
+    },
+  },
+})
+
+function createTestYoga(pluginOptions?: Parameters<typeof createYogaTelemetryPlugin>[0]) {
+  return createYoga({
+    schema: testSchema,
+    plugins: [createYogaTelemetryPlugin(pluginOptions)],
+  })
+}
+
+function postGraphQL(yoga: ReturnType<typeof createYoga>, query: string) {
+  return yoga.fetch(
+    new Request('http://localhost/graphql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query }),
+    })
+  )
+}
+
+describe('createYogaTelemetryPlugin', () => {
+  afterEach(async () => {
+    if (currentProvider) {
+      await currentProvider.shutdown()
+      currentProvider = null
+    }
+    trace.disable()
+    propagation.disable()
+  })
+
+  describe('plugin shape', () => {
+    it('returns a valid Envelop plugin', () => {
+      const plugin = createYogaTelemetryPlugin()
+      expect(plugin).toBeDefined()
+      expect(typeof plugin).toBe('object')
+    })
+  })
+
+  describe('tracing', () => {
+    it('creates spans for GraphQL execution', async () => {
+      const { exporter } = setupTracer()
+      const yoga = createTestYoga()
+
+      await postGraphQL(yoga, '{ hello }')
+
+      const spans = exporter.getFinishedSpans()
+      expect(spans.length).toBeGreaterThan(0)
+
+      // @envelop/opentelemetry names operation spans as "query.anonymous", "query.HelloOp", etc.
+      const spanNames = spans.map((s) => s.name)
+      const hasQuerySpan = spanNames.some(
+        (n) => n.startsWith('query.') || n.startsWith('mutation.') || n.startsWith('subscription.')
+      )
+      expect(hasQuerySpan).toBe(true)
+    })
+
+    it('creates resolver-level spans by default', async () => {
+      const { exporter } = setupTracer()
+      const yoga = createTestYoga() // resolvers defaults to true
+
+      await postGraphQL(yoga, '{ hello }')
+
+      const spanNames = exporter.getFinishedSpans().map((s) => s.name)
+      expect(spanNames).toContain('Query.hello')
+    })
+
+    it('suppresses resolver-level spans when resolvers is false', async () => {
+      const { exporter } = setupTracer()
+      const yoga = createTestYoga({ resolvers: false })
+
+      await postGraphQL(yoga, '{ hello }')
+
+      const spanNames = exporter.getFinishedSpans().map((s) => s.name)
+      // Should have the operation span but NOT the resolver span
+      const hasOperationSpan = spanNames.some((n) => n.startsWith('query.'))
+      const hasResolverSpan = spanNames.includes('Query.hello')
+      expect(hasOperationSpan).toBe(true)
+      expect(hasResolverSpan).toBe(false)
+    })
+
+    it('includes operation name in span attributes when provided', async () => {
+      const { exporter } = setupTracer()
+      const yoga = createTestYoga()
+
+      await postGraphQL(yoga, 'query HelloOp { hello }')
+
+      const spans = exporter.getFinishedSpans()
+      const hasOpName = spans.some((s) => {
+        const attrs = s.attributes
+        return (
+          attrs['graphql.execute.operationName'] === 'HelloOp' ||
+          attrs['graphql.operation.name'] === 'HelloOp' ||
+          s.name.includes('HelloOp')
+        )
+      })
+      expect(hasOpName).toBe(true)
+    })
+
+    it('records error attributes when a resolver throws', async () => {
+      const { exporter } = setupTracer()
+      const yoga = createTestYoga()
+
+      const res = await postGraphQL(yoga, '{ fail }')
+      const body = await res.json()
+
+      // Yoga masks error messages by default ("Unexpected error.")
+      expect(body.errors).toBeDefined()
+      expect(body.errors.length).toBeGreaterThan(0)
+
+      const spans = exporter.getFinishedSpans()
+      expect(spans.length).toBeGreaterThan(0)
+
+      // @envelop/opentelemetry records the exception on the operation span,
+      // not on a separate resolver span (resolver span is not emitted on throw)
+      const operationSpan = spans.find((s) => s.name.startsWith('query.'))
+      expect(operationSpan).toBeDefined()
+      const hasException = operationSpan!.events.some((e) => e.name === 'exception')
+      expect(hasException).toBe(true)
+    })
+  })
+
+  describe('options', () => {
+    it('accepts custom options without throwing', () => {
+      const plugin = createYogaTelemetryPlugin({
+        resolvers: true,
+        variables: false,
+        result: false,
+        document: false,
+      })
+      expect(plugin).toBeDefined()
+    })
+  })
+})

--- a/packages/telemetry/src/middleware/yoga.ts
+++ b/packages/telemetry/src/middleware/yoga.ts
@@ -1,0 +1,99 @@
+/**
+ * @catalyst/telemetry — GraphQL Yoga telemetry plugin
+ *
+ * Convenience wrapper around @envelop/opentelemetry that provides
+ * per-phase tracing (parse, validate, execute) and optional resolver tracing
+ * for GraphQL Yoga servers.
+ *
+ * WHY: Every Catalyst service using Yoga needs the same OTEL plugin config.
+ * This wrapper centralizes defaults (resolvers on, variables off, document off)
+ * so services get consistent GraphQL tracing without boilerplate.
+ *
+ * WHY @envelop/opentelemetry over @graphql-hive/plugin-opentelemetry:
+ * The Hive plugin depends on @graphql-hive/gateway-runtime, pulling in the
+ * entire Hive Gateway SDK. The Envelop plugin is lightweight and works with
+ * any Envelop-based server (Yoga uses Envelop internally).
+ *
+ * @see https://the-guild.dev/graphql/envelop/plugins/use-open-telemetry
+ * @see https://the-guild.dev/graphql/yoga-server/docs/features/monitoring
+ */
+
+import { useOpenTelemetry, type TracingOptions } from '@envelop/opentelemetry'
+import { trace } from '@opentelemetry/api'
+
+export interface YogaTelemetryOptions {
+  /**
+   * Trace individual resolver calls (default: true).
+   *
+   * WHY enabled by default: Resolver-level spans reveal N+1 queries
+   * and slow field resolution that are invisible at the operation level.
+   */
+  resolvers?: boolean
+
+  /**
+   * Include GraphQL variables in span attributes (default: false).
+   *
+   * WHY disabled by default: Variables may contain PII (user IDs,
+   * emails, tokens). Enable only in non-production environments.
+   */
+  variables?: boolean
+
+  /**
+   * Include the GraphQL result in span attributes (default: false).
+   *
+   * WHY disabled by default: Response payloads can be large and may
+   * contain sensitive data. Enable only for debugging.
+   */
+  result?: boolean
+
+  /**
+   * Include the GraphQL document (query string) in span attributes (default: false).
+   *
+   * WHY disabled by default: Query strings are high-cardinality and
+   * inflate trace storage. Operation name is typically sufficient.
+   */
+  document?: boolean
+}
+
+/**
+ * Create a Yoga-compatible telemetry plugin with sensible defaults.
+ *
+ * WHY this must be called after `initTelemetry()`: The underlying
+ * `@envelop/opentelemetry` plugin eagerly captures the TracerProvider
+ * and creates a Tracer at plugin construction time (not lazily per-request).
+ * If no real provider is registered yet, the plugin binds to the OTEL
+ * no-op provider and will never emit spans. Additionally, omitting the
+ * provider argument causes the library to create AND globally register
+ * a `BasicTracerProvider` with `ConsoleSpanExporter`, which would
+ * overwrite your application's configured provider.
+ *
+ * Usage:
+ * ```ts
+ * import { initTelemetry } from '@catalyst/telemetry'
+ * import { createYogaTelemetryPlugin } from '@catalyst/telemetry/middleware/yoga'
+ *
+ * await initTelemetry({ serviceName: 'my-service' })
+ *
+ * const yoga = createYoga({
+ *   schema,
+ *   plugins: [createYogaTelemetryPlugin()],
+ * })
+ * ```
+ */
+export function createYogaTelemetryPlugin(options?: YogaTelemetryOptions): ReturnType<typeof useOpenTelemetry> {
+  const tracingOptions: TracingOptions = {
+    resolvers: options?.resolvers ?? true,
+    variables: options?.variables ?? false,
+    result: options?.result ?? false,
+    document: options?.document ?? false,
+  }
+
+  /**
+   * WHY we pass the global TracerProvider explicitly: Without it,
+   * @envelop/opentelemetry creates its own internal ConsoleSpanExporter,
+   * bypassing whatever provider the application registered globally.
+   * Passing trace.getTracerProvider() ensures spans flow through the
+   * application's configured pipeline (e.g. OTLP exporter, BatchProcessor).
+   */
+  return useOpenTelemetry(tracingOptions, trace.getTracerProvider())
+}


### PR DESCRIPTION
Wrapper around useOpenTelemetry with secure defaults (resolvers on,
variables/result/document off) and explicit global TracerProvider
passthrough to avoid the library's ConsoleSpanExporter fallback.