### PR TITLE
feat(auth): policy engine initial implementation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,6 +51,48 @@
       "name": "@catalyst/auth",
       "version": "0.0.0",
       "dependencies": {
+        "@cerbos/grpc": "^0.24.2",
+        "@hono/capnweb": "catalog:",
+        "argon2": "^0.44.0",
+        "capnweb": "catalog:",
+        "hono": "catalog:",
+        "jose": "catalog:",
+        "zod": "catalog:",
+      },
+      "devDependencies": {
+        "@cerbos/core": "^0.27.1",
+        "@types/bun": "catalog:dev",
+        "@types/node": "catalog:dev",
+        "testcontainers": "catalog:testing",
+        "typescript": "catalog:dev",
+        "vitest": "catalog:testing",
+      },
+    },
+    "packages/auth-new": {
+      "name": "@catalyst/auth-new",
+      "version": "0.0.0",
+      "dependencies": {
+        "@cerbos/grpc": "^0.24.2",
+        "@hono/capnweb": "^0.1.0",
+        "argon2": "^0.44.0",
+        "capnweb": "^0.4.0",
+        "hono": "^4.11.3",
+        "jose": "^6.0.0",
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@cerbos/core": "^0.27.1",
+        "@types/bun": "catalog:dev",
+        "@types/node": "^20.11.0",
+        "testcontainers": "^10.7.1",
+        "typescript": "^5.3.3",
+        "vitest": "^1.2.1",
+      },
+    },
+    "packages/auth-old": {
+      "name": "@catalyst/auth-old",
+      "version": "0.0.0",
+      "dependencies": {
         "@hono/capnweb": "^0.1.0",
         "argon2": "^0.44.0",
         "capnweb": "^0.4.0",
@@ -315,11 +357,17 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.11.0", "", {}, "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ=="],
+
     "@catalyst-examples/orders-api": ["@catalyst-examples/orders-api@workspace:examples/orders-api"],
 
     "@catalyst-examples/product-api": ["@catalyst-examples/product-api@workspace:examples/product-api"],
 
     "@catalyst/auth": ["@catalyst/auth@workspace:packages/auth"],
+
+    "@catalyst/auth-new": ["@catalyst/auth-new@workspace:packages/auth-new"],
+
+    "@catalyst/auth-old": ["@catalyst/auth-old@workspace:packages/auth-old"],
 
     "@catalyst/cli": ["@catalyst/cli@workspace:packages/cli"],
 
@@ -332,6 +380,12 @@
     "@catalyst/orchestrator": ["@catalyst/orchestrator@workspace:packages/orchestrator"],
 
     "@catalyst/sdk": ["@catalyst/sdk@workspace:packages/sdk"],
+
+    "@cerbos/api": ["@cerbos/api@0.5.1", "", { "dependencies": { "@bufbuild/protobuf": "^2.10.2" } }, "sha512-OA2uTI3KTXhG7MF03H2fe6g8+76G/B6GYSZcgVn/8w+ywJkrQKvxsbm6phkxfw/v9z0pWlGAg5VmnzDVQTcRxQ=="],
+
+    "@cerbos/core": ["@cerbos/core@0.27.1", "", { "dependencies": { "@cerbos/api": "^0.5.1", "uuid": "^13.0.0" }, "peerDependencies": { "@bufbuild/protobuf": "^2.10.2" } }, "sha512-mC+lLKRN44JQPglyFw2AJX9n0gH4eOwS8WbAGzVJ145zjrHGMu7ySoxSbM2mM/PqT1CYLbeRYetaRlcUgbIfoQ=="],
+
+    "@cerbos/grpc": ["@cerbos/grpc@0.24.2", "", { "dependencies": { "@cerbos/core": "^0.27.1", "@grpc/grpc-js": "^1.14.3" }, "peerDependencies": { "@bufbuild/protobuf": "^2.10.2", "@cerbos/api": "^0.5.1" } }, "sha512-mzzcojysqCpREvzWPm0pcEgNk1AMSAs3hs7oi9fUWNDFaoAZG9iUwZvt5+jBApmZ1MfL0qNnWNKyZ1oyfrPs6A=="],
 
     "@commitlint/cli": ["@commitlint/cli@20.3.1", "", { "dependencies": { "@commitlint/format": "^20.3.1", "@commitlint/lint": "^20.3.1", "@commitlint/load": "^20.3.1", "@commitlint/read": "^20.3.1", "@commitlint/types": "^20.3.1", "tinyexec": "^1.0.0", "yargs": "^17.0.0" }, "bin": { "commitlint": "./cli.js" } }, "sha512-NtInjSlyev/+SLPvx/ulz8hRE25Wf5S9dLNDcIwazq0JyB4/w1ROF/5nV0ObPTX8YpRaKYeKtXDYWqumBNHWsw=="],
 
@@ -445,7 +499,7 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
 
-    "@fastify/busboy": ["@fastify/busboy@3.2.0", "", {}, "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="],
+    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@graphql-tools/batch-delegate": ["@graphql-tools/batch-delegate@10.0.10", "", { "dependencies": { "@graphql-tools/delegate": "^12.0.4", "@graphql-tools/utils": "^11.0.0", "@whatwg-node/promise-helpers": "^1.3.2", "dataloader": "^2.2.3", "tslib": "^2.8.1" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-xn+GVHWXreBCQsJORtXv33VKYAUuEkYXoTLufKWJCam+0XVwiKHJZBqUOasK4pxZ2WqO0fzbQ8WWu8mCyWze4A=="],
 
@@ -741,19 +795,19 @@
 
     "@vitest/coverage-v8": ["@vitest/coverage-v8@4.0.18", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.0.18", "ast-v8-to-istanbul": "^0.3.10", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.1", "obug": "^2.1.1", "std-env": "^3.10.0", "tinyrainbow": "^3.0.3" }, "peerDependencies": { "@vitest/browser": "4.0.18", "vitest": "4.0.18" }, "optionalPeers": ["@vitest/browser"] }, "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg=="],
 
-    "@vitest/expect": ["@vitest/expect@1.6.1", "", { "dependencies": { "@vitest/spy": "1.6.1", "@vitest/utils": "1.6.1", "chai": "^4.3.10" } }, "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog=="],
+    "@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
 
     "@vitest/mocker": ["@vitest/mocker@4.0.18", "", { "dependencies": { "@vitest/spy": "4.0.18", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ=="],
 
     "@vitest/pretty-format": ["@vitest/pretty-format@4.0.18", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw=="],
 
-    "@vitest/runner": ["@vitest/runner@1.6.1", "", { "dependencies": { "@vitest/utils": "1.6.1", "p-limit": "^5.0.0", "pathe": "^1.1.1" } }, "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA=="],
+    "@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@1.6.1", "", { "dependencies": { "magic-string": "^0.30.5", "pathe": "^1.1.1", "pretty-format": "^29.7.0" } }, "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
 
-    "@vitest/spy": ["@vitest/spy@1.6.1", "", { "dependencies": { "tinyspy": "^2.2.0" } }, "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw=="],
+    "@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
 
-    "@vitest/utils": ["@vitest/utils@1.6.1", "", { "dependencies": { "diff-sequences": "^29.6.3", "estree-walker": "^3.0.3", "loupe": "^2.3.7", "pretty-format": "^29.7.0" } }, "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g=="],
+    "@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
 
     "@whatwg-node/disposablestack": ["@whatwg-node/disposablestack@0.0.6", "", { "dependencies": { "@whatwg-node/promise-helpers": "^1.0.0", "tslib": "^2.6.3" } }, "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw=="],
 
@@ -933,7 +987,7 @@
 
     "diff-sequences": ["diff-sequences@29.6.3", "", {}, "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q=="],
 
-    "docker-compose": ["docker-compose@1.3.0", "", { "dependencies": { "yaml": "^2.2.2" } }, "sha512-7Gevk/5eGD50+eMD+XDnFnOrruFkL0kSd7jEG4cjmqweDSUhB7i0g8is/nBdVpl+Bx338SqIB2GLKm32M+Vs6g=="],
+    "docker-compose": ["docker-compose@1.3.1", "", { "dependencies": { "yaml": "^2.2.2" } }, "sha512-rF0wH69G3CCcmkN9J1RVMQBaKe8o77LT/3XmqcLIltWWVxcWAzp2TnO7wS3n/umZHN3/EVrlT3exSBMal+Ou1w=="],
 
     "docker-modem": ["docker-modem@5.0.6", "", { "dependencies": { "debug": "^4.1.1", "readable-stream": "^3.5.0", "split-ca": "^1.0.1", "ssh2": "^1.15.0" } }, "sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ=="],
 
@@ -1263,7 +1317,7 @@
 
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
-    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pathval": ["pathval@1.1.1", "", {}, "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="],
 
@@ -1445,7 +1499,7 @@
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
-    "undici": ["undici@7.18.2", "", {}, "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw=="],
+    "undici": ["undici@7.19.0", "", {}, "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -1457,13 +1511,13 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+    "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
 
-    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+    "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "vite-node": ["vite-node@1.6.1", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.4", "pathe": "^1.1.1", "picocolors": "^1.0.0", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA=="],
 
-    "vitest": ["vitest@1.6.1", "", { "dependencies": { "@vitest/expect": "1.6.1", "@vitest/runner": "1.6.1", "@vitest/snapshot": "1.6.1", "@vitest/spy": "1.6.1", "@vitest/utils": "1.6.1", "acorn-walk": "^8.3.2", "chai": "^4.3.10", "debug": "^4.3.4", "execa": "^8.0.1", "local-pkg": "^0.5.0", "magic-string": "^0.30.5", "pathe": "^1.1.1", "picocolors": "^1.0.0", "std-env": "^3.5.0", "strip-literal": "^2.0.0", "tinybench": "^2.5.1", "tinypool": "^0.8.3", "vite": "^5.0.0", "vite-node": "1.6.1", "why-is-node-running": "^2.2.2" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "1.6.1", "@vitest/ui": "1.6.1", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag=="],
+    "vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
 
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
 
@@ -1511,31 +1565,23 @@
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "@catalyst/auth/@types/node": ["@types/node@20.19.30", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g=="],
+    "@catalyst/auth/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
+
+    "@catalyst/auth-new/@types/node": ["@types/node@20.19.30", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g=="],
+
+    "@catalyst/auth-new/testcontainers": ["testcontainers@10.28.0", "", { "dependencies": { "@balena/dockerignore": "^1.0.2", "@types/dockerode": "^3.3.35", "archiver": "^7.0.1", "async-lock": "^1.4.1", "byline": "^5.0.0", "debug": "^4.3.5", "docker-compose": "^0.24.8", "dockerode": "^4.0.5", "get-port": "^7.1.0", "proper-lockfile": "^4.1.2", "properties-reader": "^2.3.0", "ssh-remote-port-forward": "^1.0.4", "tar-fs": "^3.0.7", "tmp": "^0.2.3", "undici": "^5.29.0" } }, "sha512-1fKrRRCsgAQNkarjHCMKzBKXSJFmzNTiTbhb5E/j5hflRXChEtHvkefjaHlgkNUjfw92/Dq8LTgwQn6RDBFbMg=="],
+
+    "@catalyst/auth-new/vitest": ["vitest@1.6.1", "", { "dependencies": { "@vitest/expect": "1.6.1", "@vitest/runner": "1.6.1", "@vitest/snapshot": "1.6.1", "@vitest/spy": "1.6.1", "@vitest/utils": "1.6.1", "acorn-walk": "^8.3.2", "chai": "^4.3.10", "debug": "^4.3.4", "execa": "^8.0.1", "local-pkg": "^0.5.0", "magic-string": "^0.30.5", "pathe": "^1.1.1", "picocolors": "^1.0.0", "std-env": "^3.5.0", "strip-literal": "^2.0.0", "tinybench": "^2.5.1", "tinypool": "^0.8.3", "vite": "^5.0.0", "vite-node": "1.6.1", "why-is-node-running": "^2.2.2" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "1.6.1", "@vitest/ui": "1.6.1", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag=="],
+
+    "@catalyst/auth-old/@types/node": ["@types/node@20.19.30", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g=="],
+
+    "@catalyst/auth-old/vitest": ["vitest@1.6.1", "", { "dependencies": { "@vitest/expect": "1.6.1", "@vitest/runner": "1.6.1", "@vitest/snapshot": "1.6.1", "@vitest/spy": "1.6.1", "@vitest/utils": "1.6.1", "acorn-walk": "^8.3.2", "chai": "^4.3.10", "debug": "^4.3.4", "execa": "^8.0.1", "local-pkg": "^0.5.0", "magic-string": "^0.30.5", "pathe": "^1.1.1", "picocolors": "^1.0.0", "std-env": "^3.5.0", "strip-literal": "^2.0.0", "tinybench": "^2.5.1", "tinypool": "^0.8.3", "vite": "^5.0.0", "vite-node": "1.6.1", "why-is-node-running": "^2.2.2" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "1.6.1", "@vitest/ui": "1.6.1", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag=="],
 
     "@catalyst/cli/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
-    "@catalyst/cli/testcontainers": ["testcontainers@11.11.0", "", { "dependencies": { "@balena/dockerignore": "^1.0.2", "@types/dockerode": "^3.3.47", "archiver": "^7.0.1", "async-lock": "^1.4.1", "byline": "^5.0.0", "debug": "^4.4.3", "docker-compose": "^1.3.0", "dockerode": "^4.0.9", "get-port": "^7.1.0", "proper-lockfile": "^4.1.2", "properties-reader": "^2.3.0", "ssh-remote-port-forward": "^1.0.4", "tar-fs": "^3.1.1", "tmp": "^0.2.5", "undici": "^7.16.0" } }, "sha512-nKTJn3n/gkyGg/3SVkOwX+isPOGSHlfI+CWMobSmvQrsj7YW01aWvl2pYIfV4LMd+C8or783yYrzKSK2JlP+Qw=="],
-
-    "@catalyst/examples/testcontainers": ["testcontainers@11.11.0", "", { "dependencies": { "@balena/dockerignore": "^1.0.2", "@types/dockerode": "^3.3.47", "archiver": "^7.0.1", "async-lock": "^1.4.1", "byline": "^5.0.0", "debug": "^4.4.3", "docker-compose": "^1.3.0", "dockerode": "^4.0.9", "get-port": "^7.1.0", "proper-lockfile": "^4.1.2", "properties-reader": "^2.3.0", "ssh-remote-port-forward": "^1.0.4", "tar-fs": "^3.1.1", "tmp": "^0.2.5", "undici": "^7.16.0" } }, "sha512-nKTJn3n/gkyGg/3SVkOwX+isPOGSHlfI+CWMobSmvQrsj7YW01aWvl2pYIfV4LMd+C8or783yYrzKSK2JlP+Qw=="],
-
-    "@catalyst/examples/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
-
     "@catalyst/gateway/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
-    "@catalyst/gateway/testcontainers": ["testcontainers@11.11.0", "", { "dependencies": { "@balena/dockerignore": "^1.0.2", "@types/dockerode": "^3.3.47", "archiver": "^7.0.1", "async-lock": "^1.4.1", "byline": "^5.0.0", "debug": "^4.4.3", "docker-compose": "^1.3.0", "dockerode": "^4.0.9", "get-port": "^7.1.0", "proper-lockfile": "^4.1.2", "properties-reader": "^2.3.0", "ssh-remote-port-forward": "^1.0.4", "tar-fs": "^3.1.1", "tmp": "^0.2.5", "undici": "^7.16.0" } }, "sha512-nKTJn3n/gkyGg/3SVkOwX+isPOGSHlfI+CWMobSmvQrsj7YW01aWvl2pYIfV4LMd+C8or783yYrzKSK2JlP+Qw=="],
-
-    "@catalyst/gateway/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
-
     "@catalyst/node/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
-
-    "@catalyst/node/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
-
-    "@catalyst/orchestrator/testcontainers": ["testcontainers@11.11.0", "", { "dependencies": { "@balena/dockerignore": "^1.0.2", "@types/dockerode": "^3.3.47", "archiver": "^7.0.1", "async-lock": "^1.4.1", "byline": "^5.0.0", "debug": "^4.4.3", "docker-compose": "^1.3.0", "dockerode": "^4.0.9", "get-port": "^7.1.0", "proper-lockfile": "^4.1.2", "properties-reader": "^2.3.0", "ssh-remote-port-forward": "^1.0.4", "tar-fs": "^3.1.1", "tmp": "^0.2.5", "undici": "^7.16.0" } }, "sha512-nKTJn3n/gkyGg/3SVkOwX+isPOGSHlfI+CWMobSmvQrsj7YW01aWvl2pYIfV4LMd+C8or783yYrzKSK2JlP+Qw=="],
-
-    "@catalyst/orchestrator/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
-
-    "@catalyst/sdk/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
 
     "@commitlint/config-validator/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
@@ -1573,11 +1619,7 @@
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
-    "@vitest/coverage-v8/@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
-
-    "@vitest/coverage-v8/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
-
-    "@vitest/mocker/@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
+    "@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "@whatwg-node/node-fetch/@fastify/busboy": ["@fastify/busboy@3.2.0", "", {}, "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="],
 
@@ -1598,6 +1640,8 @@
     "docker-modem/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "dockerode/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+
+    "dockerode/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -1627,15 +1671,11 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "mlly/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "ora/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
-
-    "pkg-types/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
@@ -1653,7 +1693,9 @@
 
     "tsup/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
-    "vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+    "vite-node/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "vite-node/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
@@ -1665,97 +1707,45 @@
 
     "@aws-sdk/signature-v4-multi-region/@aws-sdk/middleware-sdk-s3/@aws-sdk/util-arn-parser": ["@aws-sdk/util-arn-parser@3.972.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-RM5Mmo/KJ593iMSrALlHEOcc9YOIyOsDmS5x2NLOMdEmzv1o00fcpAkCQ02IGu1eFneBFT7uX0Mpag0HI+Cz2g=="],
 
+    "@catalyst/auth-new/testcontainers/docker-compose": ["docker-compose@0.24.8", "", { "dependencies": { "yaml": "^2.2.2" } }, "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw=="],
+
+    "@catalyst/auth-new/testcontainers/undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
+
+    "@catalyst/auth-new/vitest/@vitest/expect": ["@vitest/expect@1.6.1", "", { "dependencies": { "@vitest/spy": "1.6.1", "@vitest/utils": "1.6.1", "chai": "^4.3.10" } }, "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog=="],
+
+    "@catalyst/auth-new/vitest/@vitest/runner": ["@vitest/runner@1.6.1", "", { "dependencies": { "@vitest/utils": "1.6.1", "p-limit": "^5.0.0", "pathe": "^1.1.1" } }, "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA=="],
+
+    "@catalyst/auth-new/vitest/@vitest/snapshot": ["@vitest/snapshot@1.6.1", "", { "dependencies": { "magic-string": "^0.30.5", "pathe": "^1.1.1", "pretty-format": "^29.7.0" } }, "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ=="],
+
+    "@catalyst/auth-new/vitest/@vitest/spy": ["@vitest/spy@1.6.1", "", { "dependencies": { "tinyspy": "^2.2.0" } }, "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw=="],
+
+    "@catalyst/auth-new/vitest/@vitest/utils": ["@vitest/utils@1.6.1", "", { "dependencies": { "diff-sequences": "^29.6.3", "estree-walker": "^3.0.3", "loupe": "^2.3.7", "pretty-format": "^29.7.0" } }, "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g=="],
+
+    "@catalyst/auth-new/vitest/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "@catalyst/auth-new/vitest/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "@catalyst/auth-old/vitest/@vitest/expect": ["@vitest/expect@1.6.1", "", { "dependencies": { "@vitest/spy": "1.6.1", "@vitest/utils": "1.6.1", "chai": "^4.3.10" } }, "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog=="],
+
+    "@catalyst/auth-old/vitest/@vitest/runner": ["@vitest/runner@1.6.1", "", { "dependencies": { "@vitest/utils": "1.6.1", "p-limit": "^5.0.0", "pathe": "^1.1.1" } }, "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA=="],
+
+    "@catalyst/auth-old/vitest/@vitest/snapshot": ["@vitest/snapshot@1.6.1", "", { "dependencies": { "magic-string": "^0.30.5", "pathe": "^1.1.1", "pretty-format": "^29.7.0" } }, "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ=="],
+
+    "@catalyst/auth-old/vitest/@vitest/spy": ["@vitest/spy@1.6.1", "", { "dependencies": { "tinyspy": "^2.2.0" } }, "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw=="],
+
+    "@catalyst/auth-old/vitest/@vitest/utils": ["@vitest/utils@1.6.1", "", { "dependencies": { "diff-sequences": "^29.6.3", "estree-walker": "^3.0.3", "loupe": "^2.3.7", "pretty-format": "^29.7.0" } }, "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g=="],
+
+    "@catalyst/auth-old/vitest/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "@catalyst/auth-old/vitest/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "@catalyst/auth/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "@catalyst/cli/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "@catalyst/cli/testcontainers/docker-compose": ["docker-compose@1.3.1", "", { "dependencies": { "yaml": "^2.2.2" } }, "sha512-rF0wH69G3CCcmkN9J1RVMQBaKe8o77LT/3XmqcLIltWWVxcWAzp2TnO7wS3n/umZHN3/EVrlT3exSBMal+Ou1w=="],
-
-    "@catalyst/cli/testcontainers/undici": ["undici@7.19.0", "", {}, "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ=="],
-
-    "@catalyst/examples/testcontainers/docker-compose": ["docker-compose@1.3.1", "", { "dependencies": { "yaml": "^2.2.2" } }, "sha512-rF0wH69G3CCcmkN9J1RVMQBaKe8o77LT/3XmqcLIltWWVxcWAzp2TnO7wS3n/umZHN3/EVrlT3exSBMal+Ou1w=="],
-
-    "@catalyst/examples/testcontainers/undici": ["undici@7.19.0", "", {}, "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ=="],
-
-    "@catalyst/examples/vitest/@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
-
-    "@catalyst/examples/vitest/@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
-
-    "@catalyst/examples/vitest/@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
-
-    "@catalyst/examples/vitest/@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
-
-    "@catalyst/examples/vitest/@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
-
-    "@catalyst/examples/vitest/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
-    "@catalyst/examples/vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "@catalyst/gateway/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
-    "@catalyst/gateway/testcontainers/docker-compose": ["docker-compose@1.3.1", "", { "dependencies": { "yaml": "^2.2.2" } }, "sha512-rF0wH69G3CCcmkN9J1RVMQBaKe8o77LT/3XmqcLIltWWVxcWAzp2TnO7wS3n/umZHN3/EVrlT3exSBMal+Ou1w=="],
-
-    "@catalyst/gateway/testcontainers/undici": ["undici@7.19.0", "", {}, "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ=="],
-
-    "@catalyst/gateway/vitest/@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
-
-    "@catalyst/gateway/vitest/@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
-
-    "@catalyst/gateway/vitest/@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
-
-    "@catalyst/gateway/vitest/@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
-
-    "@catalyst/gateway/vitest/@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
-
-    "@catalyst/gateway/vitest/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
-    "@catalyst/gateway/vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
-
     "@catalyst/node/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "@catalyst/node/vitest/@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
-
-    "@catalyst/node/vitest/@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
-
-    "@catalyst/node/vitest/@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
-
-    "@catalyst/node/vitest/@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
-
-    "@catalyst/node/vitest/@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
-
-    "@catalyst/node/vitest/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
-    "@catalyst/node/vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
-
-    "@catalyst/orchestrator/testcontainers/docker-compose": ["docker-compose@1.3.1", "", { "dependencies": { "yaml": "^2.2.2" } }, "sha512-rF0wH69G3CCcmkN9J1RVMQBaKe8o77LT/3XmqcLIltWWVxcWAzp2TnO7wS3n/umZHN3/EVrlT3exSBMal+Ou1w=="],
-
-    "@catalyst/orchestrator/testcontainers/undici": ["undici@7.19.0", "", {}, "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ=="],
-
-    "@catalyst/orchestrator/vitest/@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
-
-    "@catalyst/orchestrator/vitest/@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
-
-    "@catalyst/orchestrator/vitest/@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
-
-    "@catalyst/orchestrator/vitest/@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
-
-    "@catalyst/orchestrator/vitest/@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
-
-    "@catalyst/orchestrator/vitest/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
-    "@catalyst/orchestrator/vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
-
-    "@catalyst/sdk/vitest/@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
-
-    "@catalyst/sdk/vitest/@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
-
-    "@catalyst/sdk/vitest/@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
-
-    "@catalyst/sdk/vitest/@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
-
-    "@catalyst/sdk/vitest/@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
-
-    "@catalyst/sdk/vitest/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
-    "@catalyst/sdk/vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "@commitlint/config-validator/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -1784,18 +1774,6 @@
     "@types/ws/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "@vitest/coverage-v8/vitest/@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
-
-    "@vitest/coverage-v8/vitest/@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
-
-    "@vitest/coverage-v8/vitest/@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
-
-    "@vitest/coverage-v8/vitest/@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
-
-    "@vitest/coverage-v8/vitest/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
-    "@vitest/coverage-v8/vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -1831,51 +1809,7 @@
 
     "restore-cursor/onetime/mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
-    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
-
-    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
-
-    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
-
-    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
-
-    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
-
-    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
-
-    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
-
-    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
-
-    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
-
-    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
-
-    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
-
-    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
-
-    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
-
-    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
-
-    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
-
-    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
-
-    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
-
-    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
-
-    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
-
-    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
-
-    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
-
-    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
-
-    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+    "vite-node/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
@@ -1885,19 +1819,11 @@
 
     "@aws-sdk/signature-v4-multi-region/@aws-sdk/middleware-sdk-s3/@aws-sdk/core/@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.0", "", { "dependencies": { "@smithy/types": "^4.12.0", "fast-xml-parser": "5.2.5", "tslib": "^2.6.2" } }, "sha512-POaGMcXnozzqBUyJM3HLUZ9GR6OKJWPGJEmhtTnxZXt8B6JcJ/6K3xRJ5H/j8oovVLz8Wg6vFxAHv8lvuASxMg=="],
 
-    "@catalyst/examples/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+    "@catalyst/auth-new/vitest/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
-    "@catalyst/gateway/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
-
-    "@catalyst/node/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
-
-    "@catalyst/orchestrator/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
-
-    "@catalyst/sdk/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+    "@catalyst/auth-old/vitest/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
     "@commitlint/top-level/find-up/locate-path/p-locate": ["p-locate@6.0.0", "", { "dependencies": { "p-limit": "^4.0.0" } }, "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw=="],
-
-    "@vitest/coverage-v8/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
@@ -1912,6 +1838,144 @@
     "log-update/cli-cursor/restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "log-update/wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "vite-node/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vite-node/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vite-node/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@catalyst/auth-new/vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@catalyst/auth-old/vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
     "@commitlint/top-level/find-up/locate-path/p-locate/p-limit": ["p-limit@4.0.0", "", { "dependencies": { "yocto-queue": "^1.0.0" } }, "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ=="],
   }

--- a/packages/auth/cerbos/policies/ibgp.yaml
+++ b/packages/auth/cerbos/policies/ibgp.yaml
@@ -1,0 +1,11 @@
+apiVersion: api.cerbos.dev/v1
+
+resourcePolicy:
+  resource: 'ibgp'
+  version: 'default'
+  rules:
+    - actions: ['open', 'close', 'update']
+      effect: EFFECT_ALLOW
+      roles:
+        - admin
+        - peer

--- a/packages/auth/cerbos/policies/ibgp_test.yaml
+++ b/packages/auth/cerbos/policies/ibgp_test.yaml
@@ -1,0 +1,88 @@
+name: IBGP Resource Policy Test
+
+principals:
+  # Can connect, update, and delete peers
+  admin:
+    id: admin_user
+    roles: ['admin']
+
+  peer:
+    id: peer_resource_01
+    roles: ['peer']
+
+  # Cannot connect, update, and delete peers
+  data_custodian:
+    id: data_custodian_user
+    roles: ['data_custodian']
+
+  network_operator:
+    id: network_operator_user
+    roles: ['network_operator']
+
+  peer_custodian:
+    id: peer_custodian_user
+    roles: ['peer_custodian']
+
+  user:
+    id: user_user
+    roles: ['user']
+
+resources:
+  ibgp_resource:
+    kind: ibgp
+    id: ibgp_resource_01
+
+  peer_resource:
+    kind: peer
+    id: peer_01
+
+tests:
+  - name: Only Admin and Peer can connect, update, and delete peers
+    input:
+      principals: ['admin', 'peer']
+      resources: ['ibgp_resource']
+      actions: ['open', 'close', 'update']
+    expected:
+      - principal: admin
+        resource: ibgp_resource
+        actions:
+          open: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          close: EFFECT_ALLOW
+      - principal: peer
+        resource: ibgp_resource
+        actions:
+          open: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          close: EFFECT_ALLOW
+
+  - name: Rest of the principals cannot connect, update, and delete peers
+    input:
+      principals: ['data_custodian', 'network_operator', 'peer_custodian', 'user']
+      resources: ['ibgp_resource']
+      actions: ['open', 'close', 'update']
+    expected:
+      - principal: data_custodian
+        resource: ibgp_resource
+        actions:
+          open: EFFECT_DENY
+          update: EFFECT_DENY
+          close: EFFECT_DENY
+      - principal: network_operator
+        resource: ibgp_resource
+        actions:
+          open: EFFECT_DENY
+          update: EFFECT_DENY
+          close: EFFECT_DENY
+      - principal: peer_custodian
+        resource: ibgp_resource
+        actions:
+          open: EFFECT_DENY
+          update: EFFECT_DENY
+          close: EFFECT_DENY
+      - principal: user
+        resource: ibgp_resource
+        actions:
+          open: EFFECT_DENY
+          update: EFFECT_DENY
+          close: EFFECT_DENY

--- a/packages/auth/cerbos/policies/peer.yaml
+++ b/packages/auth/cerbos/policies/peer.yaml
@@ -1,0 +1,11 @@
+apiVersion: api.cerbos.dev/v1
+
+resourcePolicy:
+  resource: 'peer'
+  version: 'default'
+  rules:
+    - actions: ['create', 'update', 'delete', 'list', 'view']
+      effect: EFFECT_ALLOW
+      roles:
+        - admin
+        - peer_custodian

--- a/packages/auth/cerbos/policies/peer_test.yaml
+++ b/packages/auth/cerbos/policies/peer_test.yaml
@@ -1,0 +1,66 @@
+name: Peer Resource Policy Test
+
+principals:
+  admin:
+    id: admin_user
+    roles: ['admin']
+
+  data_custodian:
+    id: data_custodian_user
+    roles: ['data_custodian']
+
+  network_operator:
+    id: network_operator_user
+    roles: ['network_operator']
+
+  peer_custodian:
+    id: peer_custodian_user
+    roles: ['peer_custodian']
+
+  user:
+    id: user_user
+    roles: ['user']
+
+resources:
+  peer_resource:
+    kind: peer
+    id: peer_resource_01
+
+tests:
+  - name: Only Admin and Peer Custodian can create, update, and delete, list, and view peers
+    input:
+      principals: ['admin', 'peer_custodian']
+      resources: ['peer_resource']
+      actions: ['create', 'update', 'delete', 'list', 'view']
+    expected:
+      - principal: admin
+        resource: peer_resource
+        actions:
+          create: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          view: EFFECT_ALLOW
+      - principal: peer_custodian
+        resource: peer_resource
+        actions:
+          create: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          view: EFFECT_ALLOW
+
+  - name: Rest of the principals cannot create, update, and delete, list, and view peers
+    input:
+      principals: ['data_custodian', 'network_operator', 'user']
+      resources: ['peer_resource']
+      actions: ['create', 'update', 'delete', 'list', 'view']
+    expected:
+      - principal: data_custodian
+        resource: peer_resource
+        actions:
+          create: EFFECT_DENY
+          delete: EFFECT_DENY
+          update: EFFECT_DENY
+          list: EFFECT_DENY
+          view: EFFECT_DENY

--- a/packages/auth/cerbos/policies/route.yaml
+++ b/packages/auth/cerbos/policies/route.yaml
@@ -1,0 +1,17 @@
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  resource: 'route'
+  version: 'default'
+  rules:
+    - actions: ['create', 'delete']
+      effect: EFFECT_ALLOW
+      roles:
+        - admin
+        - data_custodian
+
+    - actions: ['list', 'view']
+      effect: EFFECT_ALLOW
+      roles:
+        - admin
+        - data_custodian
+        - user

--- a/packages/auth/cerbos/policies/token.yaml
+++ b/packages/auth/cerbos/policies/token.yaml
@@ -1,0 +1,10 @@
+apiVersion: api.cerbos.dev/v1
+
+resourcePolicy:
+  resource: 'token'
+  version: 'default'
+  rules:
+    - actions: ['create', 'revoke', 'list']
+      effect: EFFECT_ALLOW
+      roles:
+        - admin

--- a/packages/auth/cerbos/policies/token_test.yaml
+++ b/packages/auth/cerbos/policies/token_test.yaml
@@ -1,0 +1,72 @@
+name: Token Resource Policy Test
+
+principals:
+  admin:
+    id: admin_user
+    roles: ['admin']
+
+  data_custodian:
+    id: data_custodian_user
+    roles: ['data_custodian']
+
+  network_operator:
+    id: network_operator_user
+    roles: ['network_operator']
+
+  peer_custodian:
+    id: peer_custodian_user
+    roles: ['peer_custodian']
+
+  user:
+    id: user_user
+    roles: ['user']
+
+resources:
+  token_resource:
+    kind: token
+    id: token_resource_01
+
+tests:
+  - name: Only Admin can create, revoke, and list tokens
+    input:
+      principals: ['admin']
+      resources: ['token_resource']
+      actions: ['create', 'revoke', 'list']
+    expected:
+      - principal: admin
+        resource: token_resource
+        actions:
+          create: EFFECT_ALLOW
+          revoke: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+
+  - name: Non-admin principals cannot create, revoke, and list tokens
+    input:
+      principals: ['data_custodian', 'network_operator', 'peer_custodian', 'user']
+      resources: ['token_resource']
+      actions: ['create', 'revoke', 'list']
+    expected:
+      - principal: 'data_custodian'
+        resource: token_resource
+        actions:
+          create: EFFECT_DENY
+          revoke: EFFECT_DENY
+          list: EFFECT_DENY
+      - principal: 'network_operator'
+        resource: token_resource
+        actions:
+          create: EFFECT_DENY
+          revoke: EFFECT_DENY
+          list: EFFECT_DENY
+      - principal: 'peer_custodian'
+        resource: token_resource
+        actions:
+          create: EFFECT_DENY
+          revoke: EFFECT_DENY
+          list: EFFECT_DENY
+      - principal: 'user'
+        resource: token_resource
+        actions:
+          create: EFFECT_DENY
+          revoke: EFFECT_DENY
+          list: EFFECT_DENY

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -12,21 +12,24 @@
     "dev": "bun run --watch src/server.ts",
     "build": "tsc",
     "test": "bun test",
-    "start": "bun run src/server.ts"
+    "start": "bun run src/server.ts",
+    "policy:test": "bunx cerbos compile cerbos/policies --test-output=tree 2> /dev/null"
   },
   "dependencies": {
-    "@hono/capnweb": "^0.1.0",
+    "@cerbos/grpc": "^0.24.2",
+    "@hono/capnweb": "catalog:",
     "argon2": "^0.44.0",
-    "capnweb": "^0.4.0",
-    "hono": "^4.11.3",
-    "jose": "^6.0.0",
-    "zod": "^4.0.0"
+    "capnweb": "catalog:",
+    "hono": "catalog:",
+    "jose": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
+    "@cerbos/core": "^0.27.1",
     "@types/bun": "catalog:dev",
-    "@types/node": "^20.11.0",
+    "@types/node": "catalog:dev",
     "testcontainers": "catalog:testing",
-    "typescript": "^5.3.3",
-    "vitest": "^1.2.1"
+    "typescript": "catalog:dev",
+    "vitest": "catalog:testing"
   }
 }

--- a/packages/auth/src/permissions.ts
+++ b/packages/auth/src/permissions.ts
@@ -1,125 +1,183 @@
+import type { IsAllowedRequest, Principal, Resource, Value } from '@cerbos/core'
 import { timingSafeEqual } from 'node:crypto'
+import { GRPC as CerbosGRPC } from '@cerbos/grpc'
 
 /**
  * Explicit enumerated set of permissions.
  * Aligned with orchestrator requirements and new token management.
  */
 export enum Permission {
-    // Token management
-    TokenCreate = 'token:create',
-    TokenRevoke = 'token:revoke',
-    TokenList = 'token:list',
+  // Token management
+  TokenCreate = 'token:create',
+  TokenRevoke = 'token:revoke',
+  TokenList = 'token:list',
 
-    // Peer management
-    PeerCreate = 'peer:create',
-    PeerUpdate = 'peer:update',
-    PeerDelete = 'peer:delete',
+  // Peer management
+  PeerCreate = 'peer:create',
+  PeerUpdate = 'peer:update',
+  PeerDelete = 'peer:delete',
 
-    // Route management
-    RouteCreate = 'route:create',
-    RouteDelete = 'route:delete',
+  // Route management
+  RouteCreate = 'route:create',
+  RouteDelete = 'route:delete',
 
-    // Internal protocol (iBGP)
-    IbgpConnect = 'ibgp:connect',
-    IbgpDisconnect = 'ibgp:disconnect',
-    IbgpUpdate = 'ibgp:update',
+  // Internal protocol (iBGP)
+  IbgpConnect = 'ibgp:connect',
+  IbgpDisconnect = 'ibgp:disconnect',
+  IbgpUpdate = 'ibgp:update',
 
-    // Administrative
-    Admin = '*',
+  // Administrative
+  Admin = '*',
 }
 
 /**
  * Available roles in the system.
  */
-export type Role = 'admin' | 'peer' | 'peer_custodian' | 'data_custodian' | 'user';
+export type Role = 'admin' | 'peer' | 'peer_custodian' | 'data_custodian' | 'user'
 
 /**
  * Mapping between roles and their explicit permissions.
  */
+// todo: remove this and replace with the new permission service via RPC on the orchestrator
+// change for validateion().isAuthorized() RCP Call made available in rpc/server.ts
+// the permission policy schema is now defined in /packages/auth/cerbos/policies
+// validate with bun policy:test
 export const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
-    admin: [
-        Permission.TokenCreate,
-        Permission.TokenRevoke,
-        Permission.TokenList,
-        Permission.PeerCreate,
-        Permission.PeerUpdate,
-        Permission.PeerDelete,
-        Permission.RouteCreate,
-        Permission.RouteDelete,
-        Permission.IbgpConnect,
-        Permission.IbgpDisconnect,
-        Permission.IbgpUpdate,
-        Permission.Admin,
-    ],
-    peer: [
-        Permission.IbgpConnect,
-        Permission.IbgpDisconnect,
-        Permission.IbgpUpdate,
-    ],
-    peer_custodian: [
-        Permission.PeerCreate,
-        Permission.PeerUpdate,
-        Permission.PeerDelete,
-    ],
-    data_custodian: [
-        Permission.RouteCreate,
-        Permission.RouteDelete,
-    ],
-    user: [],
-};
+  admin: [
+    Permission.TokenCreate,
+    Permission.TokenRevoke,
+    Permission.TokenList,
+    Permission.PeerCreate,
+    Permission.PeerUpdate,
+    Permission.PeerDelete,
+    Permission.RouteCreate,
+    Permission.RouteDelete,
+    Permission.IbgpConnect,
+    Permission.IbgpDisconnect,
+    Permission.IbgpUpdate,
+    Permission.Admin,
+  ],
+  peer: [Permission.IbgpConnect, Permission.IbgpDisconnect, Permission.IbgpUpdate],
+  peer_custodian: [Permission.PeerCreate, Permission.PeerUpdate, Permission.PeerDelete],
+  data_custodian: [Permission.RouteCreate, Permission.RouteDelete],
+  user: [],
+}
 
 /**
  * Resolves a list of permissions for a given set of roles.
  */
 export function getPermissionsForRoles(roles: string[]): Permission[] {
-    const permissions = new Set<Permission>();
-    for (const role of roles) {
-        const rolePermissions = ROLE_PERMISSIONS[role as Role];
-        if (rolePermissions) {
-            rolePermissions.forEach((p) => permissions.add(p));
-        } else {
-            // If it's not a known role, it might be a direct permission string
-            if (Object.values(Permission).includes(role as Permission)) {
-                permissions.add(role as Permission);
-            }
-        }
+  const permissions = new Set<Permission>()
+  for (const role of roles) {
+    const rolePermissions = ROLE_PERMISSIONS[role as Role]
+    if (rolePermissions) {
+      rolePermissions.forEach((p) => permissions.add(p))
+    } else {
+      // If it's not a known role, it might be a direct permission string
+      if (Object.values(Permission).includes(role as Permission)) {
+        permissions.add(role as Permission)
+      }
     }
-    return Array.from(permissions);
+  }
+  return Array.from(permissions)
 }
 
+// TODO: for @gabriel, remove this function and replace with
+// the new permission service via RPC on the orchestrator
+// change for validateion().isAuthorized() RCP Call made available in rpc/server.ts
 /**
  * Checks if the given roles or permissions grant the required permission.
  */
-export function hasPermission(rolesOrPermissions: string[], required: Permission | string): boolean {
-    // All effective permissions for these roles
-    const effectivePermissions = getPermissionsForRoles(rolesOrPermissions);
+export function hasPermission(
+  rolesOrPermissions: string[],
+  required: Permission | string
+): boolean {
+  // All effective permissions for these roles
+  const effectivePermissions = getPermissionsForRoles(rolesOrPermissions)
 
-    // Admin always has permission
-    if (effectivePermissions.includes(Permission.Admin)) {
-        return true;
-    }
+  // Admin always has permission
+  if (effectivePermissions.includes(Permission.Admin)) {
+    return true
+  }
 
-    // Check for direct match
-    return effectivePermissions.includes(required as Permission);
+  // Check for direct match
+  return effectivePermissions.includes(required as Permission)
 }
 
 /**
  * Timing-safe secret comparison.
  */
 export function isSecretValid(provided: string, expected: string): boolean {
-    const providedBuf = Buffer.from(provided)
-    const expectedBuf = Buffer.from(expected)
+  console.log('provided', provided, 'expected', expected)
+  const providedBuf = Buffer.from(provided)
+  const expectedBuf = Buffer.from(expected)
+  if (providedBuf.length !== expectedBuf.length) {
+    const bufLen = providedBuf.length
+    const paddedExpected = Buffer.alloc(bufLen)
+    expectedBuf.copy(paddedExpected)
+    timingSafeEqual(providedBuf, paddedExpected)
+    return false
+  }
+  return timingSafeEqual(providedBuf, expectedBuf)
+}
 
-    if (providedBuf.length !== expectedBuf.length) {
-        const maxLen = Math.max(providedBuf.length, expectedBuf.length)
-        const paddedProvided = Buffer.alloc(maxLen)
-        const paddedExpected = Buffer.alloc(maxLen)
-        providedBuf.copy(paddedProvided)
-        expectedBuf.copy(paddedExpected)
+// Principal Definition
+export type PrincipalAttributes = 'orgId'
+export type CatalystPrincipal = Principal & {
+  roles: Role[]
+  attr?: Partial<Record<PrincipalAttributes, Value>> | undefined
+}
 
-        timingSafeEqual(paddedProvided, paddedExpected)
-        return false
+// Resource Definitions
+export type PeerAttributes = 'peerId' | 'name' | 'endpoint' | 'domains'
+export type RouteAttributes = 'protocol' | 'peerId' | 'nodePath' | 'region' | 'tags'
+export type CatalystResource = Resource &
+  (
+    | {
+        kind: 'peer'
+        attr?: Partial<Record<PeerAttributes, Value>> | undefined
+      }
+    | {
+        kind: 'route'
+        attr?: Partial<Record<RouteAttributes, Value>> | undefined
+      }
+    | {
+        kind: 'ibgp'
+      }
+    | {
+        kind: 'token'
+      }
+  )
+
+export class PermissionService {
+  private cerbosClient: CerbosGRPC
+
+  constructor(url: string) {
+    this.cerbosClient = new CerbosGRPC(url, { tls: false })
+  }
+
+  async isAuthorized(
+    principal: CatalystPrincipal,
+    resource: CatalystResource,
+    permission: Permission
+  ): Promise<boolean> {
+    const requestId = crypto.randomUUID()
+    console.log(
+      '[PermissionService] Authorization requested for',
+      JSON.stringify({
+        requestId,
+        principal: { ...principal, id: undefined },
+        resource,
+        permission,
+      })
+    )
+    const action = permission.split(':').pop() as Permission
+    const request: IsAllowedRequest = {
+      requestId: requestId,
+      principal: principal,
+      resource: resource,
+      action: action,
     }
-
-    return timingSafeEqual(providedBuf, expectedBuf)
+    return this.cerbosClient.isAllowed(request)
+  }
 }

--- a/packages/auth/src/rpc/schema.ts
+++ b/packages/auth/src/rpc/schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { Role } from '../permissions.js'
+import type { CatalystResource, Permission, Role } from '../permissions.js'
 
 /**
  * SignToken Request/Response schemas
@@ -333,6 +333,11 @@ export interface ValidationHandlers {
   getJWKS(): Promise<GetJwksResponse>
   getRevocationList(): Promise<string[]>
   validate(request: { token: string }): Promise<VerifyTokenResponse>
+  isAuthorized(request: {
+    token: string
+    resource: CatalystResource
+    action: Permission
+  }): Promise<boolean>
 }
 
 /**

--- a/packages/auth/tests/jwt.unit.test.ts
+++ b/packages/auth/tests/jwt.unit.test.ts
@@ -1,378 +1,377 @@
-import { describe, it, expect, beforeAll } from 'bun:test';
-import { generateKeyPair, type KeyPair, ALGORITHM } from '../src/keys.js';
+import { describe, it, expect, beforeAll } from 'bun:test'
+import { generateKeyPair, type KeyPair, ALGORITHM } from '../src/keys.js'
 import {
-    signToken,
-    verifyToken,
-    decodeToken,
-    type SignOptions,
-    type VerifyResult,
-} from '../src/jwt.js';
+  signToken,
+  verifyToken,
+  decodeToken,
+  type SignOptions,
+  type VerifyResult,
+  type CatalystClaims,
+} from '../src/jwt.js'
 
 /**
  * Helper to decode token and assert it's valid, returning typed payload/header
  */
 function expectDecoded(token: string) {
-    const decoded = decodeToken(token);
-    expect(decoded).not.toBeNull();
-    return decoded!;
+  const decoded = decodeToken(token)
+  expect(decoded).not.toBeNull()
+  return decoded!
 }
 
 /**
  * Helper to assert verification succeeded and return typed payload
  */
-function expectValid(result: VerifyResult) {
-    expect(result.valid).toBe(true);
-    return (result as { valid: true; payload: Record<string, unknown> }).payload;
+function expectValid(result: VerifyResult): CatalystClaims {
+  expect(result.valid).toBe(true)
+  return (result as { valid: true; payload: CatalystClaims }).payload
 }
 
 /**
  * Helper to assert verification failed and return error
  */
 function expectInvalid(result: VerifyResult) {
-    expect(result.valid).toBe(false);
-    return (result as { valid: false; error: string }).error;
+  expect(result.valid).toBe(false)
+  return (result as { valid: false; error: string }).error
 }
 
 /**
  * Base64url encode (RFC 4648) - proper JWT encoding
  */
 function base64urlEncode(str: string): string {
-    return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
 }
 
 /**
  * Base64url decode (RFC 4648)
  */
 function base64urlDecode(str: string): string {
-    const padded = str + '='.repeat((4 - (str.length % 4)) % 4);
-    return atob(padded.replace(/-/g, '+').replace(/_/g, '/'));
+  const padded = str + '='.repeat((4 - (str.length % 4)) % 4)
+  return atob(padded.replace(/-/g, '+').replace(/_/g, '/'))
 }
 
 describe('jwt', () => {
-    let keyPair: KeyPair;
-    let otherKeyPair: KeyPair;
+  let keyPair: KeyPair
+  let otherKeyPair: KeyPair
 
-    beforeAll(async () => {
-        keyPair = await generateKeyPair();
-        otherKeyPair = await generateKeyPair();
-    });
+  beforeAll(async () => {
+    keyPair = await generateKeyPair()
+    otherKeyPair = await generateKeyPair()
+  })
 
-    describe('signToken', () => {
-        it('should sign a token with required options', async () => {
-            const token = await signToken(keyPair, { subject: 'user-123' });
+  describe('signToken', () => {
+    it('should sign a token with required options', async () => {
+      const token = await signToken(keyPair, { subject: 'user-123' })
 
-            expect(token).toBeString();
-            expect(token.split('.')).toHaveLength(3);
+      expect(token).toBeString()
+      expect(token.split('.')).toHaveLength(3)
 
-            const { header, payload } = expectDecoded(token);
-            expect(payload.sub).toBe('user-123');
-            expect(payload.iss).toBe('catalyst-auth');
-            expect(payload.iat).toBeNumber();
-            expect(payload.exp).toBeNumber();
-            expect(payload.jti).toBeString();
-            expect(header.kid).toBe(keyPair.kid);
-            expect(header.alg).toBe(ALGORITHM);
-        });
+      const { header, payload } = expectDecoded(token)
+      expect(payload.sub).toBe('user-123')
+      expect(payload.iss).toBe('catalyst-auth')
+      expect(payload.iat).toBeNumber()
+      expect(payload.exp).toBeNumber()
+      expect(payload.jti).toBeString()
+      expect(header.kid).toBe(keyPair.kid)
+      expect(header.alg).toBe(ALGORITHM)
+    })
 
-        it('should include audience when provided', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                audience: 'my-service',
-            });
+    it('should include audience when provided', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        audience: 'my-service',
+      })
 
-            const { payload } = expectDecoded(token);
-            expect(payload.aud).toBe('my-service');
-        });
+      const { payload } = expectDecoded(token)
+      expect(payload.aud).toBe('my-service')
+    })
 
-        it('should support array audience', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                audience: ['service-a', 'service-b'],
-            });
+    it('should support array audience', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        audience: ['service-a', 'service-b'],
+      })
 
-            const { payload } = expectDecoded(token);
-            expect(payload.aud).toEqual(['service-a', 'service-b']);
-        });
+      const { payload } = expectDecoded(token)
+      expect(payload.aud).toEqual(['service-a', 'service-b'])
+    })
 
-        it('should include custom claims', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                claims: {
-                    role: 'admin',
-                    permissions: ['read', 'write'],
-                },
-            });
+    it('should include custom claims', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        claims: {
+          role: 'admin',
+          permissions: ['read', 'write'],
+        },
+      })
 
-            const { payload } = expectDecoded(token);
-            expect(payload.role).toBe('admin');
-            expect(payload.permissions).toEqual(['read', 'write']);
-        });
+      const { payload } = expectDecoded(token)
+      expect(payload.role).toBe('admin')
+      expect(payload.permissions).toEqual(['read', 'write'])
+    })
 
-        it('should respect custom expiration', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                expiresIn: '5m',
-            });
+    it('should respect custom expiration', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        expiresIn: '5m',
+      })
 
-            const { payload } = expectDecoded(token);
-            const iat = payload.iat as number;
-            const exp = payload.exp as number;
-            expect(exp - iat).toBe(300); // 5 minutes
-        });
+      const { payload } = expectDecoded(token)
+      const iat = payload.iat as number
+      const exp = payload.exp as number
+      expect(exp - iat).toBe(300) // 5 minutes
+    })
 
-        it('should reject invalid options', async () => {
-            await expect(
-                signToken(keyPair, {} as SignOptions)
-            ).rejects.toThrow();
-        });
+    it('should reject invalid options', async () => {
+      await expect(signToken(keyPair, {} as SignOptions)).rejects.toThrow()
+    })
 
-        it('should generate unique jti for each token', async () => {
-            const token1 = await signToken(keyPair, { subject: 'user-123' });
-            const token2 = await signToken(keyPair, { subject: 'user-123' });
+    it('should generate unique jti for each token', async () => {
+      const token1 = await signToken(keyPair, { subject: 'user-123' })
+      const token2 = await signToken(keyPair, { subject: 'user-123' })
 
-            const { payload: p1 } = expectDecoded(token1);
-            const { payload: p2 } = expectDecoded(token2);
-            expect(p1.jti).not.toBe(p2.jti);
-        });
+      const { payload: p1 } = expectDecoded(token1)
+      const { payload: p2 } = expectDecoded(token2)
+      expect(p1.jti).not.toBe(p2.jti)
+    })
 
-        it('should reject expiration exceeding maximum lifetime', async () => {
-            await expect(
-                signToken(keyPair, {
-                    subject: 'user-123',
-                    expiresIn: '400d', // > 52 weeks max
-                })
-            ).rejects.toThrow('exceeds maximum allowed');
-        });
+    it('should reject expiration exceeding maximum lifetime', async () => {
+      await expect(
+        signToken(keyPair, {
+          subject: 'user-123',
+          expiresIn: '400d', // > 52 weeks max
+        })
+      ).rejects.toThrow('exceeds maximum allowed')
+    })
 
-        it('should reject invalid expiration format', async () => {
-            await expect(
-                signToken(keyPair, { subject: 'user-123', expiresIn: '100y' })
-            ).rejects.toThrow('Invalid expiration format');
+    it('should reject invalid expiration format', async () => {
+      await expect(signToken(keyPair, { subject: 'user-123', expiresIn: '100y' })).rejects.toThrow(
+        'Invalid expiration format'
+      )
 
-            await expect(
-                signToken(keyPair, { subject: 'user-123', expiresIn: 'invalid' })
-            ).rejects.toThrow('Invalid expiration format');
-        });
+      await expect(
+        signToken(keyPair, { subject: 'user-123', expiresIn: 'invalid' })
+      ).rejects.toThrow('Invalid expiration format')
+    })
 
-        it('should accept expiration at maximum lifetime', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                expiresIn: '364d',
-            });
-            expect(token).toBeString();
-        });
+    it('should accept expiration at maximum lifetime', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        expiresIn: '364d',
+      })
+      expect(token).toBeString()
+    })
 
-        it('should strip reserved claims from custom claims', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                claims: {
-                    iss: 'evil-issuer',
-                    sub: 'evil-subject',
-                    exp: 9999999999,
-                    iat: 0,
-                    jti: 'evil-jti',
-                    role: 'admin',
-                },
-            });
+    it('should strip reserved claims from custom claims', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        claims: {
+          iss: 'evil-issuer',
+          sub: 'evil-subject',
+          exp: 9999999999,
+          iat: 0,
+          jti: 'evil-jti',
+          role: 'admin',
+        },
+      })
 
-            const { payload } = expectDecoded(token);
-            expect(payload.iss).toBe('catalyst-auth');
-            expect(payload.sub).toBe('user-123');
-            expect(payload.jti).not.toBe('evil-jti');
-            expect(payload.role).toBe('admin');
-        });
-    });
+      const { payload } = expectDecoded(token)
+      expect(payload.iss).toBe('catalyst-auth')
+      expect(payload.sub).toBe('user-123')
+      expect(payload.jti).not.toBe('evil-jti')
+      expect(payload.role).toBe('admin')
+    })
+  })
 
-    describe('verifyToken', () => {
-        it('should verify a valid token', async () => {
-            const token = await signToken(keyPair, { subject: 'user-123' });
-            const result = await verifyToken(keyPair, token);
+  describe('verifyToken', () => {
+    it('should verify a valid token', async () => {
+      const token = await signToken(keyPair, { subject: 'user-123' })
+      const result = await verifyToken(keyPair, token)
 
-            const payload = expectValid(result);
-            expect(payload.sub).toBe('user-123');
-        });
+      const payload = expectValid(result)
+      expect(payload.sub).toBe('user-123')
+    })
 
-        it('should return payload with all claims', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                claims: { role: 'admin' },
-            });
+    it('should return payload with all claims', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        claims: { role: 'admin' },
+      })
 
-            const payload = expectValid(await verifyToken(keyPair, token));
-            expect(payload.sub).toBe('user-123');
-            expect(payload.role).toBe('admin');
-            expect(payload.iss).toBe('catalyst-auth');
-            expect(payload.jti).toBeString();
-        });
+      const payload = expectValid(await verifyToken(keyPair, token))
+      expect(payload.sub).toBe('user-123')
+      expect(payload.role).toBe('admin')
+      expect(payload.iss).toBe('catalyst-auth')
+      expect(payload.jti).toBeString()
+    })
 
-        it('should reject token signed with different key', async () => {
-            const token = await signToken(otherKeyPair, { subject: 'user-123' });
-            const result = await verifyToken(keyPair, token);
+    it('should reject token signed with different key', async () => {
+      const token = await signToken(otherKeyPair, { subject: 'user-123' })
+      const result = await verifyToken(keyPair, token)
 
-            const error = expectInvalid(result);
-            expect(error).toBe('Invalid token');
-        });
+      const error = expectInvalid(result)
+      expect(error).toBe('Invalid token')
+    })
 
-        it('should reject expired token', async () => {
-            // Create a token that's already expired by tampering with exp
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                expiresIn: '1h',
-            });
+    it('should reject expired token', async () => {
+      // Create a token that's already expired by tampering with exp
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        expiresIn: '1h',
+      })
 
-            // Tamper with exp to make it expired (set to past timestamp)
-            const parts = token.split('.');
-            const payload = JSON.parse(base64urlDecode(parts[1]));
-            payload.exp = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
-            parts[1] = base64urlEncode(JSON.stringify(payload));
-            const expiredToken = parts.join('.');
+      // Tamper with exp to make it expired (set to past timestamp)
+      const parts = token.split('.')
+      const payload = JSON.parse(base64urlDecode(parts[1]))
+      payload.exp = Math.floor(Date.now() / 1000) - 3600 // 1 hour ago
+      parts[1] = base64urlEncode(JSON.stringify(payload))
+      const expiredToken = parts.join('.')
 
-            // This will fail signature verification (tampered), not expiration
-            // But that's fine - the point is it rejects invalid tokens
-            const result = await verifyToken(keyPair, expiredToken);
-            expectInvalid(result);
-        });
+      // This will fail signature verification (tampered), not expiration
+      // But that's fine - the point is it rejects invalid tokens
+      const result = await verifyToken(keyPair, expiredToken)
+      expectInvalid(result)
+    })
 
-        it('should reject malformed token', async () => {
-            const error = expectInvalid(await verifyToken(keyPair, 'not-a-valid-token'));
-            expect(error).toBe('Invalid token');
-        });
+    it('should reject malformed token', async () => {
+      const error = expectInvalid(await verifyToken(keyPair, 'not-a-valid-token'))
+      expect(error).toBe('Invalid token')
+    })
 
-        it('should reject token with tampered payload', async () => {
-            const token = await signToken(keyPair, { subject: 'user-123' });
+    it('should reject token with tampered payload', async () => {
+      const token = await signToken(keyPair, { subject: 'user-123' })
 
-            const parts = token.split('.');
-            const payload = JSON.parse(base64urlDecode(parts[1]));
-            payload.sub = 'user-456';
-            parts[1] = base64urlEncode(JSON.stringify(payload));
-            const tamperedToken = parts.join('.');
+      const parts = token.split('.')
+      const payload = JSON.parse(base64urlDecode(parts[1]))
+      payload.sub = 'user-456'
+      parts[1] = base64urlEncode(JSON.stringify(payload))
+      const tamperedToken = parts.join('.')
 
-            expectInvalid(await verifyToken(keyPair, tamperedToken));
-        });
+      expectInvalid(await verifyToken(keyPair, tamperedToken))
+    })
 
-        it('should reject empty string token', async () => {
-            const error = expectInvalid(await verifyToken(keyPair, ''));
-            expect(error).toBe('Invalid token');
-        });
+    it('should reject empty string token', async () => {
+      const error = expectInvalid(await verifyToken(keyPair, ''))
+      expect(error).toBe('Invalid token')
+    })
 
-        describe('audience validation', () => {
-            it('should accept token with matching audience', async () => {
-                const token = await signToken(keyPair, {
-                    subject: 'user-123',
-                    audience: 'my-service',
-                });
+    describe('audience validation', () => {
+      it('should accept token with matching audience', async () => {
+        const token = await signToken(keyPair, {
+          subject: 'user-123',
+          audience: 'my-service',
+        })
 
-                const result = await verifyToken(keyPair, token, { audience: 'my-service' });
-                expectValid(result);
-            });
+        const result = await verifyToken(keyPair, token, { audience: 'my-service' })
+        expectValid(result)
+      })
 
-            it('should accept token when audience is in array', async () => {
-                const token = await signToken(keyPair, {
-                    subject: 'user-123',
-                    audience: ['service-a', 'service-b'],
-                });
+      it('should accept token when audience is in array', async () => {
+        const token = await signToken(keyPair, {
+          subject: 'user-123',
+          audience: ['service-a', 'service-b'],
+        })
 
-                const result = await verifyToken(keyPair, token, { audience: 'service-a' });
-                expectValid(result);
-            });
+        const result = await verifyToken(keyPair, token, { audience: 'service-a' })
+        expectValid(result)
+      })
 
-            it('should reject token with wrong audience', async () => {
-                const token = await signToken(keyPair, {
-                    subject: 'user-123',
-                    audience: 'service-a',
-                });
+      it('should reject token with wrong audience', async () => {
+        const token = await signToken(keyPair, {
+          subject: 'user-123',
+          audience: 'service-a',
+        })
 
-                const result = await verifyToken(keyPair, token, { audience: 'service-b' });
-                expectInvalid(result);
-            });
+        const result = await verifyToken(keyPair, token, { audience: 'service-b' })
+        expectInvalid(result)
+      })
 
-            it('should reject token without audience when audience required', async () => {
-                const token = await signToken(keyPair, { subject: 'user-123' });
+      it('should reject token without audience when audience required', async () => {
+        const token = await signToken(keyPair, { subject: 'user-123' })
 
-                const result = await verifyToken(keyPair, token, { audience: 'my-service' });
-                expectInvalid(result);
-            });
+        const result = await verifyToken(keyPair, token, { audience: 'my-service' })
+        expectInvalid(result)
+      })
 
-            it('should accept token with audience when not checking', async () => {
-                const token = await signToken(keyPair, {
-                    subject: 'user-123',
-                    audience: 'any-service',
-                });
+      it('should accept token with audience when not checking', async () => {
+        const token = await signToken(keyPair, {
+          subject: 'user-123',
+          audience: 'any-service',
+        })
 
-                expectValid(await verifyToken(keyPair, token));
-            });
-        });
-    });
+        expectValid(await verifyToken(keyPair, token))
+      })
+    })
+  })
 
-    describe('decodeToken', () => {
-        it('should decode a valid token without verification', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                claims: { role: 'admin' },
-            });
+  describe('decodeToken', () => {
+    it('should decode a valid token without verification', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        claims: { role: 'admin' },
+      })
 
-            const { header, payload } = expectDecoded(token);
-            expect(header.alg).toBe(ALGORITHM);
-            expect(header.kid).toBe(keyPair.kid);
-            expect(payload.sub).toBe('user-123');
-            expect(payload.role).toBe('admin');
-        });
+      const { header, payload } = expectDecoded(token)
+      expect(header.alg).toBe(ALGORITHM)
+      expect(header.kid).toBe(keyPair.kid)
+      expect(payload.sub).toBe('user-123')
+      expect(payload.role).toBe('admin')
+    })
 
-        it('should decode token signed with different key', async () => {
-            const token = await signToken(otherKeyPair, { subject: 'user-123' });
+    it('should decode token signed with different key', async () => {
+      const token = await signToken(otherKeyPair, { subject: 'user-123' })
 
-            const { header, payload } = expectDecoded(token);
-            expect(payload.sub).toBe('user-123');
-            expect(header.kid).toBe(otherKeyPair.kid);
-        });
+      const { header, payload } = expectDecoded(token)
+      expect(payload.sub).toBe('user-123')
+      expect(header.kid).toBe(otherKeyPair.kid)
+    })
 
-        it('should return null for invalid tokens', () => {
-            expect(decodeToken('not-a-valid-token')).toBeNull();
-            expect(decodeToken('')).toBeNull();
-            expect(decodeToken('invalid.base64.here!!!')).toBeNull();
-            expect(decodeToken('only.two')).toBeNull();
-            expect(decodeToken('one')).toBeNull();
-            expect(decodeToken('a.b.c.d')).toBeNull();
-        });
-    });
+    it('should return null for invalid tokens', () => {
+      expect(decodeToken('not-a-valid-token')).toBeNull()
+      expect(decodeToken('')).toBeNull()
+      expect(decodeToken('invalid.base64.here!!!')).toBeNull()
+      expect(decodeToken('only.two')).toBeNull()
+      expect(decodeToken('one')).toBeNull()
+      expect(decodeToken('a.b.c.d')).toBeNull()
+    })
+  })
 
-    describe('edge cases', () => {
-        it('should handle unicode in claims', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                claims: { name: '日本語テスト', emoji: '🔐🎉' },
-            });
+  describe('edge cases', () => {
+    it('should handle unicode in claims', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        claims: { name: '日本語テスト', emoji: '🔐🎉', custom: 'custom' },
+      })
 
-            const payload = expectValid(await verifyToken(keyPair, token));
-            expect(payload.name).toBe('日本語テスト');
-            expect(payload.emoji).toBe('🔐🎉');
-        });
+      const payload = expectValid(await verifyToken(keyPair, token))
+      expect(payload.name).toBe('日本語テスト')
+      expect(payload.emoji).toBe('🔐🎉')
+    })
 
-        it('should handle nested objects in claims', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                claims: { metadata: { nested: { deep: 'value' } } },
-            });
+    it('should handle nested objects in claims', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        claims: { metadata: { nested: { deep: 'value' } } },
+      })
 
-            const payload = expectValid(await verifyToken(keyPair, token));
-            expect(payload.metadata).toEqual({ nested: { deep: 'value' } });
-        });
+      const payload = expectValid(await verifyToken(keyPair, token))
+      expect(payload.metadata).toEqual({ nested: { deep: 'value' } })
+    })
 
-        it('should handle empty claims object', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                claims: {},
-            });
+    it('should handle empty claims object', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        claims: {},
+      })
 
-            expectValid(await verifyToken(keyPair, token));
-        });
+      expectValid(await verifyToken(keyPair, token))
+    })
 
-        it('should handle very long subject', async () => {
-            const longSubject = 'x'.repeat(1000);
-            const token = await signToken(keyPair, { subject: longSubject });
+    it('should handle very long subject', async () => {
+      const longSubject = 'x'.repeat(1000)
+      const token = await signToken(keyPair, { subject: longSubject })
 
-            const payload = expectValid(await verifyToken(keyPair, token));
-            expect(payload.sub).toBe(longSubject);
-        });
-    });
-});
+      const payload = expectValid(await verifyToken(keyPair, token))
+      expect(payload.sub).toBe(longSubject)
+    })
+  })
+})

--- a/packages/auth/tests/permission.test.ts
+++ b/packages/auth/tests/permission.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import {
+  type CatalystPrincipal,
+  type CatalystResource,
+  Permission,
+  PermissionService,
+  isSecretValid,
+} from '../src'
+import { GenericContainer, Wait, type StartedTestContainer } from 'testcontainers'
+import path from 'path'
+
+describe('Validate secrets timing safe', () => {
+  it('should validate secrets safely with around same time duration', () => {
+    expect(isSecretValid('hello', 'hello')).toBe(true)
+    expect(isSecretValid('hello', 'incoad')).toBe(false)
+    expect(isSecretValid('hello', 'thisisaverylongsecretthatisnotthesameashello')).toBe(false)
+    expect(isSecretValid('invalid', 'secret')).toBe(false)
+    expect(isSecretValid('verryyyylong', 'secret')).toBe(false)
+    expect(isSecretValid('shor', 'secret')).toBe(false)
+  })
+})
+
+describe('Permission', () => {
+  let cerbosContainer: StartedTestContainer
+  let permissionService: PermissionService
+  const cerbosImage = 'ghcr.io/cerbos/cerbos:0.50.0'
+  const repoRoot = path.resolve(__dirname, '../../../')
+
+  beforeAll(async () => {
+    // pull cerbos container
+    console.log('Pulling cerbos image...')
+    const pullResult = Bun.spawnSync(['docker', 'pull', cerbosImage], {
+      stdout: 'inherit',
+      stderr: 'inherit',
+    })
+    if (pullResult.exitCode !== 0) {
+      throw new Error(`Failed to pull cerbos image: ${pullResult.exitCode} ${pullResult.stderr}`)
+    }
+
+    // start cerbos container
+    console.log('Starting cerbos container...')
+    cerbosContainer = await new GenericContainer(cerbosImage)
+      .withExposedPorts(3592, 3593)
+      .withName('cerbos-pdp-test')
+      .withBindMounts([
+        {
+          source: path.resolve(repoRoot, 'packages/auth/cerbos/policies'),
+          target: '/policies',
+        },
+      ])
+      .withEnvironment({
+        CERBOS_NO_TELEMETRY: '1',
+      })
+      .withWaitStrategy(Wait.forLogMessage('Starting gRPC server'))
+      .start()
+
+    const grpcPort = cerbosContainer.getMappedPort(3593)
+    const url = `localhost:${grpcPort}`
+    console.log('Cerbos gRPC URL:', url)
+    permissionService = new PermissionService(url)
+  })
+
+  afterAll(async () => {
+    await cerbosContainer?.stop()
+  })
+
+  it('should allow admin to create peers', async () => {
+    const principal: CatalystPrincipal = {
+      id: 'admin_user',
+      roles: ['admin'],
+      attr: { orgId: 'orgId' },
+    }
+    const resource: CatalystResource = { kind: 'peer', id: 'peer-1', attr: { network: 'internal' } }
+    const allowed = await permissionService.isAuthorized(principal, resource, Permission.PeerCreate)
+    expect(allowed).toBe(true)
+  })
+
+  it('should allow admin to create complex resource peers', async () => {
+    expect(true).toBe(true) // TODO: Remove this once the test is implemented
+    const principal: CatalystPrincipal = {
+      id: 'user-1',
+      roles: ['data_custodian'],
+      policyVersion: 'default',
+      scope: 'data_custodian',
+    }
+    const resource: CatalystResource = {
+      kind: 'route',
+      id: 'route-1',
+      attr: {
+        peerName: 'peer-1',
+        protocol: 'http',
+        nodePath: ['node-1', 'node-2'],
+        region: 'us-east-1',
+        tags: ['tag-1', 'tag-2'],
+      },
+    }
+    const allowed = await permissionService.isAuthorized(
+      principal,
+      resource,
+      Permission.RouteCreate
+    )
+    expect(allowed).toBe(true)
+  })
+
+  it('should deny standard user from creating peers', async () => {
+    const principal: CatalystPrincipal = { id: 'user-1', roles: ['user'] }
+    const resource: CatalystResource = { kind: 'peer', id: 'peer-1', attr: { network: 'internal' } }
+    const allowed = await permissionService.isAuthorized(principal, resource, Permission.PeerCreate)
+    expect(allowed).toBe(false)
+  })
+
+  it('should allow user to revoke their own token', async () => {
+    const principal: CatalystPrincipal = { id: 'alice', roles: ['user'] }
+    const resource: CatalystResource = { kind: 'token', id: 'token-1', attr: { ownerId: 'alice' } }
+    const allowed = await permissionService.isAuthorized(
+      principal,
+      resource,
+      Permission.TokenRevoke
+    )
+    expect(allowed).toBe(false)
+  })
+
+  it('should deny user from revoking others tokens', async () => {
+    const principal: CatalystPrincipal = { id: 'user-1', roles: ['user'] }
+    const resource: CatalystResource = { kind: 'token', id: 'token-2' }
+    const allowed = await permissionService.isAuthorized(
+      principal,
+      resource,
+      Permission.TokenRevoke
+    )
+    expect(allowed).toBe(false)
+  })
+})

--- a/packages/auth/tests/rpc-progressive.test.ts
+++ b/packages/auth/tests/rpc-progressive.test.ts
@@ -2,80 +2,79 @@ import { describe, it, expect, beforeAll } from 'bun:test'
 import { AuthRpcServer } from '../src/rpc/server.js'
 import { EphemeralKeyManager } from '../src/key-manager/ephemeral.js'
 import { InMemoryRevocationStore } from '../src/revocation.js'
-import { Permission, Role } from '../src/permissions.js'
 
 describe('Auth Progressive API', () => {
-    let keyManager: EphemeralKeyManager
-    let rpcServer: AuthRpcServer
-    let adminToken: string
-    let userToken: string
+  let keyManager: EphemeralKeyManager
+  let rpcServer: AuthRpcServer
+  let adminToken: string
+  let userToken: string
 
-    beforeAll(async () => {
-        keyManager = new EphemeralKeyManager()
-        await keyManager.initialize()
+  beforeAll(async () => {
+    keyManager = new EphemeralKeyManager()
+    await keyManager.initialize()
 
-        // Sign tokens for testing
-        adminToken = await keyManager.sign({
-            subject: 'admin-user',
-            claims: { roles: ['admin'] },
-        })
-
-        userToken = await keyManager.sign({
-            subject: 'regular-user',
-            claims: { roles: ['user'] },
-        })
-
-        rpcServer = new AuthRpcServer(keyManager, new InMemoryRevocationStore())
+    // Sign tokens for testing
+    adminToken = await keyManager.sign({
+      subject: 'admin-user',
+      claims: { roles: ['admin'] },
     })
 
-    describe('admin sub-api', () => {
-        it('should grant access to admin handlers with valid admin token', async () => {
-            const handlers = await rpcServer.admin(adminToken)
-            expect(handlers).not.toHaveProperty('error')
-            const adminHandlers = handlers as any
-            expect(adminHandlers.createToken).toBeDefined()
-            expect(adminHandlers.revokeToken).toBeDefined()
-        })
-
-        it('should deny access to admin handlers with non-admin token', async () => {
-            const result = await rpcServer.admin(userToken)
-            expect(result).toHaveProperty('error')
-            expect((result as any).error).toContain('admin role required')
-        })
-
-        it('should deny access with invalid token', async () => {
-            const result = await rpcServer.admin('invalid-token')
-            expect(result).toHaveProperty('error')
-            expect((result as any).error).toBe('Invalid token')
-        })
-
-        it('should allow creating a token via admin handlers', async () => {
-            const handlers = (await rpcServer.admin(adminToken)) as any
-            const newToken = await handlers.createToken({ role: 'peer', name: 'new-peer' })
-            expect(newToken).toBeString()
-        })
+    userToken = await keyManager.sign({
+      subject: 'regular-user',
+      claims: { roles: ['user'] },
     })
 
-    describe('validation sub-api', () => {
-        it('should grant access to validation handlers with any valid token', async () => {
-            const result = await rpcServer.validation(userToken)
-            expect(result).not.toHaveProperty('error')
-            const handlers = result as any
-            expect(handlers.validate).toBeDefined()
-            expect(handlers.getJWKS).toBeDefined()
-        })
+    rpcServer = new AuthRpcServer(keyManager, new InMemoryRevocationStore())
+  })
 
-        it('should deny access with invalid token', async () => {
-            const result = await rpcServer.validation('invalid-token')
-            expect(result).toHaveProperty('error')
-            expect((result as any).error).toBe('Invalid token')
-        })
-
-        it('should allow validating a token via validation handlers', async () => {
-            const handlers = (await rpcServer.validation(adminToken)) as any
-            const validationResult = await handlers.validate({ token: userToken })
-            expect(validationResult.valid).toBe(true)
-            expect(validationResult.payload.sub).toBe('regular-user')
-        })
+  describe('admin sub-api', () => {
+    it('should grant access to admin handlers with valid admin token', async () => {
+      const handlers = await rpcServer.admin(adminToken)
+      expect(handlers).not.toHaveProperty('error')
+      const adminHandlers = handlers as any
+      expect(adminHandlers.createToken).toBeDefined()
+      expect(adminHandlers.revokeToken).toBeDefined()
     })
+
+    it('should deny access to admin handlers with non-admin token', async () => {
+      const result = await rpcServer.admin(userToken)
+      expect(result).toHaveProperty('error')
+      expect((result as any).error).toContain('admin role required')
+    })
+
+    it('should deny access with invalid token', async () => {
+      const result = await rpcServer.admin('invalid-token')
+      expect(result).toHaveProperty('error')
+      expect((result as any).error).toBe('Invalid token')
+    })
+
+    it('should allow creating a token via admin handlers', async () => {
+      const handlers = (await rpcServer.admin(adminToken)) as any
+      const newToken = await handlers.createToken({ role: 'peer', name: 'new-peer' })
+      expect(newToken).toBeString()
+    })
+  })
+
+  describe('validation sub-api', () => {
+    it('should grant access to validation handlers with any valid token', async () => {
+      const result = await rpcServer.validation(userToken)
+      expect(result).not.toHaveProperty('error')
+      const handlers = result as any
+      expect(handlers.validate).toBeDefined()
+      expect(handlers.getJWKS).toBeDefined()
+    })
+
+    it('should deny access with invalid token', async () => {
+      const result = await rpcServer.validation('invalid-token')
+      expect(result).toHaveProperty('error')
+      expect((result as any).error).toBe('Invalid token')
+    })
+
+    it('should allow validating a token via validation handlers', async () => {
+      const handlers = (await rpcServer.validation(adminToken)) as any
+      const validationResult = await handlers.validate({ token: userToken })
+      expect(validationResult.valid).toBe(true)
+      expect(validationResult.payload.sub).toBe('regular-user')
+    })
+  })
 })

--- a/packages/auth/tests/system-token.test.ts
+++ b/packages/auth/tests/system-token.test.ts
@@ -1,57 +1,58 @@
 import { describe, it, expect, beforeAll } from 'bun:test'
 import { decodeToken } from '../src/jwt.js'
 import { Permission } from '../src/permissions.js'
+import type { JWTPayload } from 'jose'
 
 describe('System Admin Token', () => {
-    let systemToken: string
+  let systemToken: string
 
-    beforeAll(async () => {
-        // Ensure we don't try to write to disk in this environment
-        process.env.KEY_MANAGER_TYPE = 'ephemeral'
+  beforeAll(async () => {
+    // Ensure we don't try to write to disk in this environment
+    process.env.KEY_MANAGER_TYPE = 'ephemeral'
 
-        // Import and start server to trigger minting
-        const { startServer } = await import('../src/server.js')
-        const result = await startServer()
-        systemToken = result.systemToken!
-    })
+    // Import and start server to trigger minting
+    const { startServer } = await import('../src/server.js')
+    const result = await startServer()
+    systemToken = result.systemToken!
+  })
 
-    it('should be minted and available after startup', () => {
-        expect(systemToken).toBeDefined()
-        expect(typeof systemToken).toBe('string')
-        expect(systemToken.length).toBeGreaterThan(10)
-    })
+  it('should be minted and available after startup', () => {
+    expect(systemToken).toBeDefined()
+    expect(typeof systemToken).toBe('string')
+    expect(systemToken.length).toBeGreaterThan(10)
+  })
 
-    it('should contain expected administrative claims', () => {
-        const result = decodeToken(systemToken)
-        expect(result).toBeDefined()
-        const payload = result?.payload as any
-        expect(payload).toBeDefined()
+  it('should contain expected administrative claims', () => {
+    const result = decodeToken(systemToken)
+    expect(result).toBeDefined()
+    const payload = result?.payload as JWTPayload
+    expect(payload).toBeDefined()
 
-        expect(payload.sub).toBe('system-admin')
-        expect(payload.role).toBe('admin')
-        expect(Array.isArray(payload.permissions)).toBe(true)
+    expect(payload.sub).toBe('system-admin')
+    expect(payload.role).toBe('admin')
+    expect(Array.isArray(payload.permissions)).toBe(true)
 
-        const permissions = payload.permissions
+    const permissions = payload.permissions
 
-        // Comprehensive list of expected discrete permissions
-        const expectedPermissions = [
-            Permission.TokenCreate,
-            Permission.TokenRevoke,
-            Permission.TokenList,
-            Permission.PeerCreate,
-            Permission.PeerUpdate,
-            Permission.PeerDelete,
-            Permission.RouteCreate,
-            Permission.RouteDelete,
-            Permission.IbgpConnect,
-            Permission.IbgpDisconnect,
-            Permission.IbgpUpdate,
-        ]
+    // Comprehensive list of expected discrete permissions
+    const expectedPermissions = [
+      Permission.TokenCreate,
+      Permission.TokenRevoke,
+      Permission.TokenList,
+      Permission.PeerCreate,
+      Permission.PeerUpdate,
+      Permission.PeerDelete,
+      Permission.RouteCreate,
+      Permission.RouteDelete,
+      Permission.IbgpConnect,
+      Permission.IbgpDisconnect,
+      Permission.IbgpUpdate,
+    ]
 
-        for (const perm of expectedPermissions) {
-            expect(permissions).toContain(perm)
-        }
+    for (const perm of expectedPermissions) {
+      expect(permissions).toContain(perm)
+    }
 
-        expect(permissions).toHaveLength(expectedPermissions.length)
-    })
+    expect(permissions).toHaveLength(expectedPermissions.length)
+  })
 })

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -8,9 +8,9 @@
     "skipLibCheck": true,
     "declaration": true,
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": ".",
     "types": ["bun"]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": ["src", "tests"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
# Add Cerbos for Role-Based Access Control

### TL;DR

Integrates Cerbos for policy-based authorization, adding fine-grained access control for resources like peers, routes, tokens, and iBGP connections.

### What changed?

- Added Cerbos GRPC client for policy-based authorization
- Created policy definitions for various resources (peer, route, token, ibgp)
- Added policy test files to validate authorization rules
- Implemented `PermissionService` class for authorization checks
- Enhanced JWT claims schema to support roles and attributes
- Updated RPC server to support authorization checks
- Added unit tests for permission validation

### How to test?

1. Run the policy tests:
   ```
   cd packages/auth
   bun run policy:test
   ```

2. Run the permission integration tests:
   ```
   cd packages/auth
   bun test tests/permission.test.ts
   ```

3. Verify that the existing tests still pass:
   ```
   cd packages/auth
   bun test
   ```

### Why make this change?

This change implements a more robust and maintainable authorization system using Cerbos, which provides:

1. Declarative policy definitions in YAML
2. Separation of authorization logic from application code
3. Fine-grained access control based on resource types and attributes
4. Testable policies with built-in validation
5. Centralized policy management for consistent authorization across services

The implementation follows the principle of least privilege, ensuring users only have access to resources and actions they need based on their roles.