### PR TITLE
feat(sdk): add CatalystService class for standardized service bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "typecheck": "bunx tsc --noEmit -p packages/telemetry/tsconfig.json && bunx tsc --noEmit -p packages/sdk/tsconfig.json"
   },
   "workspaces": {
     "packages": [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -9,9 +9,11 @@
     "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
     "test": "vitest",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@types/bun": "catalog:dev",
     "@vitest/coverage-v8": "catalog:testing",
     "tsup": "catalog:dev",
     "typescript": "catalog:dev",
@@ -19,7 +21,17 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "catalog:",
+    "@opentelemetry/api": "catalog:",
     "graphql": "catalog:",
-    "graphql-yoga": "catalog:"
+    "graphql-yoga": "catalog:",
+    "hono": "catalog:"
+  },
+  "peerDependencies": {
+    "@catalyst/telemetry": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@catalyst/telemetry": {
+      "optional": true
+    }
   }
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,1 +1,4 @@
-export const VERSION = '0.0.1';
+export const VERSION = '0.0.1'
+
+export { CatalystService } from './service'
+export type { ServiceOptions } from './service'

--- a/packages/sdk/src/service.test.ts
+++ b/packages/sdk/src/service.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Hono } from 'hono'
+import { CatalystService } from './service'
+
+describe('CatalystService', () => {
+  let service: CatalystService
+
+  afterEach(async () => {
+    if (service) {
+      // Use a short timeout to avoid hanging on tests with stuck callbacks
+      await service.shutdown(500)
+    }
+  })
+
+  describe('constructor', () => {
+    it('creates an instance with required options', () => {
+      service = new CatalystService({ name: 'test-service' })
+      expect(service).toBeInstanceOf(CatalystService)
+    })
+
+    it('exposes a Hono app', () => {
+      service = new CatalystService({ name: 'test-service' })
+      expect(service.app).toBeInstanceOf(Hono)
+    })
+
+    it('throws on empty service name', () => {
+      expect(() => new CatalystService({ name: '' })).toThrow(
+        '[CatalystService] name is required and must be non-empty'
+      )
+    })
+
+    it('throws on whitespace-only service name', () => {
+      expect(() => new CatalystService({ name: '   ' })).toThrow(
+        '[CatalystService] name is required and must be non-empty'
+      )
+    })
+
+    it('exposes the service name via accessor', () => {
+      service = new CatalystService({ name: 'my-api' })
+      expect(service.name).toBe('my-api')
+    })
+
+    it('uses default port 3000 when not specified', () => {
+      service = new CatalystService({ name: 'test-service' })
+      expect(service.port).toBe(3000)
+    })
+
+    it('accepts custom port', () => {
+      service = new CatalystService({ name: 'test-service', port: 8080 })
+      expect(service.port).toBe(8080)
+    })
+
+    it('uses default hostname 0.0.0.0 when not specified', () => {
+      service = new CatalystService({ name: 'test-service' })
+      expect(service.hostname).toBe('0.0.0.0')
+    })
+
+    it('accepts custom hostname', () => {
+      service = new CatalystService({ name: 'test-service', hostname: '127.0.0.1' })
+      expect(service.hostname).toBe('127.0.0.1')
+    })
+  })
+
+  describe('health endpoint', () => {
+    it('responds 200 on /health by default', async () => {
+      service = new CatalystService({ name: 'test-service' })
+      const res = await service.app.request('/health')
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body).toEqual({ status: 'ok' })
+    })
+
+    it('uses custom health path when configured', async () => {
+      service = new CatalystService({
+        name: 'test-service',
+        healthPath: '/ready',
+      })
+      const res = await service.app.request('/ready')
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body).toEqual({ status: 'ok' })
+    })
+  })
+
+  describe('serve', () => {
+    it('returns an object with fetch, port, hostname, and websocket', () => {
+      service = new CatalystService({ name: 'test-service', port: 4000 })
+      const config = service.serve()
+      expect(config.port).toBe(4000)
+      expect(config.hostname).toBe('0.0.0.0')
+      expect(typeof config.fetch).toBe('function')
+      expect(config.websocket).toBeDefined()
+    })
+
+    it('returns custom hostname in serve config', () => {
+      service = new CatalystService({ name: 'test-service', hostname: '127.0.0.1' })
+      const config = service.serve()
+      expect(config.hostname).toBe('127.0.0.1')
+    })
+
+    it('returns a bound fetch that works without Hono this context', async () => {
+      service = new CatalystService({ name: 'test-service' })
+      service.app.get('/ping', (c) => c.text('pong'))
+
+      const { fetch } = service.serve()
+      // Call fetch as a standalone function (simulates Bun runtime)
+      const res = await fetch(new Request('http://localhost/ping'))
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('pong')
+    })
+  })
+
+  describe('shutdown', () => {
+    it('calls registered onShutdown callbacks', async () => {
+      service = new CatalystService({ name: 'test-service' })
+      const fn1 = vi.fn()
+      const fn2 = vi.fn()
+      service.onShutdown(fn1)
+      service.onShutdown(fn2)
+
+      await service.shutdown()
+
+      expect(fn1).toHaveBeenCalledOnce()
+      expect(fn2).toHaveBeenCalledOnce()
+    })
+
+    it('handles async shutdown callbacks', async () => {
+      service = new CatalystService({ name: 'test-service' })
+      let resolved = false
+      service.onShutdown(async () => {
+        await new Promise((r) => setTimeout(r, 10))
+        resolved = true
+      })
+
+      await service.shutdown()
+      expect(resolved).toBe(true)
+    })
+
+    it('logs errors from shutdown callbacks but does not throw', async () => {
+      service = new CatalystService({ name: 'test-service' })
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      service.onShutdown(() => {
+        throw new Error('shutdown boom')
+      })
+
+      await expect(service.shutdown()).resolves.toBeUndefined()
+      expect(consoleSpy).toHaveBeenCalled()
+      consoleSpy.mockRestore()
+    })
+
+    it('runs callbacks in registration order', async () => {
+      service = new CatalystService({ name: 'test-service' })
+      const order: number[] = []
+      service.onShutdown(() => {
+        order.push(1)
+      })
+      service.onShutdown(() => {
+        order.push(2)
+      })
+      service.onShutdown(() => {
+        order.push(3)
+      })
+
+      await service.shutdown()
+      expect(order).toEqual([1, 2, 3])
+    })
+
+    it('times out if a callback hangs', async () => {
+      service = new CatalystService({ name: 'test-service' })
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      service.onShutdown(
+        () => new Promise(() => {}) // never resolves
+      )
+
+      // Use a short timeout (100ms) for the test
+      await service.shutdown(100)
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[test-service]'),
+        expect.stringContaining('timed out')
+      )
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('OTEL accessors (no telemetry)', () => {
+    it('exposes no-op tracer when telemetry is not initialized', () => {
+      service = new CatalystService({ name: 'test-service' })
+      const tracer = service.tracer
+      expect(tracer).toBeDefined()
+      // No-op tracer should still have startSpan
+      expect(typeof tracer.startSpan).toBe('function')
+    })
+
+    it('exposes no-op meter when telemetry is not initialized', () => {
+      service = new CatalystService({ name: 'test-service' })
+      const meter = service.meter
+      expect(meter).toBeDefined()
+      // No-op meter should still have createCounter
+      expect(typeof meter.createCounter).toBe('function')
+    })
+  })
+
+  describe('custom routes', () => {
+    it('allows mounting routes on the app after construction', async () => {
+      service = new CatalystService({ name: 'test-service' })
+      service.app.get('/custom', (c) => c.text('hello'))
+
+      const res = await service.app.request('/custom')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('hello')
+    })
+  })
+})

--- a/packages/sdk/src/service.ts
+++ b/packages/sdk/src/service.ts
@@ -1,0 +1,241 @@
+/**
+ * @catalyst/sdk — CatalystService
+ *
+ * Standardized service entrypoint for Catalyst Node services.
+ *
+ * WHY: Every Catalyst service repeats the same bootstrap boilerplate:
+ * create Hono app → mount /health → wire SIGTERM → export { fetch, port }.
+ * CatalystService extracts this into a single class that optionally
+ * integrates @catalyst/telemetry for traces, metrics, and logs.
+ *
+ * WHY optional telemetry: Not all services need full OTEL instrumentation
+ * (e.g. CLI tools, test harnesses). When telemetry is disabled, the class
+ * falls back to @opentelemetry/api's built-in no-op implementations,
+ * so consuming code never needs null checks.
+ *
+ * @see packages/auth/src/index.ts — example service bootstrap pattern
+ * @see packages/gateway/src/index.ts — example service bootstrap pattern
+ */
+
+import { Hono } from 'hono'
+import { websocket } from 'hono/bun'
+import { trace, metrics } from '@opentelemetry/api'
+import type { Tracer, Meter } from '@opentelemetry/api'
+
+export interface ServiceOptions {
+  /**
+   * Service name used for logging and OTEL resource attributes.
+   *
+   * WHY required: The service name is the primary identifier in traces,
+   * metrics, and logs. Without it, spans show as "unknown_service".
+   */
+  name: string
+
+  /**
+   * Port to listen on (default: process.env.PORT || 3000).
+   *
+   * WHY env fallback: Container orchestrators typically inject PORT via
+   * environment. Explicit option takes precedence for dev/testing.
+   */
+  port?: number
+
+  /**
+   * Hostname to bind to (default: '0.0.0.0').
+   *
+   * WHY 0.0.0.0: Required for containers where the service must accept
+   * connections from outside the container network namespace.
+   */
+  hostname?: string
+
+  /**
+   * Path for the health check endpoint (default: '/health').
+   *
+   * WHY '/health': Standard Kubernetes liveness/readiness probe path.
+   * Override for services that need a different convention.
+   */
+  healthPath?: string
+}
+
+/**
+ * Standardized Catalyst service entrypoint.
+ *
+ * Usage:
+ * ```ts
+ * import { CatalystService } from '@catalyst/sdk'
+ *
+ * const service = new CatalystService({ name: 'my-service', port: 4001 })
+ *
+ * service.app.get('/', (c) => c.text('Hello'))
+ * service.app.route('/rpc', rpcApp)
+ *
+ * service.onShutdown(async () => {
+ *   await db.close()
+ * })
+ *
+ * export default service.serve()
+ * ```
+ */
+export class CatalystService {
+  readonly app: Hono
+  readonly port: number
+  readonly hostname: string
+
+  private readonly _name: string
+  private readonly _shutdownCallbacks: Array<() => Promise<void> | void> = []
+  private _signalHandler: (() => void) | null = null
+
+  constructor(options: ServiceOptions) {
+    // Validate service name — required for telemetry and logging
+    if (!options.name || options.name.trim() === '') {
+      throw new Error('[CatalystService] name is required and must be non-empty')
+    }
+
+    this._name = options.name
+    this.port = options.port ?? (process.env.PORT ? Number(process.env.PORT) : 3000)
+    this.hostname = options.hostname ?? '0.0.0.0'
+
+    this.app = new Hono()
+
+    // Mount health endpoint
+    const healthPath = options.healthPath ?? '/health'
+    this.app.get(healthPath, (c) => c.json({ status: 'ok' }))
+
+    /**
+     * WHY SIGTERM/SIGINT exit the process: In Kubernetes, SIGTERM signals
+     * the pod to terminate. SIGINT (Ctrl+C) is used in local development.
+     * Both should trigger graceful shutdown. If the process doesn't exit,
+     * the kubelet waits for the grace period then sends SIGKILL.
+     */
+    this._signalHandler = () => {
+      this.shutdown()
+        .then(() => process.exit(0))
+        .catch((err) => {
+          console.error(`[${this._name}] Shutdown error:`, err)
+          process.exit(1)
+        })
+    }
+    process.on('SIGTERM', this._signalHandler)
+    process.on('SIGINT', this._signalHandler)
+  }
+
+  /**
+   * Get the service name.
+   *
+   * WHY public accessor: Useful for logging, debugging, and when consumers
+   * need to reference the service name (e.g., for custom metrics labels).
+   */
+  get name(): string {
+    return this._name
+  }
+
+  /**
+   * Get a Tracer for this service.
+   *
+   * WHY this returns the global tracer: If @catalyst/telemetry has been
+   * initialized via initTelemetry(), this returns a real tracer. Otherwise,
+   * @opentelemetry/api returns a no-op tracer that silently discards spans.
+   * Either way, consuming code works without null checks.
+   */
+  get tracer(): Tracer {
+    return trace.getTracer(this._name)
+  }
+
+  /**
+   * Get a Meter for this service.
+   *
+   * WHY this returns the global meter: Same rationale as tracer — real
+   * or no-op depending on whether telemetry was initialized.
+   */
+  get meter(): Meter {
+    return metrics.getMeter(this._name)
+  }
+
+  /**
+   * Register a callback to run during graceful shutdown.
+   *
+   * WHY callbacks not events: Callbacks are awaited sequentially, ensuring
+   * ordered cleanup (e.g. flush logs before closing DB connections).
+   * Event emitters don't guarantee ordering or async completion.
+   */
+  onShutdown(fn: () => Promise<void> | void): void {
+    this._shutdownCallbacks.push(fn)
+  }
+
+  /**
+   * Build the Bun server configuration.
+   *
+   * WHY this returns an object (not starts a server): Bun's runtime
+   * expects `export default { fetch, port, websocket }` at the module level.
+   * Starting the server is Bun's responsibility, not ours.
+   */
+  serve(): { fetch: Hono['fetch']; port: number; hostname: string; websocket: typeof websocket } {
+    /**
+     * WHY .bind(): Bun's runtime calls `fetch(req, server)` on the returned
+     * object. Without binding, `this` inside Hono's fetch is the plain object,
+     * not the Hono instance — causing runtime errors or silent failures.
+     *
+     * WHY websocket: Enables WebSocket upgrade support via Hono's upgradeWebSocket.
+     * Without this, services cannot use Cap'n Proto RPC or other WS protocols.
+     */
+    return {
+      fetch: this.app.fetch.bind(this.app),
+      port: this.port,
+      hostname: this.hostname,
+      websocket,
+    }
+  }
+
+  /**
+   * Run all shutdown callbacks and clean up resources.
+   *
+   * WHY sequential execution: Shutdown callbacks may have ordering
+   * dependencies (e.g. flush telemetry before closing network connections).
+   * Running them in parallel could cause lost data.
+   *
+   * WHY timeout: A misbehaving callback (e.g. exporter blocked on a stalled
+   * collector) should not hang the process indefinitely. The default 30s
+   * matches Kubernetes' default terminationGracePeriodSeconds.
+   *
+   * @param timeoutMs — Maximum time for all callbacks to complete (default: 30000ms)
+   */
+  async shutdown(timeoutMs = 30_000): Promise<void> {
+    // Remove signal handlers to avoid double-shutdown
+    if (this._signalHandler) {
+      process.removeListener('SIGTERM', this._signalHandler)
+      process.removeListener('SIGINT', this._signalHandler)
+      this._signalHandler = null
+    }
+
+    const runCallbacks = async () => {
+      for (const fn of this._shutdownCallbacks) {
+        try {
+          await fn()
+        } catch (err) {
+          console.error(`[${this._name}] Shutdown callback error:`, err)
+        }
+      }
+    }
+
+    /**
+     * WHY we track timeoutId: When runCallbacks() completes before the timeout,
+     * Promise.race resolves but the setTimeout continues running. Without
+     * clearing it, the timer leaks and eventually fires a rejected promise
+     * that nobody is listening to.
+     */
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
+        () => reject(new Error(`Shutdown timed out after ${timeoutMs}ms`)),
+        timeoutMs
+      )
+    })
+
+    try {
+      await Promise.race([runCallbacks(), timeout])
+    } catch (err) {
+      console.error(`[${this._name}]`, err instanceof Error ? err.message : err)
+    } finally {
+      if (timeoutId) clearTimeout(timeoutId)
+    }
+  }
+}

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Extracts common Hono app setup, health endpoint, SIGTERM shutdown,
and OTEL accessor boilerplate into a reusable service entrypoint.
Telemetry is optional via @opentelemetry/api no-op fallbacks.