### PR TITLE
fix(telemetry): make LoggerProvider required and add production OTLP exporter

### DIFF
--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -75,7 +75,11 @@ async function performInit(opts: InitOptions): Promise<void> {
     })
 
     await initLogger({
-      loggerProvider: opts._testLoggerProvider,
+      serviceName: opts.serviceName,
+      serviceVersion: opts.serviceVersion,
+      environment: opts.environment,
+      otlpEndpoint: opts.otlpEndpoint,
+      _testLoggerProvider: opts._testLoggerProvider,
       logLevel: opts.logLevel,
       enableConsole: opts.enableConsole,
     })

--- a/packages/telemetry/src/logger.test.ts
+++ b/packages/telemetry/src/logger.test.ts
@@ -42,7 +42,7 @@ describe('logger', () => {
   describe('initLogger', () => {
     it('configures LogTape with OTEL sink', async () => {
       const { logExporter, loggerProvider } = createTestProviders()
-      await initLogger({ loggerProvider, enableConsole: false })
+      await initLogger({ _testLoggerProvider: loggerProvider, enableConsole: false })
 
       const logger = getLogger('test-module')
       logger.info('hello from logger')
@@ -56,7 +56,7 @@ describe('logger', () => {
   describe('getLogger', () => {
     it('returns a logger for a single category', async () => {
       const { loggerProvider } = createTestProviders()
-      await initLogger({ loggerProvider, enableConsole: false })
+      await initLogger({ _testLoggerProvider: loggerProvider, enableConsole: false })
 
       const logger = getLogger('gateway')
       expect(logger).toBeDefined()
@@ -65,7 +65,7 @@ describe('logger', () => {
 
     it('returns a logger for nested categories', async () => {
       const { logExporter, loggerProvider } = createTestProviders()
-      await initLogger({ loggerProvider, enableConsole: false })
+      await initLogger({ _testLoggerProvider: loggerProvider, enableConsole: false })
 
       const logger = getLogger('gateway', 'federation')
       logger.info('nested log')
@@ -80,7 +80,7 @@ describe('logger', () => {
   describe('trace context injection', () => {
     it('includes traceId and spanId when logging within an active span', async () => {
       const { logExporter, loggerProvider } = createTestProviders()
-      await initLogger({ loggerProvider, enableConsole: false })
+      await initLogger({ _testLoggerProvider: loggerProvider, enableConsole: false })
 
       const tracer = trace.getTracer('test')
       const span = tracer.startSpan('test-op')
@@ -104,7 +104,7 @@ describe('logger', () => {
   describe('edge cases', () => {
     it('handles undefined properties without throwing', async () => {
       const { loggerProvider } = createTestProviders()
-      await initLogger({ loggerProvider, enableConsole: false })
+      await initLogger({ _testLoggerProvider: loggerProvider, enableConsole: false })
 
       const logger = getLogger('test')
       logger.info('value is {value}', { value: undefined })
@@ -112,7 +112,7 @@ describe('logger', () => {
 
     it('handles empty string messages', async () => {
       const { logExporter, loggerProvider } = createTestProviders()
-      await initLogger({ loggerProvider, enableConsole: false })
+      await initLogger({ _testLoggerProvider: loggerProvider, enableConsole: false })
 
       const logger = getLogger('test')
       logger.info('')

--- a/packages/telemetry/src/logger.ts
+++ b/packages/telemetry/src/logger.ts
@@ -3,18 +3,38 @@
  *
  * Configures LogTape with console and OTEL sinks.
  * All loggers use getLogger(name, ...subcategories) for consistent categories.
+ *
+ * WHY create our own LoggerProvider: Unlike tracer/meter which use the global
+ * OTEL API, LogTape bridges to OTEL via @logtape/otel which needs an explicit
+ * LoggerProvider. We create one with BatchLogRecordProcessor + OTLPLogExporter
+ * following the same pattern as tracer.ts and meter.ts.
  */
 
 import { configure, getLogger as logtapeGetLogger, reset } from '@logtape/logtape'
 import type { Logger } from '@logtape/logtape'
+import { LoggerProvider, BatchLogRecordProcessor } from '@opentelemetry/sdk-logs'
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
 import { createConsoleSink } from './sinks/console'
-import { createOtelSink, shutdownLoggerProvider } from './sinks/otel'
-import type { LoggerProvider } from '@opentelemetry/sdk-logs'
+import { createOtelSink, setLoggerProvider, shutdownLoggerProvider } from './sinks/otel'
+import { buildResource } from './resource'
 
 interface LoggerOptions {
-  loggerProvider?: LoggerProvider
+  /** Service name for OTEL resource attributes */
+  serviceName?: string
+  /** Service version for OTEL resource attributes */
+  serviceVersion?: string
+  /** Deployment environment for OTEL resource attributes */
+  environment?: string
+  /** OTLP endpoint for log export */
+  otlpEndpoint?: string
+  /** @internal Test-only: inject a pre-configured LoggerProvider */
+  _testLoggerProvider?: LoggerProvider
+  /** Minimum log level */
   logLevel?: 'debug' | 'info' | 'warning' | 'error' | 'fatal'
+  /** Enable console sink (default: true) */
   enableConsole?: boolean
+  /** Enable OTEL sink (default: true) */
+  enableOtel?: boolean
 }
 
 let initialized = false
@@ -33,8 +53,42 @@ export async function initLogger(opts?: LoggerOptions): Promise<void> {
     sinkNames.push('console')
   }
 
-  if (opts?.loggerProvider) {
-    sinks['otel'] = createOtelSink({ loggerProvider: opts.loggerProvider })
+  // Set up OTEL sink with either test provider or production exporter
+  if (opts?.enableOtel !== false) {
+    let loggerProvider: LoggerProvider
+
+    if (opts?._testLoggerProvider) {
+      // Test mode: use injected provider
+      loggerProvider = opts._testLoggerProvider
+    } else {
+      /**
+       * WHY we create our own LoggerProvider: The tracer and meter both create
+       * OTLP exporters for production. The logger needs the same treatment to
+       * ensure logs reach the collector alongside traces and metrics.
+       *
+       * WHY 5s timeout: Matches tracer.ts and meter.ts — bounds shutdown time
+       * while still allowing reasonable export attempts.
+       */
+      const resource = buildResource({
+        serviceName: opts?.serviceName ?? 'unknown_service',
+        serviceVersion: opts?.serviceVersion,
+        environment: opts?.environment,
+      })
+
+      const exporter = new OTLPLogExporter({
+        url: `${opts?.otlpEndpoint ?? process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? 'http://localhost:4318'}/v1/logs`,
+        timeoutMillis: 5000,
+      })
+
+      loggerProvider = new LoggerProvider({
+        resource,
+        processors: [new BatchLogRecordProcessor(exporter)],
+      })
+    }
+
+    // Track provider for shutdown (works for both test and production)
+    setLoggerProvider(loggerProvider)
+    sinks['otel'] = createOtelSink({ loggerProvider })
     sinkNames.push('otel')
   }
 

--- a/packages/telemetry/src/sinks/otel.test.ts
+++ b/packages/telemetry/src/sinks/otel.test.ts
@@ -118,15 +118,4 @@ describe('otel sink', () => {
       expect(records[0].attributes['email']).toBe('[EMAIL]')
     })
   })
-
-  describe('resilience', () => {
-    it('does not throw when no loggerProvider is given', async () => {
-      // createOtelSink with no provider should still return a usable sink
-      const sink = createOtelSink()
-      await setupLogtape(sink)
-
-      // Logging should not throw even without a backend
-      getLogger(['test']).info('no provider')
-    })
-  })
 })


### PR DESCRIPTION
- Pass resource configuration (serviceName, serviceVersion, environment,
  otlpEndpoint) through to initLogger for proper OTLP log export
- Create production LoggerProvider with BatchLogRecordProcessor and
  OTLPLogExporter following the same pattern as tracer/meter
- Make loggerProvider required in createOtelSink to prevent silent failures
- Rename loggerProvider to _testLoggerProvider for test injection clarity
- Add setLoggerProvider for explicit lifecycle management
- Remove no-provider resilience test since provider is now required