### PR TITLE
fix: bring auth and orch up to date with policy mngmt movet to auth

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -73,6 +73,7 @@
         "catalyst": "./src/index.ts",
       },
       "dependencies": {
+        "@catalyst/orchestrator": "workspace:*",
         "capnweb": "catalog:",
         "chalk": "^5.3.0",
         "commander": "catalog:",
@@ -933,7 +934,7 @@
 
     "diff-sequences": ["diff-sequences@29.6.3", "", {}, "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q=="],
 
-    "docker-compose": ["docker-compose@1.3.0", "", { "dependencies": { "yaml": "^2.2.2" } }, "sha512-7Gevk/5eGD50+eMD+XDnFnOrruFkL0kSd7jEG4cjmqweDSUhB7i0g8is/nBdVpl+Bx338SqIB2GLKm32M+Vs6g=="],
+    "docker-compose": ["docker-compose@1.3.1", "", { "dependencies": { "yaml": "^2.2.2" } }, "sha512-rF0wH69G3CCcmkN9J1RVMQBaKe8o77LT/3XmqcLIltWWVxcWAzp2TnO7wS3n/umZHN3/EVrlT3exSBMal+Ou1w=="],
 
     "docker-modem": ["docker-modem@5.0.6", "", { "dependencies": { "debug": "^4.1.1", "readable-stream": "^3.5.0", "split-ca": "^1.0.1", "ssh2": "^1.15.0" } }, "sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ=="],
 
@@ -1445,7 +1446,7 @@
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
-    "undici": ["undici@7.18.2", "", {}, "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw=="],
+    "undici": ["undici@7.19.0", "", {}, "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -1515,23 +1516,15 @@
 
     "@catalyst/cli/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
-    "@catalyst/cli/testcontainers": ["testcontainers@11.11.0", "", { "dependencies": { "@balena/dockerignore": "^1.0.2", "@types/dockerode": "^3.3.47", "archiver": "^7.0.1", "async-lock": "^1.4.1", "byline": "^5.0.0", "debug": "^4.4.3", "docker-compose": "^1.3.0", "dockerode": "^4.0.9", "get-port": "^7.1.0", "proper-lockfile": "^4.1.2", "properties-reader": "^2.3.0", "ssh-remote-port-forward": "^1.0.4", "tar-fs": "^3.1.1", "tmp": "^0.2.5", "undici": "^7.16.0" } }, "sha512-nKTJn3n/gkyGg/3SVkOwX+isPOGSHlfI+CWMobSmvQrsj7YW01aWvl2pYIfV4LMd+C8or783yYrzKSK2JlP+Qw=="],
-
-    "@catalyst/examples/testcontainers": ["testcontainers@11.11.0", "", { "dependencies": { "@balena/dockerignore": "^1.0.2", "@types/dockerode": "^3.3.47", "archiver": "^7.0.1", "async-lock": "^1.4.1", "byline": "^5.0.0", "debug": "^4.4.3", "docker-compose": "^1.3.0", "dockerode": "^4.0.9", "get-port": "^7.1.0", "proper-lockfile": "^4.1.2", "properties-reader": "^2.3.0", "ssh-remote-port-forward": "^1.0.4", "tar-fs": "^3.1.1", "tmp": "^0.2.5", "undici": "^7.16.0" } }, "sha512-nKTJn3n/gkyGg/3SVkOwX+isPOGSHlfI+CWMobSmvQrsj7YW01aWvl2pYIfV4LMd+C8or783yYrzKSK2JlP+Qw=="],
-
     "@catalyst/examples/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
 
     "@catalyst/gateway/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
-
-    "@catalyst/gateway/testcontainers": ["testcontainers@11.11.0", "", { "dependencies": { "@balena/dockerignore": "^1.0.2", "@types/dockerode": "^3.3.47", "archiver": "^7.0.1", "async-lock": "^1.4.1", "byline": "^5.0.0", "debug": "^4.4.3", "docker-compose": "^1.3.0", "dockerode": "^4.0.9", "get-port": "^7.1.0", "proper-lockfile": "^4.1.2", "properties-reader": "^2.3.0", "ssh-remote-port-forward": "^1.0.4", "tar-fs": "^3.1.1", "tmp": "^0.2.5", "undici": "^7.16.0" } }, "sha512-nKTJn3n/gkyGg/3SVkOwX+isPOGSHlfI+CWMobSmvQrsj7YW01aWvl2pYIfV4LMd+C8or783yYrzKSK2JlP+Qw=="],
 
     "@catalyst/gateway/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
 
     "@catalyst/node/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
     "@catalyst/node/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
-
-    "@catalyst/orchestrator/testcontainers": ["testcontainers@11.11.0", "", { "dependencies": { "@balena/dockerignore": "^1.0.2", "@types/dockerode": "^3.3.47", "archiver": "^7.0.1", "async-lock": "^1.4.1", "byline": "^5.0.0", "debug": "^4.4.3", "docker-compose": "^1.3.0", "dockerode": "^4.0.9", "get-port": "^7.1.0", "proper-lockfile": "^4.1.2", "properties-reader": "^2.3.0", "ssh-remote-port-forward": "^1.0.4", "tar-fs": "^3.1.1", "tmp": "^0.2.5", "undici": "^7.16.0" } }, "sha512-nKTJn3n/gkyGg/3SVkOwX+isPOGSHlfI+CWMobSmvQrsj7YW01aWvl2pYIfV4LMd+C8or783yYrzKSK2JlP+Qw=="],
 
     "@catalyst/orchestrator/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
 
@@ -1578,8 +1571,6 @@
     "@vitest/coverage-v8/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
 
     "@vitest/mocker/@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
-
-    "@whatwg-node/node-fetch/@fastify/busboy": ["@fastify/busboy@3.2.0", "", {}, "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="],
 
     "archiver-utils/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
@@ -1667,14 +1658,6 @@
 
     "@catalyst/cli/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
-    "@catalyst/cli/testcontainers/docker-compose": ["docker-compose@1.3.1", "", { "dependencies": { "yaml": "^2.2.2" } }, "sha512-rF0wH69G3CCcmkN9J1RVMQBaKe8o77LT/3XmqcLIltWWVxcWAzp2TnO7wS3n/umZHN3/EVrlT3exSBMal+Ou1w=="],
-
-    "@catalyst/cli/testcontainers/undici": ["undici@7.19.0", "", {}, "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ=="],
-
-    "@catalyst/examples/testcontainers/docker-compose": ["docker-compose@1.3.1", "", { "dependencies": { "yaml": "^2.2.2" } }, "sha512-rF0wH69G3CCcmkN9J1RVMQBaKe8o77LT/3XmqcLIltWWVxcWAzp2TnO7wS3n/umZHN3/EVrlT3exSBMal+Ou1w=="],
-
-    "@catalyst/examples/testcontainers/undici": ["undici@7.19.0", "", {}, "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ=="],
-
     "@catalyst/examples/vitest/@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
 
     "@catalyst/examples/vitest/@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
@@ -1690,10 +1673,6 @@
     "@catalyst/examples/vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "@catalyst/gateway/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "@catalyst/gateway/testcontainers/docker-compose": ["docker-compose@1.3.1", "", { "dependencies": { "yaml": "^2.2.2" } }, "sha512-rF0wH69G3CCcmkN9J1RVMQBaKe8o77LT/3XmqcLIltWWVxcWAzp2TnO7wS3n/umZHN3/EVrlT3exSBMal+Ou1w=="],
-
-    "@catalyst/gateway/testcontainers/undici": ["undici@7.19.0", "", {}, "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ=="],
 
     "@catalyst/gateway/vitest/@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
 
@@ -1724,10 +1703,6 @@
     "@catalyst/node/vitest/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "@catalyst/node/vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
-
-    "@catalyst/orchestrator/testcontainers/docker-compose": ["docker-compose@1.3.1", "", { "dependencies": { "yaml": "^2.2.2" } }, "sha512-rF0wH69G3CCcmkN9J1RVMQBaKe8o77LT/3XmqcLIltWWVxcWAzp2TnO7wS3n/umZHN3/EVrlT3exSBMal+Ou1w=="],
-
-    "@catalyst/orchestrator/testcontainers/undici": ["undici@7.19.0", "", {}, "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ=="],
 
     "@catalyst/orchestrator/vitest/@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
 

--- a/packages/auth/Dockerfile
+++ b/packages/auth/Dockerfile
@@ -11,13 +11,15 @@ RUN cd /temp/dev && bun install
 # Install with --production (exclude devDependencies)
 RUN mkdir -p /temp/prod
 COPY package.json /temp/prod/
-RUN cd /temp/prod && bun install --production
+# cant use production flag becuase of frozen-lockfile error: for now just omit dev dependencies
+# manually but let lockfile changes
+RUN cd /temp/prod && bun install --omit=dev --ignore-scripts
 
 # Copy node_modules from temp directory
 # Then copy all (non-ignored) project files into the image
 FROM base AS prerelease
 COPY --from=install /temp/dev/node_modules node_modules
-COPY . .
+COPY packages/auth packages/auth
 
 # [optional] tests & build
 ENV NODE_ENV=production
@@ -26,9 +28,9 @@ ENV NODE_ENV=production
 # copy production dependencies and source code into final image
 FROM base AS release
 COPY --from=install /temp/prod/node_modules node_modules
-COPY --from=prerelease /app/src src
-COPY --from=prerelease /app/package.json .
-COPY --from=prerelease /app/tsconfig.json .
+COPY --from=prerelease /app/packages/auth/src src
+COPY --from=prerelease /app/packages/auth/package.json .
+COPY --from=prerelease /app/packages/auth/tsconfig.json .
 
 # run the app
 USER bun

--- a/packages/auth/src/permissions.ts
+++ b/packages/auth/src/permissions.ts
@@ -5,121 +5,120 @@ import { timingSafeEqual } from 'node:crypto'
  * Aligned with orchestrator requirements and new token management.
  */
 export enum Permission {
-    // Token management
-    TokenCreate = 'token:create',
-    TokenRevoke = 'token:revoke',
-    TokenList = 'token:list',
+  // Token management
+  TokenCreate = 'token:create',
+  TokenRevoke = 'token:revoke',
+  TokenList = 'token:list',
 
-    // Peer management
-    PeerCreate = 'peer:create',
-    PeerUpdate = 'peer:update',
-    PeerDelete = 'peer:delete',
+  // Peer management
+  PeerCreate = 'peer:create',
+  PeerUpdate = 'peer:update',
+  PeerDelete = 'peer:delete',
 
-    // Route management
-    RouteCreate = 'route:create',
-    RouteDelete = 'route:delete',
+  // Route management
+  RouteCreate = 'route:create',
+  RouteDelete = 'route:delete',
 
-    // Internal protocol (iBGP)
-    IbgpConnect = 'ibgp:connect',
-    IbgpDisconnect = 'ibgp:disconnect',
-    IbgpUpdate = 'ibgp:update',
+  // Internal protocol (iBGP)
+  IbgpConnect = 'ibgp:connect',
+  IbgpDisconnect = 'ibgp:disconnect',
+  IbgpUpdate = 'ibgp:update',
 
-    // Administrative
-    Admin = '*',
+  // Administrative
+  Admin = '*',
 }
 
 /**
  * Available roles in the system.
  */
-export type Role = 'admin' | 'peer' | 'peer_custodian' | 'data_custodian' | 'user';
+export type Role = 'admin' | 'peer' | 'peer_custodian' | 'data_custodian' | 'user'
 
 /**
  * Mapping between roles and their explicit permissions.
  */
 export const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
-    admin: [
-        Permission.TokenCreate,
-        Permission.TokenRevoke,
-        Permission.TokenList,
-        Permission.PeerCreate,
-        Permission.PeerUpdate,
-        Permission.PeerDelete,
-        Permission.RouteCreate,
-        Permission.RouteDelete,
-        Permission.IbgpConnect,
-        Permission.IbgpDisconnect,
-        Permission.IbgpUpdate,
-        Permission.Admin,
-    ],
-    peer: [
-        Permission.IbgpConnect,
-        Permission.IbgpDisconnect,
-        Permission.IbgpUpdate,
-    ],
-    peer_custodian: [
-        Permission.PeerCreate,
-        Permission.PeerUpdate,
-        Permission.PeerDelete,
-    ],
-    data_custodian: [
-        Permission.RouteCreate,
-        Permission.RouteDelete,
-    ],
-    user: [],
-};
+  admin: [
+    Permission.TokenCreate,
+    Permission.TokenRevoke,
+    Permission.TokenList,
+    Permission.PeerCreate,
+    Permission.PeerUpdate,
+    Permission.PeerDelete,
+    Permission.RouteCreate,
+    Permission.RouteDelete,
+    Permission.IbgpConnect,
+    Permission.IbgpDisconnect,
+    Permission.IbgpUpdate,
+    Permission.Admin,
+  ],
+  peer: [Permission.IbgpConnect, Permission.IbgpDisconnect, Permission.IbgpUpdate],
+  peer_custodian: [
+    Permission.PeerCreate,
+    Permission.PeerUpdate,
+    Permission.PeerDelete,
+    Permission.IbgpConnect,
+    Permission.IbgpDisconnect,
+    Permission.IbgpUpdate,
+  ],
+  data_custodian: [Permission.RouteCreate, Permission.RouteDelete],
+  user: [],
+}
 
 /**
  * Resolves a list of permissions for a given set of roles.
  */
 export function getPermissionsForRoles(roles: string[]): Permission[] {
-    const permissions = new Set<Permission>();
-    for (const role of roles) {
-        const rolePermissions = ROLE_PERMISSIONS[role as Role];
-        if (rolePermissions) {
-            rolePermissions.forEach((p) => permissions.add(p));
-        } else {
-            // If it's not a known role, it might be a direct permission string
-            if (Object.values(Permission).includes(role as Permission)) {
-                permissions.add(role as Permission);
-            }
-        }
+  const permissions = new Set<Permission>()
+  for (const role of roles) {
+    const rolePermissions = ROLE_PERMISSIONS[role as Role]
+    if (rolePermissions) {
+      rolePermissions.forEach((p) => permissions.add(p))
+    } else {
+      // If it's not a known role, it might be a direct permission string
+      if (Object.values(Permission).includes(role as Permission)) {
+        permissions.add(role as Permission)
+      }
     }
-    return Array.from(permissions);
+  }
+  return Array.from(permissions)
 }
 
 /**
  * Checks if the given roles or permissions grant the required permission.
  */
-export function hasPermission(rolesOrPermissions: string[], required: Permission | string): boolean {
-    // All effective permissions for these roles
-    const effectivePermissions = getPermissionsForRoles(rolesOrPermissions);
+export function hasPermission(
+  rolesOrPermissions: string[],
+  required: Permission | string
+): boolean {
+  // All effective permissions for these roles
+  const effectivePermissions = getPermissionsForRoles(rolesOrPermissions)
 
-    // Admin always has permission
-    if (effectivePermissions.includes(Permission.Admin)) {
-        return true;
-    }
+  // Admin always has permission
+  if (effectivePermissions.includes(Permission.Admin)) {
+    return true
+  }
 
-    // Check for direct match
-    return effectivePermissions.includes(required as Permission);
+  // Check for direct match
+  return effectivePermissions.includes(required as Permission)
 }
 
 /**
  * Timing-safe secret comparison.
  */
 export function isSecretValid(provided: string, expected: string): boolean {
-    const providedBuf = Buffer.from(provided)
-    const expectedBuf = Buffer.from(expected)
+  const providedBuf = Buffer.from(provided)
+  const expectedBuf = Buffer.from(expected)
 
-    if (providedBuf.length !== expectedBuf.length) {
-        const maxLen = Math.max(providedBuf.length, expectedBuf.length)
-        const paddedProvided = Buffer.alloc(maxLen)
-        const paddedExpected = Buffer.alloc(maxLen)
-        providedBuf.copy(paddedProvided)
-        expectedBuf.copy(paddedExpected)
+  if (providedBuf.length !== expectedBuf.length) {
+    const maxLen = Math.max(providedBuf.length, expectedBuf.length)
+    const paddedProvided = Buffer.alloc(maxLen)
+    const paddedExpected = Buffer.alloc(maxLen)
+    providedBuf.copy(paddedProvided)
+    expectedBuf.copy(paddedExpected)
 
-        timingSafeEqual(paddedProvided, paddedExpected)
-        return false
-    }
+    timingSafeEqual(paddedProvided, paddedExpected)
+    return false
+  }
 
-    return timingSafeEqual(providedBuf, expectedBuf)
+  return timingSafeEqual(providedBuf, expectedBuf)
 }

--- a/packages/auth/tests/rpc-progressive.test.ts
+++ b/packages/auth/tests/rpc-progressive.test.ts
@@ -2,80 +2,79 @@ import { describe, it, expect, beforeAll } from 'bun:test'
 import { AuthRpcServer } from '../src/rpc/server.js'
 import { EphemeralKeyManager } from '../src/key-manager/ephemeral.js'
 import { InMemoryRevocationStore } from '../src/revocation.js'
-import { Permission, Role } from '../src/permissions.js'
 
 describe('Auth Progressive API', () => {
-    let keyManager: EphemeralKeyManager
-    let rpcServer: AuthRpcServer
-    let adminToken: string
-    let userToken: string
+  let keyManager: EphemeralKeyManager
+  let rpcServer: AuthRpcServer
+  let adminToken: string
+  let userToken: string
 
-    beforeAll(async () => {
-        keyManager = new EphemeralKeyManager()
-        await keyManager.initialize()
+  beforeAll(async () => {
+    keyManager = new EphemeralKeyManager()
+    await keyManager.initialize()
 
-        // Sign tokens for testing
-        adminToken = await keyManager.sign({
-            subject: 'admin-user',
-            claims: { roles: ['admin'] },
-        })
-
-        userToken = await keyManager.sign({
-            subject: 'regular-user',
-            claims: { roles: ['user'] },
-        })
-
-        rpcServer = new AuthRpcServer(keyManager, new InMemoryRevocationStore())
+    // Sign tokens for testing
+    adminToken = await keyManager.sign({
+      subject: 'admin-user',
+      claims: { roles: ['admin'] },
     })
 
-    describe('admin sub-api', () => {
-        it('should grant access to admin handlers with valid admin token', async () => {
-            const handlers = await rpcServer.admin(adminToken)
-            expect(handlers).not.toHaveProperty('error')
-            const adminHandlers = handlers as any
-            expect(adminHandlers.createToken).toBeDefined()
-            expect(adminHandlers.revokeToken).toBeDefined()
-        })
-
-        it('should deny access to admin handlers with non-admin token', async () => {
-            const result = await rpcServer.admin(userToken)
-            expect(result).toHaveProperty('error')
-            expect((result as any).error).toContain('admin role required')
-        })
-
-        it('should deny access with invalid token', async () => {
-            const result = await rpcServer.admin('invalid-token')
-            expect(result).toHaveProperty('error')
-            expect((result as any).error).toBe('Invalid token')
-        })
-
-        it('should allow creating a token via admin handlers', async () => {
-            const handlers = (await rpcServer.admin(adminToken)) as any
-            const newToken = await handlers.createToken({ role: 'peer', name: 'new-peer' })
-            expect(newToken).toBeString()
-        })
+    userToken = await keyManager.sign({
+      subject: 'regular-user',
+      claims: { roles: ['user'] },
     })
 
-    describe('validation sub-api', () => {
-        it('should grant access to validation handlers with any valid token', async () => {
-            const result = await rpcServer.validation(userToken)
-            expect(result).not.toHaveProperty('error')
-            const handlers = result as any
-            expect(handlers.validate).toBeDefined()
-            expect(handlers.getJWKS).toBeDefined()
-        })
+    rpcServer = new AuthRpcServer(keyManager, new InMemoryRevocationStore())
+  })
 
-        it('should deny access with invalid token', async () => {
-            const result = await rpcServer.validation('invalid-token')
-            expect(result).toHaveProperty('error')
-            expect((result as any).error).toBe('Invalid token')
-        })
-
-        it('should allow validating a token via validation handlers', async () => {
-            const handlers = (await rpcServer.validation(adminToken)) as any
-            const validationResult = await handlers.validate({ token: userToken })
-            expect(validationResult.valid).toBe(true)
-            expect(validationResult.payload.sub).toBe('regular-user')
-        })
+  describe('admin sub-api', () => {
+    it('should grant access to admin handlers with valid admin token', async () => {
+      const handlers = await rpcServer.admin(adminToken)
+      expect(handlers).not.toHaveProperty('error')
+      const adminHandlers = handlers as any
+      expect(adminHandlers.createToken).toBeDefined()
+      expect(adminHandlers.revokeToken).toBeDefined()
     })
+
+    it('should deny access to admin handlers with non-admin token', async () => {
+      const result = await rpcServer.admin(userToken)
+      expect(result).toHaveProperty('error')
+      expect((result as any).error).toContain('admin role required')
+    })
+
+    it('should deny access with invalid token', async () => {
+      const result = await rpcServer.admin('invalid-token')
+      expect(result).toHaveProperty('error')
+      expect((result as any).error).toBe('Invalid token')
+    })
+
+    it('should allow creating a token via admin handlers', async () => {
+      const handlers = (await rpcServer.admin(adminToken)) as any
+      const newToken = await handlers.createToken({ role: 'peer', name: 'new-peer' })
+      expect(newToken).toBeString()
+    })
+  })
+
+  describe('validation sub-api', () => {
+    it('should grant access to validation handlers with any valid token', async () => {
+      const result = await rpcServer.validation(userToken)
+      expect(result).not.toHaveProperty('error')
+      const handlers = result as any
+      expect(handlers.validate).toBeDefined()
+      expect(handlers.getJWKS).toBeDefined()
+    })
+
+    it('should deny access with invalid token', async () => {
+      const result = await rpcServer.validation('invalid-token')
+      expect(result).toHaveProperty('error')
+      expect((result as any).error).toBe('Invalid token')
+    })
+
+    it('should allow validating a token via validation handlers', async () => {
+      const handlers = (await rpcServer.validation(adminToken)) as any
+      const validationResult = await handlers.validate({ token: userToken })
+      expect(validationResult.valid).toBe(true)
+      expect(validationResult.payload.sub).toBe('regular-user')
+    })
+  })
 })

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -8,9 +8,9 @@
     "skipLibCheck": true,
     "declaration": true,
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": ".",
     "types": ["bun"]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": ["src", "tests"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,8 @@
     "commander": "catalog:",
     "inquirer": "^9.2.14",
     "ws": "^8.19.0",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "@catalyst/orchestrator": "workspace:*"
   },
   "devDependencies": {
     "@types/inquirer": "^9.0.7",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -10,5 +10,5 @@
     "allowImportingTsExtensions": true,
     "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/**/*"]
 }

--- a/packages/orchestrator/Dockerfile
+++ b/packages/orchestrator/Dockerfile
@@ -9,11 +9,13 @@ COPY package.json bun.lock ./
 COPY packages/orchestrator/package.json packages/orchestrator/package.json
 COPY packages/auth/package.json packages/auth/package.json
 
-# Install dependencies
-WORKDIR /app/packages/orchestrator
-
 # Install dependencies (cache dependencies)
 RUN bun install --omit=dev --ignore-scripts
+
+COPY packages/auth packages/auth
+
+# Install dependencies
+WORKDIR /app/packages/orchestrator
 
 # Copy orchestrator package (copy all files)
 COPY packages/orchestrator .

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -1,13 +1,18 @@
 import type { z } from 'zod'
 import { type Action } from './schema.js'
+import { Actions } from './action-types.js'
 import type { PeerInfo, InternalRoute } from './routing/state.js'
 export type { PeerInfo, InternalRoute }
 import { newRouteTable, type RouteTable, type PeerRecord } from './routing/state.js'
 import type { DataChannelDefinition } from './routing/datachannel.js'
 import type { UpdateMessageSchema } from './routing/internal/actions.js'
-import { type AuthContext, AuthContextSchema, type OrchestratorConfig } from './types.js'
-import { getRequiredPermission, hasPermission, isSecretValid } from './permissions.js'
-import { Actions } from './action-types.js'
+import {
+  type AuthContext,
+  AuthContextSchema,
+  type OrchestratorConfig,
+  OrchestratorConfigSchema,
+} from './types.js'
+import { getRequiredPermission, hasPermission, isSecretValid, Permission } from './permissions.js'
 import {
   newHttpBatchRpcSession,
   newWebSocketRpcSession,
@@ -193,7 +198,7 @@ export class CatalystNodeBus extends RpcTarget {
     if (!permission) {
       return { success: false, error: `Unauthorized action: ${action.action}` }
     }
-    if (!hasPermission(auth.roles, permission, auth.permissions)) {
+    if (!hasPermission(auth.roles, permission)) {
       return { success: false, error: `Permission denied: ${permission}` }
     }
 
@@ -790,9 +795,9 @@ export class CatalystNodeBus extends RpcTarget {
         }
 
         const auth: AuthContext = {
-          userId: 'networkmgmt',
-          roles: ['networkcustodian'],
-          permissions: ['peer:create', 'peer:update', 'peer:delete'],
+          userId: 'peermgmt',
+          roles: ['peer_custodian'],
+          permissions: [Permission.PeerCreate, Permission.PeerUpdate, Permission.PeerDelete],
         }
 
         return {
@@ -824,8 +829,8 @@ export class CatalystNodeBus extends RpcTarget {
 
         const auth: AuthContext = {
           userId: 'datamgmt',
-          roles: ['datacustodian'],
-          permissions: ['route:create', 'route:delete'],
+          roles: ['data_custodian'],
+          permissions: [Permission.RouteCreate, Permission.RouteDelete],
         }
 
         return {
@@ -857,8 +862,8 @@ export class CatalystNodeBus extends RpcTarget {
 
         const auth: AuthContext = {
           userId: 'ibgppeer',
-          roles: ['networkpeer'],
-          permissions: ['ibgp:connect', 'ibgp:disconnect', 'ibgp:update'],
+          roles: ['peer'],
+          permissions: [Permission.IbgpConnect, Permission.IbgpDisconnect, Permission.IbgpUpdate],
         }
 
         return {

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -2,6 +2,7 @@ import type { Action } from './schema.js'
 import type { RouteTable } from './routing/state.js'
 import { z } from 'zod'
 import { PeerInfoSchema } from './routing/state.js'
+import { Permission, type Role } from '@catalyst/auth'
 
 export const OrchestratorConfigSchema = z.object({
   node: PeerInfoSchema,
@@ -21,8 +22,9 @@ export type OrchestratorConfig = z.infer<typeof OrchestratorConfigSchema>
 
 export const AuthContextSchema = z.object({
   userId: z.string(),
-  roles: z.array(z.string()),
-  permissions: z.array(z.string()).optional(),
+  // roles is an array of Role from @catalyst/auth
+  roles: z.array(z.enum<Role[]>(['admin', 'peer', 'peer_custodian', 'data_custodian', 'user'])),
+  permissions: z.array(z.enum<Permission[]>(Object.values(Permission))).optional(),
 })
 export type AuthContext = z.infer<typeof AuthContextSchema>
 

--- a/packages/orchestrator/tests/orchestrator.gateway.test.ts
+++ b/packages/orchestrator/tests/orchestrator.gateway.test.ts
@@ -3,6 +3,7 @@ import { Actions } from '../src/action-types.js'
 import { CatalystNodeBus, ConnectionPool, type PublicApi } from '../src/orchestrator.js'
 import type { RpcStub } from 'capnweb'
 import type { PeerInfo } from '../src/routing/state.js'
+import type { AuthContext } from '../src/types.js'
 
 const MOCK_NODE: PeerInfo = {
   name: 'node-a.somebiz.local.io',
@@ -46,7 +47,7 @@ class MockConnectionPool extends ConnectionPool {
   }
 }
 
-const ADMIN_AUTH = { userId: 'admin', roles: ['*'] }
+const ADMIN_AUTH: AuthContext = { userId: 'admin', roles: ['admin'] }
 
 describe('CatalystNodeBus > GraphQL Gateway Sync', () => {
   let bus: CatalystNodeBus

--- a/packages/orchestrator/tsconfig.json
+++ b/packages/orchestrator/tsconfig.json
@@ -6,10 +6,10 @@
     "strict": true,
     "skipLibCheck": true,
     "outDir": "./dist",
-    "rootDir": "../../",
+    "rootDir": ".",
     "types": ["bun"],
     "allowImportingTsExtensions": true,
     "noEmit": true
   },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": ["src", "tests"]
 }


### PR DESCRIPTION
### TL;DR

Updated dependency management and improved authentication integration between packages.

### What changed?

- Added `@catalyst/orchestrator` as a dependency to the CLI package
- Updated Docker configurations for both auth and orchestrator services to properly handle workspace dependencies
- Moved permission tests from orchestrator to auth package for better separation of concerns
- Updated dependency versions for `docker-compose` (1.3.0 → 1.3.1) and `undici` (7.18.2 → 7.19.0)
- Enhanced the peer_custodian role to include iBGP permissions
- Fixed tsconfig settings to properly handle source and test files
- Improved code formatting in the auth permissions module

### How to test?

1. Build the Docker images for both auth and orchestrator services:
   ```
   docker build -f packages/auth/Dockerfile -t catalyst-auth .
   docker build -f packages/orchestrator/Dockerfile -t catalyst-orchestrator .
   ```

2. Run the orchestrator tests to verify the integration:
   ```
   cd packages/orchestrator
   bun test
   ```

3. Run the auth tests to verify permission handling:
   ```
   cd packages/auth
   bun test
   ```

### Why make this change?

This change improves the integration between the auth and orchestrator packages by properly defining dependencies and ensuring consistent permission handling across the system. It also fixes Docker build issues related to workspace dependencies and ensures that the peer_custodian role has the necessary permissions to manage both peers and their connections. The code organization is improved by moving permission tests to the auth package where they logically belong.