### PR TITLE
test: fix naming technically correct but

### DIFF
--- a/packages/auth/tests/permission.test.ts
+++ b/packages/auth/tests/permission.test.ts
@@ -60,10 +60,10 @@ describe('hasPermission', () => {
     })
   })
 
-  describe('viewer role (no permissions)', () => {
-    it('should deny write permissions to viewer', () => {
-      expect(hasPermission(['viewer'], 'peer:create')).toBe(false)
-      expect(hasPermission(['viewer'], 'route:delete')).toBe(false)
+  describe('user role (no permissions)', () => {
+    it('should deny write permissions to user', () => {
+      expect(hasPermission(['user'], 'peer:create')).toBe(false)
+      expect(hasPermission(['user'], 'route:delete')).toBe(false)
     })
   })
 })


### PR DESCRIPTION
### TL;DR

Updated role name from 'viewer' to 'user' in permission tests.

### What changed?

Renamed the 'viewer' role to 'user' in the permission test file. This includes updating the test description and the role name in the test assertions.

### How to test?

Run the permission tests to verify they pass with the updated role name:
```
cd packages/auth
npm test -- -t "user role"
```

### Why make this change?

This change aligns the test terminology with the actual role naming convention used in the application. The role is referred to as 'user' throughout the codebase, so the tests should reflect this consistent naming.