### PR TITLE
docs: add telemetry, sdk, and observability stack documentation

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -1,0 +1,203 @@
+# Observability Stack
+
+Local observability infrastructure for Catalyst Node development.
+
+## Components
+
+| Service        | Port                     | Purpose                          | UI                     |
+| -------------- | ------------------------ | -------------------------------- | ---------------------- |
+| OTEL Collector | 4317 (gRPC), 4318 (HTTP) | Receives telemetry from services | -                      |
+| Jaeger         | 16687                    | Distributed tracing              | http://localhost:16687 |
+| Prometheus     | 9091                     | Metrics storage                  | http://localhost:9091  |
+| InfluxDB       | 8087                     | Log storage                      | http://localhost:8087  |
+
+## Quick Start
+
+```bash
+# Start the stack
+docker-compose -f docker-compose/docker-compose.observability.yaml up -d
+
+# Check status
+docker-compose -f docker-compose/docker-compose.observability.yaml ps
+
+# View logs
+docker-compose -f docker-compose/docker-compose.observability.yaml logs -f
+
+# Stop
+docker-compose -f docker-compose/docker-compose.observability.yaml down
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Your Service                           │
+│                                                             │
+│   @catalyst/telemetry → OTLP HTTP → localhost:4318         │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+                    ┌─────────────────┐
+                    │  OTEL Collector │
+                    │   :4317/:4318   │
+                    └────────┬────────┘
+                             │
+         ┌───────────────────┼───────────────────┐
+         │                   │                   │
+         ▼                   ▼                   ▼
+   ┌──────────┐       ┌──────────┐       ┌──────────┐
+   │  Jaeger  │       │Prometheus│       │ InfluxDB │
+   │  :16687  │       │  :9091   │       │  :8087   │
+   │ (traces) │       │ (metrics)│       │  (logs)  │
+   └──────────┘       └──────────┘       └──────────┘
+```
+
+## Service Configuration
+
+Configure your service to send telemetry to the collector:
+
+```typescript
+import { initTelemetry } from '@catalyst/telemetry'
+
+await initTelemetry({
+  serviceName: 'my-service',
+  otlpEndpoint: 'http://localhost:4318',
+})
+```
+
+Or via environment variable:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 bun run src/index.ts
+```
+
+## Viewing Telemetry
+
+### Traces (Jaeger)
+
+1. Open http://localhost:16687
+2. Select your service from the dropdown
+3. Click "Find Traces"
+4. Click a trace to see the waterfall view
+
+**Tips:**
+
+- Filter by operation name, tags, or duration
+- Use "Compare" to diff two traces
+- Check "Dependencies" for service maps
+
+### Metrics (Prometheus)
+
+1. Open http://localhost:9091
+2. Enter a PromQL query, e.g.:
+   - `http_server_request_duration_seconds_bucket` — request latency histogram
+   - `http_server_request_total` — request count by status
+3. Click "Execute" → "Graph"
+
+**Tips:**
+
+- Use `rate()` for per-second rates: `rate(http_server_request_total[5m])`
+- Use `histogram_quantile()` for percentiles
+
+### Logs (InfluxDB)
+
+1. Open http://localhost:8087
+2. Login: `admin` / `adminpassword`
+3. Go to "Data Explorer"
+4. Select bucket: `logs`
+5. Filter by `_measurement`, `service.name`, `severity`, etc.
+
+**Tips:**
+
+- Filter by trace_id to find logs for a specific request
+- Use Flux queries for advanced filtering
+
+## Files
+
+| File                                                    | Purpose                  |
+| ------------------------------------------------------- | ------------------------ |
+| `docker-compose.observability.yaml`                     | Docker Compose config    |
+| `prometheus.yaml`                                       | Prometheus scrape config |
+| `../services/otel-collector/otel-collector-config.yaml` | Collector pipelines      |
+
+## Customization
+
+### Change Ports
+
+Edit `docker-compose.observability.yaml`:
+
+```yaml
+services:
+  jaeger:
+    ports:
+      - '16687:16686' # Change left side
+```
+
+### Add Sampling
+
+Edit `services/otel-collector/otel-collector-config.yaml`:
+
+```yaml
+processors:
+  probabilistic_sampler:
+    sampling_percentage: 10
+
+service:
+  pipelines:
+    traces:
+      processors: [memory_limiter, probabilistic_sampler, batch]
+```
+
+### Persist Data
+
+Data persists in Docker volumes:
+
+- `prometheus-data` — Prometheus TSDB
+- `influxdb-data` — InfluxDB data
+
+To reset:
+
+```bash
+docker-compose -f docker-compose/docker-compose.observability.yaml down -v
+```
+
+## Troubleshooting
+
+### Collector not starting
+
+Check logs:
+
+```bash
+docker-compose -f docker-compose/docker-compose.observability.yaml logs otel-collector
+```
+
+Common issues:
+
+- Invalid YAML in `otel-collector-config.yaml`
+- Port conflicts
+
+### No traces appearing
+
+1. Verify collector is running: `docker ps | grep otel`
+2. Check your service is sending to `http://localhost:4318`
+3. Check collector logs for export errors
+
+### Port conflicts
+
+If ports are in use, edit the compose file to use different host ports:
+
+```yaml
+ports:
+  - '16688:16686' # Map to different host port
+```
+
+## License Compliance
+
+All components are Apache 2.0 or MIT licensed:
+
+| Component        | License    |
+| ---------------- | ---------- |
+| OTEL Collector   | Apache 2.0 |
+| Jaeger           | Apache 2.0 |
+| Prometheus       | Apache 2.0 |
+| InfluxDB 2.x OSS | MIT        |

--- a/docker-compose/docker-compose.observability.yaml
+++ b/docker-compose/docker-compose.observability.yaml
@@ -1,0 +1,64 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.92.0
+    command: ['--config=/etc/otel-collector-config.yaml']
+    volumes:
+      - ../services/otel-collector/otel-collector-config.yaml:/etc/otel-collector-config.yaml:ro
+    ports:
+      - '4317:4317' # OTLP gRPC
+      - '4318:4318' # OTLP HTTP
+      - '8888:8888' # Collector metrics
+    depends_on:
+      - jaeger
+      - prometheus
+      - influxdb
+    networks:
+      - observability
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.54
+    ports:
+      - '16687:16686' # Jaeger UI (mapped to 16687 to avoid conflicts)
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    networks:
+      - observability
+
+  prometheus:
+    image: prom/prometheus:v2.49.0
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yaml:ro
+      - prometheus-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yaml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=15d'
+      - '--web.enable-lifecycle'
+    ports:
+      - '9091:9090' # Prometheus UI (mapped to 9091 to avoid conflicts)
+    networks:
+      - observability
+
+  influxdb:
+    image: influxdb:2.7
+    ports:
+      - '8087:8086' # InfluxDB UI and API (mapped to 8087 to avoid conflicts)
+    environment:
+      - DOCKER_INFLUXDB_INIT_MODE=setup
+      - DOCKER_INFLUXDB_INIT_USERNAME=admin
+      - DOCKER_INFLUXDB_INIT_PASSWORD=adminpassword
+      - DOCKER_INFLUXDB_INIT_ORG=catalyst
+      - DOCKER_INFLUXDB_INIT_BUCKET=logs
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=catalyst-token
+    volumes:
+      - influxdb-data:/var/lib/influxdb2
+    networks:
+      - observability
+
+volumes:
+  prometheus-data:
+  influxdb-data:
+
+networks:
+  observability:
+    driver: bridge

--- a/docker-compose/prometheus.yaml
+++ b/docker-compose/prometheus.yaml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'otel-collector'
+    static_configs:
+      - targets: ['otel-collector:8888']
+
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']

--- a/examples/smoke-test/README.md
+++ b/examples/smoke-test/README.md
@@ -1,0 +1,88 @@
+# Smoke Test
+
+End-to-end test for `@catalyst/telemetry` and `@catalyst/sdk` with the observability stack.
+
+## Prerequisites
+
+Start the observability stack:
+
+```bash
+docker-compose -f docker-compose/docker-compose.observability.yaml up -d
+```
+
+## Run
+
+```bash
+bun run examples/smoke-test/index.ts
+```
+
+## Endpoints
+
+| Endpoint            | Description                           |
+| ------------------- | ------------------------------------- |
+| `GET /health`       | Health check (not instrumented)       |
+| `GET /hello`        | Simple JSON response                  |
+| `GET /slow`         | 500ms delay with custom span          |
+| `GET /user/:id`     | Path parameter (normalized in traces) |
+| `GET /metrics-test` | Records custom metrics                |
+| `GET /error`        | Throws error (captured in trace)      |
+
+## Test It
+
+```bash
+# Health check
+curl http://localhost:3000/health
+
+# Generate traces
+curl http://localhost:3000/hello
+curl http://localhost:3000/slow
+curl http://localhost:3000/user/123
+curl http://localhost:3000/user/456
+
+# Generate metrics
+curl http://localhost:3000/metrics-test
+
+# Generate error trace
+curl http://localhost:3000/error
+```
+
+## View Telemetry
+
+### Traces
+
+1. Open Jaeger: http://localhost:16687
+2. Select service: `smoke-test`
+3. Click "Find Traces"
+
+You should see:
+
+- `HTTP GET /hello` — simple request
+- `HTTP GET /slow` with child span `slow-operation`
+- `HTTP GET /user/:id` — path normalized
+- `HTTP GET /error` — error recorded
+
+### Metrics
+
+1. Open Prometheus: http://localhost:9091
+2. Query: `smoke_test_requests_total`
+
+### Logs
+
+1. Open InfluxDB: http://localhost:8087
+2. Login: `admin` / `adminpassword`
+3. Data Explorer → bucket: `logs`
+4. Filter: `service.name` = `smoke-test`
+
+Logs include `trace_id` for correlation with Jaeger.
+
+## What It Tests
+
+- [x] `initTelemetry()` initialization
+- [x] `CatalystService` bootstrap
+- [x] `telemetryMiddleware` auto-instrumentation
+- [x] `getLogger()` with trace correlation
+- [x] `service.tracer` manual spans
+- [x] `service.meter` custom metrics
+- [x] Path normalization (`/user/:id`)
+- [x] Error recording in spans
+- [x] Graceful shutdown with `onShutdown`

--- a/examples/smoke-test/index.ts
+++ b/examples/smoke-test/index.ts
@@ -1,0 +1,102 @@
+/**
+ * Smoke Test Service
+ *
+ * Tests @catalyst/telemetry + CatalystService with the observability stack.
+ *
+ * Usage:
+ *   1. Start observability stack:
+ *      docker compose -f docker-compose/docker-compose.observability.yaml up -d
+ *
+ *   2. Run this service:
+ *      bun run examples/smoke-test/index.ts
+ *
+ *   3. Hit endpoints:
+ *      curl http://localhost:3000/hello
+ *      curl http://localhost:3000/slow
+ *      curl http://localhost:3000/error
+ *
+ *   4. Check observability UIs:
+ *      - Jaeger: http://localhost:16686 (traces)
+ *      - Prometheus: http://localhost:9090 (metrics)
+ *      - InfluxDB: http://localhost:8086 (logs)
+ */
+
+import { initTelemetry, getLogger, shutdown } from '@catalyst/telemetry'
+import { telemetryMiddleware } from '@catalyst/telemetry/middleware/hono'
+import { CatalystService } from '@catalyst/sdk'
+
+// Initialize telemetry FIRST (before any other imports that might create spans)
+await initTelemetry({
+  serviceName: 'smoke-test',
+  serviceVersion: '1.0.0',
+  environment: 'development',
+  otlpEndpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? 'http://localhost:4318',
+  enableConsole: true,
+  logLevel: 'debug',
+})
+
+const logger = getLogger('smoke-test')
+
+// Create service
+const service = new CatalystService({
+  name: 'smoke-test',
+  port: 3000,
+})
+
+// Add telemetry middleware
+service.app.use('*', telemetryMiddleware({ ignorePaths: ['/health'] }))
+
+// Routes
+service.app.get('/hello', (c) => {
+  logger.info('Hello endpoint hit')
+  return c.json({ message: 'Hello from smoke test!' })
+})
+
+service.app.get('/slow', async (c) => {
+  logger.info('Slow endpoint starting')
+  const tracer = service.tracer
+  const span = tracer.startSpan('slow-operation')
+
+  // Simulate slow work
+  await new Promise((resolve) => setTimeout(resolve, 500))
+
+  span.setAttribute('operation.duration_ms', 500)
+  span.end()
+
+  logger.info('Slow endpoint completed')
+  return c.json({ message: 'Slow operation complete', duration: 500 })
+})
+
+service.app.get('/error', (_c) => {
+  logger.error('Error endpoint triggered')
+  throw new Error('Intentional error for testing')
+})
+
+service.app.get('/user/:id', (c) => {
+  const userId = c.req.param('id')
+  logger.info('User lookup for {userId}', { userId })
+  return c.json({ userId, name: 'Test User' })
+})
+
+// Metrics endpoint (manual metric recording)
+service.app.get('/metrics-test', (c) => {
+  const meter = service.meter
+  const counter = meter.createCounter('smoke_test.requests')
+  counter.add(1, { endpoint: '/metrics-test' })
+
+  const histogram = meter.createHistogram('smoke_test.response_time')
+  histogram.record(Math.random() * 100, { endpoint: '/metrics-test' })
+
+  logger.info('Metrics recorded')
+  return c.json({ message: 'Metrics recorded' })
+})
+
+// Register shutdown callback
+service.onShutdown(async () => {
+  logger.info('Shutting down smoke test service')
+  await shutdown()
+})
+
+logger.info('Smoke test service starting on port {port}', { port: service.port })
+
+export default service.serve()

--- a/examples/smoke-test/package.json
+++ b/examples/smoke-test/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "smoke-test",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "bun run index.ts"
+  },
+  "dependencies": {
+    "@catalyst/telemetry": "workspace:*",
+    "@catalyst/sdk": "workspace:*"
+  }
+}

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,223 @@
+# @catalyst/sdk
+
+Standardized service entrypoint for Catalyst Node services. Reduces boilerplate for creating HTTP services with health checks, graceful shutdown, and optional telemetry.
+
+## Installation
+
+```bash
+bun add @catalyst/sdk
+```
+
+## Quick Start
+
+```typescript
+import { CatalystService } from '@catalyst/sdk'
+
+const service = new CatalystService({
+  name: 'my-service',
+  port: 3000,
+})
+
+// Add routes
+service.app.get('/api/users', (c) => c.json({ users: [] }))
+
+// Register shutdown callbacks
+service.onShutdown(async () => {
+  await database.close()
+})
+
+// Export for Bun
+export default service.serve()
+```
+
+## Features
+
+- **Hono app** — Pre-configured HTTP server
+- **Health endpoint** — `/health` mounted by default
+- **Graceful shutdown** — SIGTERM/SIGINT handling with timeout
+- **WebSocket support** — Ready for Cap'n Proto RPC
+- **OTEL integration** — Optional telemetry via `@catalyst/telemetry`
+
+## Configuration
+
+### `ServiceOptions`
+
+| Option       | Type     | Default                      | Description                               |
+| ------------ | -------- | ---------------------------- | ----------------------------------------- |
+| `name`       | `string` | **required**                 | Service name (used for logging/telemetry) |
+| `port`       | `number` | `process.env.PORT \|\| 3000` | Port to listen on                         |
+| `hostname`   | `string` | `"0.0.0.0"`                  | Hostname to bind to                       |
+| `healthPath` | `string` | `"/health"`                  | Health check endpoint path                |
+
+## API
+
+### `service.app`
+
+The underlying [Hono](https://hono.dev) application. Add routes, middleware, etc.
+
+```typescript
+service.app.get('/api/items', (c) => c.json({ items: [] }))
+service.app.post('/api/items', async (c) => {
+  const body = await c.req.json()
+  return c.json({ id: 1, ...body }, 201)
+})
+
+// Mount sub-applications
+service.app.route('/rpc', rpcApp)
+```
+
+### `service.name`
+
+The service name (read-only).
+
+```typescript
+console.log(`Starting ${service.name}`)
+```
+
+### `service.port`
+
+The port number (read-only).
+
+### `service.hostname`
+
+The hostname (read-only).
+
+### `service.tracer`
+
+Get an OpenTelemetry tracer for this service. Returns a no-op tracer if `@catalyst/telemetry` isn't initialized.
+
+```typescript
+const span = service.tracer.startSpan('custom-operation')
+// ... do work
+span.end()
+```
+
+### `service.meter`
+
+Get an OpenTelemetry meter for this service. Returns a no-op meter if `@catalyst/telemetry` isn't initialized.
+
+```typescript
+const counter = service.meter.createCounter('custom.counter')
+counter.add(1)
+```
+
+### `service.onShutdown(callback)`
+
+Register a callback to run during graceful shutdown. Callbacks are executed sequentially in registration order.
+
+```typescript
+service.onShutdown(async () => {
+  await database.close()
+})
+
+service.onShutdown(() => {
+  console.log('Goodbye!')
+})
+```
+
+### `service.serve()`
+
+Returns the Bun server configuration. Must be the default export.
+
+```typescript
+export default service.serve()
+// Returns: { fetch, port, hostname, websocket }
+```
+
+### `service.shutdown(timeoutMs?)`
+
+Manually trigger shutdown. Usually not needed — SIGTERM/SIGINT are handled automatically.
+
+```typescript
+await service.shutdown(5000) // 5 second timeout
+```
+
+## With Telemetry
+
+For full observability, initialize `@catalyst/telemetry` before creating the service:
+
+```typescript
+import { initTelemetry, shutdown } from '@catalyst/telemetry'
+import { telemetryMiddleware } from '@catalyst/telemetry/middleware/hono'
+import { CatalystService } from '@catalyst/sdk'
+
+// Initialize telemetry FIRST
+await initTelemetry({
+  serviceName: 'my-service',
+  otlpEndpoint: 'http://localhost:4318',
+})
+
+const service = new CatalystService({ name: 'my-service' })
+
+// Add telemetry middleware
+service.app.use(
+  '*',
+  telemetryMiddleware({
+    ignorePaths: ['/health'],
+  })
+)
+
+// Add routes
+service.app.get('/api/data', (c) => c.json({ data: [] }))
+
+// Shutdown telemetry on service shutdown
+service.onShutdown(shutdown)
+
+export default service.serve()
+```
+
+## Health Endpoint
+
+The health endpoint returns:
+
+```json
+{ "status": "ok" }
+```
+
+Customize the path:
+
+```typescript
+const service = new CatalystService({
+  name: 'my-service',
+  healthPath: '/ready',
+})
+```
+
+## Graceful Shutdown
+
+On SIGTERM or SIGINT:
+
+1. Signal handlers are removed (prevents double-shutdown)
+2. Registered `onShutdown` callbacks run sequentially
+3. Timeout after 30 seconds (configurable via `shutdown(timeoutMs)`)
+4. Process exits with code 0 (or 1 on error)
+
+## WebSocket Support
+
+The `serve()` return includes Hono's WebSocket handler for protocols like Cap'n Proto RPC:
+
+```typescript
+import { upgradeWebSocket } from 'hono/bun'
+
+service.app.get(
+  '/ws',
+  upgradeWebSocket((c) => ({
+    onMessage(event, ws) {
+      ws.send(`Echo: ${event.data}`)
+    },
+  }))
+)
+
+export default service.serve()
+// Includes: { fetch, port, hostname, websocket }
+```
+
+## Environment Variables
+
+| Variable | Description                                      |
+| -------- | ------------------------------------------------ |
+| `PORT`   | Port to listen on (overridden by `options.port`) |
+
+## License
+
+MIT

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@catalyst/sdk",
   "version": "0.0.1",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts",
     "dev": "tsup src/index.ts --format cjs,esm --dts --watch",

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -1,0 +1,266 @@
+# @catalyst/telemetry
+
+Unified OpenTelemetry instrumentation for Catalyst Node services. Provides traces, metrics, and structured logging with automatic correlation.
+
+## Installation
+
+```bash
+bun add @catalyst/telemetry
+```
+
+## Quick Start
+
+```typescript
+import { initTelemetry, getLogger, getTracer, getMeter, shutdown } from '@catalyst/telemetry'
+
+// Initialize FIRST, before other imports
+await initTelemetry({
+  serviceName: 'my-service',
+  serviceVersion: '1.0.0',
+  environment: process.env.NODE_ENV ?? 'development',
+  otlpEndpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? 'http://localhost:4318',
+})
+
+// Get instrumentation primitives
+const logger = getLogger('my-service')
+const tracer = getTracer('my-service')
+const meter = getMeter('my-service')
+
+// Use them
+logger.info`Server starting on port 3000`
+
+const span = tracer.startSpan('process-request')
+// ... do work
+span.end()
+
+const counter = meter.createCounter('requests.total')
+counter.add(1, { endpoint: '/api' })
+
+// Graceful shutdown (flushes all telemetry)
+process.on('SIGTERM', async () => {
+  await shutdown()
+  process.exit(0)
+})
+```
+
+## Configuration
+
+### `initTelemetry(options)`
+
+| Option                       | Type                                        | Default                   | Description                    |
+| ---------------------------- | ------------------------------------------- | ------------------------- | ------------------------------ |
+| `serviceName`                | `string`                                    | **required**              | Service name for OTEL resource |
+| `serviceVersion`             | `string`                                    | `"0.0.0"`                 | Service version                |
+| `environment`                | `string`                                    | `"development"`           | Deployment environment         |
+| `otlpEndpoint`               | `string`                                    | `"http://localhost:4318"` | OTLP HTTP endpoint             |
+| `logLevel`                   | `"debug" \| "info" \| "warning" \| "error"` | `"info"`                  | Minimum log level              |
+| `enableConsole`              | `boolean`                                   | `true`                    | Enable console log output      |
+| `batch`                      | `BatchConfig`                               | see below                 | Trace batch processor config   |
+| `metricExportIntervalMillis` | `number`                                    | `60000`                   | Metrics export interval        |
+
+### `BatchConfig`
+
+| Option                 | Type     | Default | Description          |
+| ---------------------- | -------- | ------- | -------------------- |
+| `maxQueueSize`         | `number` | `2048`  | Max spans in queue   |
+| `maxExportBatchSize`   | `number` | `512`   | Max spans per export |
+| `scheduledDelayMillis` | `number` | `5000`  | Export interval      |
+
+## Logging
+
+Uses [LogTape](https://logtape.org) for structured logging with automatic trace correlation.
+
+```typescript
+import { getLogger } from '@catalyst/telemetry'
+
+const logger = getLogger('my-service', 'subsystem')
+
+// Template literal syntax (recommended)
+logger.info`User ${userId} logged in`
+logger.error`Failed to process order ${orderId}: ${error.message}`
+
+// With structured properties
+logger.info('Request processed', {
+  userId,
+  duration: 150,
+  endpoint: '/api/users',
+})
+```
+
+Logs automatically include `trace_id` and `span_id` when emitted within an active span context.
+
+## Tracing
+
+```typescript
+import { getTracer, SpanStatusCode } from '@catalyst/telemetry'
+
+const tracer = getTracer('my-service')
+
+// Manual spans
+const span = tracer.startSpan('operation-name', {
+  attributes: {
+    'user.id': userId,
+    'operation.type': 'query',
+  },
+})
+
+try {
+  const result = await doWork()
+  span.setStatus({ code: SpanStatusCode.OK })
+  return result
+} catch (error) {
+  span.setStatus({ code: SpanStatusCode.ERROR, message: error.message })
+  span.recordException(error)
+  throw error
+} finally {
+  span.end()
+}
+```
+
+## Metrics
+
+```typescript
+import { getMeter } from '@catalyst/telemetry'
+
+const meter = getMeter('my-service')
+
+// Counter
+const requestCounter = meter.createCounter('http.requests.total', {
+  description: 'Total HTTP requests',
+})
+requestCounter.add(1, { method: 'GET', status: 200 })
+
+// Histogram
+const latencyHistogram = meter.createHistogram('http.request.duration', {
+  description: 'Request duration in milliseconds',
+  unit: 'ms',
+})
+latencyHistogram.record(42, { endpoint: '/api/users' })
+
+// Observable gauge
+meter.createObservableGauge(
+  'system.memory.usage',
+  {
+    description: 'Memory usage in bytes',
+  },
+  (result) => {
+    result.observe(process.memoryUsage().heapUsed)
+  }
+)
+```
+
+## HTTP Middleware (Hono)
+
+Auto-instruments HTTP requests with spans and metrics.
+
+```typescript
+import { Hono } from 'hono'
+import { telemetryMiddleware } from '@catalyst/telemetry/middleware/hono'
+
+const app = new Hono()
+
+app.use(
+  '*',
+  telemetryMiddleware({
+    ignorePaths: ['/health', '/ready'], // Skip instrumentation
+    spanNamePrefix: 'HTTP', // Span name prefix
+  })
+)
+
+app.get('/api/users', (c) => c.json({ users: [] }))
+```
+
+Each request creates a span with:
+
+- `http.request.method`
+- `http.route`
+- `http.response.status_code`
+- `url.path`
+
+## GraphQL Middleware (Yoga)
+
+Instruments GraphQL operations with resolver-level tracing.
+
+```typescript
+import { createYoga } from 'graphql-yoga'
+import { createYogaTelemetryPlugin } from '@catalyst/telemetry/middleware/yoga'
+
+const yoga = createYoga({
+  schema,
+  plugins: [
+    createYogaTelemetryPlugin({
+      resolvers: true, // Trace individual resolvers
+      variables: false, // Don't log variables (may contain PII)
+      result: false, // Don't log results
+    }),
+  ],
+})
+```
+
+**Important**: Call `initTelemetry()` before creating the Yoga instance.
+
+## Trace Context Propagation
+
+For distributed tracing across services:
+
+```typescript
+import { injectTraceHeaders, extractTraceContext, getTraceId, getSpanId } from '@catalyst/telemetry'
+
+// Outbound request — inject trace headers
+const headers = {}
+injectTraceHeaders(headers)
+await fetch('http://other-service/api', { headers })
+
+// Inbound request — extract parent context
+const parentContext = extractTraceContext(request.headers)
+
+// Get current trace/span IDs (e.g., for logging)
+const traceId = getTraceId()
+const spanId = getSpanId()
+```
+
+## PII Sanitization
+
+Sensitive data is automatically redacted from telemetry:
+
+```typescript
+import { sanitizeAttributes } from '@catalyst/telemetry'
+
+const attrs = sanitizeAttributes({
+  'user.email': 'alice@example.com', // → '[EMAIL]'
+  'auth.token': 'secret123', // → '[REDACTED]'
+  'http.method': 'GET', // → 'GET' (unchanged)
+})
+```
+
+Redacted keys: `password`, `token`, `secret`, `authorization`, `cookie`, `api_key`, `bearer`, `credential`, `private_key`
+
+## Path Normalization
+
+Prevents high-cardinality span names:
+
+```typescript
+import { normalizePath } from '@catalyst/telemetry'
+
+normalizePath('/users/123') // → '/users/:id'
+normalizePath('/orders/550e8400-e29b-41d4-..') // → '/orders/:uuid'
+```
+
+## Environment Variables
+
+| Variable                      | Description                                        |
+| ----------------------------- | -------------------------------------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint URL                                  |
+| `OTEL_SERVICE_NAME`           | Service name (can also be set via `initTelemetry`) |
+
+## Bun Compatibility
+
+This package is designed for Bun runtime:
+
+- Uses OTLP HTTP (not gRPC) — Bun's gRPC support is limited
+- No auto-instrumentation — Bun doesn't support Node.js require hooks
+- AsyncLocalStorage works since Bun 1.0 — required for trace context propagation
+
+## License
+
+MIT

--- a/services/otel-collector/README.md
+++ b/services/otel-collector/README.md
@@ -1,0 +1,151 @@
+# OTEL Collector Configuration
+
+OpenTelemetry Collector configuration for the Catalyst Node observability stack.
+
+## Overview
+
+The collector acts as a central hub for all telemetry:
+
+```
+Services → OTLP HTTP/gRPC → Collector → Backends
+                                │
+                    ┌───────────┼───────────┐
+                    ▼           ▼           ▼
+                 Jaeger    Prometheus   InfluxDB
+                (traces)   (metrics)     (logs)
+```
+
+## Configuration
+
+### `otel-collector-config.yaml`
+
+#### Receivers
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+```
+
+Services send telemetry to:
+
+- **gRPC**: `localhost:4317`
+- **HTTP**: `localhost:4318`
+
+#### Processors
+
+```yaml
+processors:
+  memory_limiter: # Prevent OOM
+  batch: # Batch exports for efficiency
+  attributes: # Add/modify attributes
+```
+
+#### Exporters
+
+| Exporter                | Target           | Signal         |
+| ----------------------- | ---------------- | -------------- |
+| `otlp/jaeger`           | Jaeger :4317     | Traces         |
+| `prometheusremotewrite` | Prometheus :9090 | Metrics        |
+| `influxdb`              | InfluxDB :8086   | Logs           |
+| `debug`                 | stdout           | All (dev only) |
+
+#### Pipelines
+
+```yaml
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch, attributes]
+      exporters: [otlp/jaeger, debug]
+
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [prometheusremotewrite, debug]
+
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [influxdb, debug]
+```
+
+## Customization
+
+### Add Sampling
+
+```yaml
+processors:
+  probabilistic_sampler:
+    sampling_percentage: 10
+
+  tail_sampling:
+    decision_wait: 10s
+    policies:
+      - name: errors
+        type: status_code
+        status_code: { status_codes: [ERROR] }
+      - name: slow
+        type: latency
+        latency: { threshold_ms: 1000 }
+```
+
+### Add Resource Attributes
+
+```yaml
+processors:
+  resource:
+    attributes:
+      - key: deployment.environment
+        value: production
+        action: upsert
+      - key: service.namespace
+        value: catalyst
+        action: upsert
+```
+
+### Filter Telemetry
+
+```yaml
+processors:
+  filter/traces:
+    traces:
+      span:
+        - 'attributes["http.route"] == "/health"'
+```
+
+## Debugging
+
+Enable verbose logging:
+
+```yaml
+service:
+  telemetry:
+    logs:
+      level: debug
+```
+
+Check collector metrics:
+
+```bash
+curl http://localhost:8888/metrics
+```
+
+## Production Considerations
+
+1. **Remove debug exporter** — logs all telemetry to stdout
+2. **Add authentication** — use `bearertokenauth` extension
+3. **Enable TLS** — configure `tls:` on receivers/exporters
+4. **Tune memory limits** — adjust based on traffic
+5. **Add tail sampling** — reduce storage costs
+
+## Reference
+
+- [OTEL Collector Docs](https://opentelemetry.io/docs/collector/)
+- [Collector Configuration](https://opentelemetry.io/docs/collector/configuration/)
+- [Available Components](https://github.com/open-telemetry/opentelemetry-collector-contrib)

--- a/services/otel-collector/otel-collector-config.yaml
+++ b/services/otel-collector/otel-collector-config.yaml
@@ -1,0 +1,70 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+
+  batch:
+    timeout: 5s
+    send_batch_size: 1024
+
+  attributes:
+    actions:
+      - key: deployment.environment
+        action: upsert
+        value: development
+
+exporters:
+  # Traces → Jaeger
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+  # Metrics → Prometheus
+  prometheusremotewrite:
+    endpoint: http://prometheus:9090/api/v1/write
+    tls:
+      insecure: true
+
+  # Logs → InfluxDB
+  influxdb:
+    endpoint: http://influxdb:8086
+    org: catalyst
+    bucket: logs
+    token: catalyst-token
+
+  # Debug output (development only)
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch, attributes]
+      exporters: [otlp/jaeger, debug]
+
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [prometheusremotewrite, debug]
+
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [influxdb, debug]
+
+  telemetry:
+    logs:
+      level: info
+    metrics:
+      address: 0.0.0.0:8888


### PR DESCRIPTION
- Add README for @catalyst/telemetry with full API reference
- Add README for @catalyst/sdk with CatalystService usage guide
- Add observability stack docker-compose with Jaeger, Prometheus, InfluxDB
- Add OTEL Collector configuration and README
- Add smoke-test example for end-to-end validation
- Fix SDK package.json exports for workspace resolution