### PR TITLE
feat(telemetry): add capnweb RPC instrumentation via Proxy

### DIFF
--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -136,6 +136,10 @@ export { normalizePath } from './normalize'
 // Re-export propagation helpers
 export { injectTraceHeaders, extractTraceContext, getTraceId, getSpanId } from './propagation/w3c'
 
+// Re-export RPC instrumentation
+export { instrumentRpcTarget, instrumentPublicApi } from './middleware/capnweb'
+export type { RpcInstrumentationOptions } from './middleware/capnweb'
+
 // Re-export types
 export type {
   TelemetryOptions,

--- a/packages/telemetry/src/middleware/capnweb.test.ts
+++ b/packages/telemetry/src/middleware/capnweb.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Tests for capnweb RPC instrumentation
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { propagation, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api'
+import {
+  InMemorySpanExporter,
+  NodeTracerProvider,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-node'
+import { W3CTraceContextPropagator } from '@opentelemetry/core'
+import { resourceFromAttributes } from '@opentelemetry/resources'
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
+import { instrumentRpcTarget, instrumentPublicApi } from './capnweb'
+
+function setupTracer() {
+  const exporter = new InMemorySpanExporter()
+  const provider = new NodeTracerProvider({
+    resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: 'test' }),
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  })
+  provider.register()
+  propagation.setGlobalPropagator(new W3CTraceContextPropagator())
+  return { exporter, provider }
+}
+
+describe('instrumentRpcTarget', () => {
+  afterEach(() => {
+    trace.disable()
+    propagation.disable()
+  })
+
+  it('creates spans for async method calls with correct attributes', async () => {
+    const { exporter } = setupTracer()
+    const target = {
+      async greet(name: string) {
+        return { success: true, message: `Hello, ${name}!` }
+      },
+    }
+
+    const instrumented = instrumentRpcTarget(target, { serviceName: 'test' })
+    const result = await instrumented.greet('World')
+
+    expect(result).toEqual({ success: true, message: 'Hello, World!' })
+
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+
+    const span = spans[0]
+    expect(span.name).toBe('test/greet')
+    expect(span.attributes['rpc.system.name']).toBe('capnweb')
+    expect(span.attributes['rpc.method']).toBe('test/greet')
+    expect(span.status.code).toBe(SpanStatusCode.OK)
+  })
+
+  it('sets SpanKind.SERVER per OTEL RPC spec', async () => {
+    const { exporter } = setupTracer()
+    const target = {
+      async process() {
+        return { success: true }
+      },
+    }
+
+    const instrumented = instrumentRpcTarget(target)
+    await instrumented.process()
+
+    const span = exporter.getFinishedSpans()[0]
+    expect(span.kind).toBe(SpanKind.SERVER)
+  })
+
+  it('records errors from thrown exceptions with error.type', async () => {
+    const { exporter } = setupTracer()
+    const target = {
+      async fail() {
+        throw new Error('Something went wrong')
+      },
+    }
+
+    const instrumented = instrumentRpcTarget(target)
+
+    await expect(instrumented.fail()).rejects.toThrow('Something went wrong')
+
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+
+    const span = spans[0]
+    expect(span.status.code).toBe(SpanStatusCode.ERROR)
+    expect(span.status.message).toBe('Something went wrong')
+    expect(span.attributes['error.type']).toBe('Error')
+    expect(span.events).toHaveLength(1)
+    expect(span.events[0].name).toBe('exception')
+  })
+
+  it('uses exception constructor name for error.type', async () => {
+    const { exporter } = setupTracer()
+
+    class CustomError extends Error {
+      constructor(message: string) {
+        super(message)
+        this.name = 'CustomError'
+      }
+    }
+
+    const target = {
+      async fail() {
+        throw new CustomError('Custom failure')
+      },
+    }
+
+    const instrumented = instrumentRpcTarget(target)
+    await expect(instrumented.fail()).rejects.toThrow('Custom failure')
+
+    const span = exporter.getFinishedSpans()[0]
+    expect(span.attributes['error.type']).toBe('CustomError')
+  })
+
+  it('detects capnweb-style error responses with error.type', async () => {
+    const { exporter } = setupTracer()
+    const target = {
+      async badRequest() {
+        return { success: false, error: 'Invalid input' }
+      },
+    }
+
+    const instrumented = instrumentRpcTarget(target, { serviceName: 'api' })
+    const result = await instrumented.badRequest()
+
+    expect(result).toEqual({ success: false, error: 'Invalid input' })
+
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+
+    const span = spans[0]
+    expect(span.status.code).toBe(SpanStatusCode.ERROR)
+    expect(span.status.message).toBe('Invalid input')
+    expect(span.attributes['error.type']).toBe('RpcError')
+    expect(span.attributes['catalyst.rpc.response.error']).toBe('Invalid input')
+  })
+
+  it('detects { valid: false } error responses (verifyToken pattern)', async () => {
+    const { exporter } = setupTracer()
+    const target = {
+      async verifyToken() {
+        return { valid: false, error: 'Token expired' }
+      },
+    }
+
+    const instrumented = instrumentRpcTarget(target, { serviceName: 'auth' })
+    const result = await instrumented.verifyToken()
+
+    expect(result).toEqual({ valid: false, error: 'Token expired' })
+
+    const span = exporter.getFinishedSpans()[0]
+    expect(span.status.code).toBe(SpanStatusCode.ERROR)
+    expect(span.status.message).toBe('Token expired')
+    expect(span.attributes['error.type']).toBe('RpcError')
+  })
+
+  it('treats { valid: true } as success', async () => {
+    const { exporter } = setupTracer()
+    const target = {
+      async verifyToken() {
+        return { valid: true, payload: { sub: 'user-1' } }
+      },
+    }
+
+    const instrumented = instrumentRpcTarget(target, { serviceName: 'auth' })
+    await instrumented.verifyToken()
+
+    const span = exporter.getFinishedSpans()[0]
+    expect(span.status.code).toBe(SpanStatusCode.OK)
+  })
+
+  it('skips methods starting with underscore', async () => {
+    const { exporter } = setupTracer()
+    const target = {
+      async _internal() {
+        return 'internal'
+      },
+      async publicMethod() {
+        return 'public'
+      },
+    }
+
+    const instrumented = instrumentRpcTarget(target)
+
+    await instrumented._internal()
+    await instrumented.publicMethod()
+
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+    expect(spans[0].name).toBe('rpc/publicMethod')
+  })
+
+  it('skips methods in ignoreMethods list', async () => {
+    const { exporter } = setupTracer()
+    const target = {
+      async ping() {
+        return 'pong'
+      },
+      async process() {
+        return 'done'
+      },
+    }
+
+    const instrumented = instrumentRpcTarget(target, {
+      ignoreMethods: ['ping'],
+    })
+
+    await instrumented.ping()
+    await instrumented.process()
+
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+    expect(spans[0].name).toBe('rpc/process')
+  })
+
+  it('records sanitized arguments when enabled', async () => {
+    const { exporter } = setupTracer()
+    const target = {
+      async login(_credentials: { username: string; password: string }) {
+        return { success: true }
+      },
+    }
+
+    const instrumented = instrumentRpcTarget(target, {
+      serviceName: 'auth',
+      recordArguments: true,
+    })
+
+    await instrumented.login({ username: 'user', password: 'secret123' })
+
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+
+    const argsAttr = spans[0].attributes['catalyst.rpc.request.args'] as string
+    expect(argsAttr).toBeDefined()
+
+    const parsed = JSON.parse(argsAttr)
+    // Password should be redacted by sanitizeAttributes
+    expect(parsed[0].password).toBe('[REDACTED]')
+    expect(parsed[0].username).toBe('user')
+  })
+
+  it('passes through non-function properties', () => {
+    setupTracer()
+    const target = {
+      name: 'TestService',
+      version: 1,
+      async method() {
+        return 'ok'
+      },
+    }
+
+    const instrumented = instrumentRpcTarget(target)
+
+    expect(instrumented.name).toBe('TestService')
+    expect(instrumented.version).toBe(1)
+  })
+
+  it('preserves this context in method calls', async () => {
+    const { exporter } = setupTracer()
+    const target = {
+      prefix: 'Hello',
+      async greet(name: string) {
+        return `${this.prefix}, ${name}!`
+      },
+    }
+
+    const instrumented = instrumentRpcTarget(target)
+    const result = await instrumented.greet('World')
+
+    expect(result).toBe('Hello, World!')
+    expect(exporter.getFinishedSpans()).toHaveLength(1)
+  })
+
+  it('uses default service name when not provided', async () => {
+    const { exporter } = setupTracer()
+    const target = {
+      async doSomething() {
+        return 'done'
+      },
+    }
+
+    const instrumented = instrumentRpcTarget(target)
+    await instrumented.doSomething()
+
+    const span = exporter.getFinishedSpans()[0]
+    expect(span.name).toBe('rpc/doSomething')
+    expect(span.attributes['rpc.method']).toBe('rpc/doSomething')
+  })
+})
+
+describe('instrumentPublicApi', () => {
+  afterEach(() => {
+    trace.disable()
+    propagation.disable()
+  })
+
+  it('wraps publicApi() method result', async () => {
+    const { exporter } = setupTracer()
+
+    class MockService {
+      publicApi() {
+        return {
+          async getData() {
+            return { success: true, data: [1, 2, 3] }
+          },
+        }
+      }
+    }
+
+    const service = new MockService()
+    const api = instrumentPublicApi(service, 'mock-service')
+
+    const result = await api.getData()
+    expect(result).toEqual({ success: true, data: [1, 2, 3] })
+
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+    expect(spans[0].name).toBe('mock-service/getData')
+    expect(spans[0].kind).toBe(SpanKind.SERVER)
+  })
+})

--- a/packages/telemetry/src/middleware/capnweb.ts
+++ b/packages/telemetry/src/middleware/capnweb.ts
@@ -1,0 +1,195 @@
+/**
+ * @catalyst/telemetry — capnweb RPC instrumentation
+ *
+ * Wraps RpcTarget instances with a Proxy to automatically create spans
+ * for each RPC method call. Since capnweb v0.4.0 has no middleware hooks,
+ * this uses JavaScript Proxy to intercept method calls.
+ *
+ * WHY Proxy instead of class extension:
+ * - Services already extend RpcTarget (CatalystNodeBus, AuthRpcServer, etc.)
+ * - publicApi() returns a plain object, not the RpcTarget itself
+ * - Proxy wraps at the HTTP boundary, keeping telemetry decoupled from RPC logic
+ * - No change required to existing RpcTarget subclasses
+ *
+ * @see https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans/
+ */
+
+import { SpanKind, SpanStatusCode, trace } from '@opentelemetry/api'
+import { sanitizeAttributes } from '../sanitizers'
+
+// RPC semconv attributes (not yet stable/exported from @opentelemetry/semantic-conventions)
+const ATTR_RPC_SYSTEM_NAME = 'rpc.system.name'
+const ATTR_RPC_METHOD = 'rpc.method'
+const ATTR_ERROR_TYPE = 'error.type'
+
+// Custom attributes (catalyst-specific, not in OTEL semconv)
+const ATTR_CATALYST_RPC_REQUEST_ARGS = 'catalyst.rpc.request.args'
+const ATTR_CATALYST_RPC_RESPONSE_ERROR = 'catalyst.rpc.response.error'
+
+/**
+ * Methods to skip instrumentation for (internal RpcTarget methods).
+ */
+const SKIP_METHODS = new Set([
+  'constructor',
+  'toString',
+  'valueOf',
+  'toJSON',
+  // capnweb internal methods
+  '_handleMessage',
+  '_sendMessage',
+  '_serialize',
+  '_deserialize',
+])
+
+/**
+ * Options for instrumentRpcTarget.
+ */
+export interface RpcInstrumentationOptions {
+  /** Service name for span attributes. Defaults to 'rpc'. */
+  serviceName?: string
+
+  /** Method names to skip instrumentation for. */
+  ignoreMethods?: string[]
+
+  /**
+   * Whether to record method arguments as span attributes. Defaults to false.
+   * WHY opt-in: RPC args may contain sensitive data. When enabled, args are
+   * passed through sanitizeAttributes() to redact passwords/tokens.
+   */
+  recordArguments?: boolean
+}
+
+/**
+ * Wraps an RpcTarget instance with OpenTelemetry instrumentation.
+ *
+ * Creates a span for each public method call with RPC semantic conventions:
+ * - `rpc.system.name`: 'capnweb'
+ * - `rpc.method`: service/method name
+ *
+ * @example
+ * ```typescript
+ * const bus = new CatalystNodeBus({ ... })
+ * const instrumented = instrumentRpcTarget(bus.publicApi(), {
+ *   serviceName: 'orchestrator'
+ * })
+ *
+ * app.all('/rpc', (c) => {
+ *   return newRpcResponse(c, instrumented, { upgradeWebSocket })
+ * })
+ * ```
+ */
+export function instrumentRpcTarget<T extends object>(
+  target: T,
+  options?: RpcInstrumentationOptions
+): T {
+  const serviceName = options?.serviceName ?? 'rpc'
+  const ignoreMethods = new Set([...SKIP_METHODS, ...(options?.ignoreMethods ?? [])])
+  const recordArguments = options?.recordArguments ?? false
+
+  const tracer = trace.getTracer('@catalyst/telemetry')
+
+  return new Proxy(target, {
+    get(obj, prop, receiver) {
+      const value = Reflect.get(obj, prop, receiver)
+
+      // Skip non-functions and internal methods
+      if (typeof value !== 'function') {
+        return value
+      }
+
+      const methodName = String(prop)
+
+      // Skip internal/ignored methods
+      if (methodName.startsWith('_') || ignoreMethods.has(methodName)) {
+        return value
+      }
+
+      // Return instrumented wrapper
+      return async function instrumentedMethod(...args: unknown[]) {
+        const rpcMethod = `${serviceName}/${methodName}`
+
+        // WHY SpanKind.SERVER: Per OTEL spec, server-side RPC spans MUST have
+        // kind SERVER. This enables correct topology rendering in tracing UIs.
+        return tracer.startActiveSpan(rpcMethod, { kind: SpanKind.SERVER }, async (span) => {
+          // Set RPC semantic convention attributes
+          span.setAttribute(ATTR_RPC_SYSTEM_NAME, 'capnweb')
+          span.setAttribute(ATTR_RPC_METHOD, rpcMethod)
+
+          // Optionally record sanitized arguments
+          if (recordArguments && args.length > 0) {
+            try {
+              const sanitized = sanitizeAttributes({ args })
+              span.setAttribute(ATTR_CATALYST_RPC_REQUEST_ARGS, JSON.stringify(sanitized.args))
+            } catch {
+              // Ignore serialization errors
+            }
+          }
+
+          try {
+            const result = await value.apply(obj, args)
+
+            // WHY check for { success: false } and { valid: false }: capnweb methods
+            // return result objects instead of throwing. Most use { success: false, error }
+            // but verifyToken uses { valid: false, error } as its discriminator.
+            const isErrorResult =
+              result &&
+              typeof result === 'object' &&
+              'error' in result &&
+              (('success' in result && !result.success) || ('valid' in result && !result.valid))
+
+            if (result && typeof result === 'object' && ('success' in result || 'valid' in result)) {
+              if (isErrorResult) {
+                span.setAttribute(ATTR_ERROR_TYPE, 'RpcError')
+                span.setAttribute(ATTR_CATALYST_RPC_RESPONSE_ERROR, String(result.error))
+                span.setStatus({
+                  code: SpanStatusCode.ERROR,
+                  message: String(result.error),
+                })
+              } else {
+                span.setStatus({ code: SpanStatusCode.OK })
+              }
+            } else {
+              span.setStatus({ code: SpanStatusCode.OK })
+            }
+
+            return result
+          } catch (err) {
+            const errorType = err instanceof Error ? err.constructor.name : 'Error'
+            span.setAttribute(ATTR_ERROR_TYPE, errorType)
+            span.recordException(err as Error)
+            span.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: err instanceof Error ? err.message : String(err),
+            })
+            throw err
+          } finally {
+            span.end()
+          }
+        })
+      }
+    },
+  })
+}
+
+/**
+ * Creates an instrumented version of an RpcTarget's public API.
+ *
+ * This is a convenience wrapper for services that expose a publicApi() method.
+ *
+ * @example
+ * ```typescript
+ * const bus = new CatalystNodeBus({ ... })
+ *
+ * app.all('/rpc', (c) => {
+ *   return newRpcResponse(c, instrumentPublicApi(bus, 'orchestrator'), {
+ *     upgradeWebSocket,
+ *   })
+ * })
+ * ```
+ */
+export function instrumentPublicApi<T extends { publicApi(): object }>(
+  target: T,
+  serviceName?: string
+): ReturnType<T['publicApi']> {
+  return instrumentRpcTarget(target.publicApi(), { serviceName }) as ReturnType<T['publicApi']>
+}


### PR DESCRIPTION
- instrumentRpcTarget wraps any object with OTEL spans per method call
- Uses SpanKind.SERVER per OTEL RPC semconv spec
- Sets rpc.system.name, rpc.method, error.type attributes
- Detects capnweb-style { success: false, error } responses
- Namespaces custom attrs as catalyst.rpc.* to avoid semconv conflicts
- sanitizeAttributes redacts passwords when recordArguments enabled