### PR TITLE
feat(auth/rcp): initial integration into the AuthenticationService

### DIFF
--- a/packages/auth/scripts/validate-policies.ts
+++ b/packages/auth/scripts/validate-policies.ts
@@ -1,0 +1,21 @@
+import { AuthorizationEngine } from '@catalyst/authorization'
+import fs from 'fs'
+
+const schemaPath = process.env.CATALYST_AUTH_SCHEMA || './src/policies/schema.cedar'
+const policiesPath = process.env.CATALYST_AUTH_POLICIES || './src/policies/policies.cedar'
+
+const schema = fs.readFileSync(schemaPath, 'utf8')
+const policies = fs.readFileSync(policiesPath, 'utf8')
+
+console.log('Schema path:', schemaPath)
+console.log('Policies path:', policiesPath)
+
+const engine = new AuthorizationEngine(schema, policies)
+
+try {
+  engine.validatePolicies()
+  console.log('Policies validated successfully')
+} catch (error) {
+  console.error('Error validating policies:', error)
+  process.exit(1)
+}

--- a/packages/auth/src/policies/mappers/index.ts
+++ b/packages/auth/src/policies/mappers/index.ts
@@ -1,0 +1,1 @@
+export { userModelToEntityMapper } from './user-mapper.js'

--- a/packages/auth/src/policies/mappers/user-mapper.ts
+++ b/packages/auth/src/policies/mappers/user-mapper.ts
@@ -1,0 +1,27 @@
+import type { EntityUid, Mapper } from '@catalyst/authorization'
+import type { CatalystPolicyDomain, UserEntity } from '../types'
+
+/**
+ * Maps a user object to an entity for the CatalystPolicyDomain.
+ * @param user - The user object to convert to an entity.
+ * @returns The entity representing the user.
+ */
+export const userModelToEntityMapper: Mapper<CatalystPolicyDomain, UserEntity> = (
+  user: UserEntity
+) => {
+  const roles: EntityUid<CatalystPolicyDomain, 'Role'>[] = user.roles.map((role) => ({
+    type: 'Role',
+    id: role,
+  }))
+
+  return {
+    id: user.id,
+    attrs: {
+      email: user.email,
+      orgId: user.orgId,
+      createdAt: user.createdAt,
+      lastLoginAt: user.lastLoginAt,
+    },
+    parents: roles,
+  }
+}

--- a/packages/auth/src/policies/policies.cedar
+++ b/packages/auth/src/policies/policies.cedar
@@ -1,0 +1,48 @@
+// IBGP Resource Policy
+permit (
+    principal,
+    action in [Action::"open", Action::"close", Action::"update"],
+    resource is IBGP
+)
+when {
+    principal in Role::"admin" || principal in Role::"peer"
+};
+
+// Peer Resource Policy
+permit (
+    principal,
+    action in [Action::"create", Action::"update", Action::"delete", Action::"list", Action::"view"],
+    resource is Peer
+)
+when {
+    principal in Role::"admin" || principal in Role::"peer_custodian"
+};
+
+// Route Resource Policy
+permit (
+    principal,
+    action in [Action::"create", Action::"delete"],
+    resource is Route
+)
+when {
+    principal in Role::"admin" || principal in Role::"data_custodian"
+};
+
+permit (
+    principal,
+    action in [Action::"list", Action::"view"],
+    resource is Route
+)
+when {
+    principal in Role::"admin" || principal in Role::"data_custodian" || principal in Role::"user"
+};
+
+// Token Resource Policy
+permit (
+    principal,
+    action in [Action::"create", Action::"revoke", Action::"list"],
+    resource is Token
+)
+when {
+    principal in Role::"admin"
+};

--- a/packages/auth/src/policies/schema.cedar
+++ b/packages/auth/src/policies/schema.cedar
@@ -1,0 +1,54 @@
+entity User in [Role] {
+    id: String,
+    roles: Set<Role>,
+    email: String,
+    passwordHash: String,
+    roles: Set<String>,
+    orgId: String,
+    createdAt: String,
+    lastLoginAt?: String
+};
+
+entity Role = {
+    name: String
+};
+
+entity IBGP;
+entity Peer;
+entity Route;
+entity Token;
+
+action open, close appliesTo {
+    principal: User,
+    resource: IBGP
+};
+
+action update appliesTo {
+    principal: User,
+    resource: [IBGP, Peer]
+};
+
+action create appliesTo {
+    principal: User,
+    resource: [Peer, Route, Token]
+};
+
+action delete appliesTo {
+    principal: User,
+    resource: [Peer, Route]
+};
+
+action list appliesTo {
+    principal: User,
+    resource: [Peer, Route, Token]
+};
+
+action view appliesTo {
+    principal: User,
+    resource: [Peer, Route]
+};
+
+action revoke appliesTo {
+    principal: User,
+    resource: Token
+};

--- a/packages/auth/src/policies/types.ts
+++ b/packages/auth/src/policies/types.ts
@@ -1,0 +1,69 @@
+import type { AuthorizationDomain, AuthorizationEngine } from '@catalyst/authorization'
+import type { User as UserEntity } from '../models'
+
+/***
+ *
+ * TODO:
+ * - Add the missing entities and actions to the domain.
+ *
+ * NOTE: This is a temporary type definition for the Catalyst Policy Domain.
+ * It is not final and will be replaced with a more permanent solution in the future.
+ *
+ * We need to centralize the Data Models in one place. We could import them from the orchestrator
+ * package or elsewhere. Currently this entities below duplicate/replicating the values in orchestrator package.
+ *
+ *
+ */
+
+export type { UserEntity }
+
+export type RoleEntity = {
+  name: string
+}
+
+export type IBGPEntity = {
+  name: string
+  status: 'connected' | 'disconnected'
+  connectedAt: string
+  disconnectedAt?: string
+  lastUpdate: string
+  lastUpdateReason?: string
+  lastUpdateCode?: number
+  lastUpdateMessage?: string
+  lastUpdateError?: string
+}
+
+export type PeerEntity = {
+  name: string
+  status: 'connected' | 'disconnected'
+  connectedAt: string
+  disconnectedAt?: string
+  lastUpdate: string
+  lastUpdateReason?: string
+  lastUpdateCode?: number
+  lastUpdateMessage?: string
+  lastUpdateError?: string
+}
+
+export type RouteEntity = {
+  name: string
+  protocol: 'http' | 'http:graphql' | 'http:gql' | 'http:grpc'
+  endpoint?: string | undefined
+  region?: string | undefined
+  tags?: string[] | undefined
+}
+
+// Domain
+export interface CatalystPolicyDomain extends AuthorizationDomain {
+  Actions: 'login' | 'open' | 'close' | 'update' | 'create' | 'delete' | 'list' | 'view' | 'revoke'
+  Entities: {
+    User: UserEntity
+    Role: RoleEntity
+    IBGP: IBGPEntity
+    Peer: PeerEntity
+    Route: RouteEntity
+    AdminPanel: Record<string, unknown>
+  }
+}
+
+export type CatalystPolicyEngine = AuthorizationEngine<CatalystPolicyDomain>

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -1,22 +1,25 @@
+import {
+  AuthorizationEngine,
+  BunSqliteTokenStore,
+  LocalTokenManager,
+} from '@catalyst/authorization'
 import { Hono } from 'hono'
 import { websocket } from 'hono/bun'
-import { createKeyManagerFromEnv } from './key-manager/factory.js'
-import { AuthRpcServer, createAuthRpcHandler } from './rpc/server.js'
-import { InMemoryRevocationStore } from './revocation.js'
-import {
-    InMemoryUserStore,
-    InMemoryServiceAccountStore,
-    InMemoryBootstrapStore,
-} from './stores/memory.js'
-import {
-    LocalTokenManager,
-    BunSqliteTokenStore
-} from '@catalyst/authorization'
-import { BootstrapService } from './bootstrap.js'
-import { LoginService } from './login.js'
 import { ApiKeyService } from './api-key-service.js'
+import { BootstrapService } from './bootstrap.js'
+import { createKeyManagerFromEnv } from './key-manager/factory.js'
+import { LoginService } from './login.js'
 import { hashPassword } from './password.js'
 import { Permission } from './permissions.js'
+import { userModelToEntityMapper } from './policies/mappers'
+import type { CatalystPolicyDomain } from './policies/types.js'
+import { InMemoryRevocationStore } from './revocation.js'
+import { AuthRpcServer, createAuthRpcHandler } from './rpc/server.js'
+import {
+  InMemoryBootstrapStore,
+  InMemoryServiceAccountStore,
+  InMemoryUserStore,
+} from './stores/memory.js'
 
 /**
  * The system-wide administrative token minted at startup.
@@ -28,151 +31,169 @@ export let systemToken: string | undefined
  * Initializes and starts the Auth service.
  */
 export async function startServer() {
-    // Initialize KeyManager using factory pattern
-    const keyManager = createKeyManagerFromEnv()
-    await keyManager.initialize()
+  // Initialize KeyManager using factory pattern
+  const keyManager = createKeyManagerFromEnv()
+  await keyManager.initialize()
 
-    const currentKid = await keyManager.getCurrentKeyId()
-    console.log(JSON.stringify({ level: 'info', msg: 'KeyManager initialized', kid: currentKid }))
+  const currentKid = await keyManager.getCurrentKeyId()
+  console.log(JSON.stringify({ level: 'info', msg: 'KeyManager initialized', kid: currentKid }))
 
-    // Initialize token tracking
-    const tokenStore = new BunSqliteTokenStore(process.env.CATALYST_AUTH_DB || 'auth.db')
-    const tokenManager = new LocalTokenManager(keyManager, tokenStore)
+  // initialze the policy authorization engine
+  const policyService = new AuthorizationEngine<CatalystPolicyDomain>(
+    process.env.CATALYST_AUTH_SCHEMA || './policies/schema.cedar',
+    process.env.CATALYST_AUTH_POLICIES || './policies/policies.cedar'
+  )
+  const validationResult = policyService.validatePolicies()
+  if (!validationResult) {
+    console.error(JSON.stringify({ level: 'error', msg: 'Invalid policies' }))
+    process.exit(1)
+  }
 
-    // Mint system admin token
-    systemToken = await tokenManager.mint({
-        subject: 'system-admin',
-        entity: {
-            id: 'system',
-            name: 'System Admin',
-            type: 'service',
-        },
-        claims: {
-            role: 'admin',
-            permissions: [
-                Permission.TokenCreate,
-                Permission.TokenRevoke,
-                Permission.TokenList,
-                Permission.PeerCreate,
-                Permission.PeerUpdate,
-                Permission.PeerDelete,
-                Permission.RouteCreate,
-                Permission.RouteDelete,
-                Permission.IbgpConnect,
-                Permission.IbgpDisconnect,
-                Permission.IbgpUpdate,
-            ],
-        },
-    })
+  // Register user mapper: A converter function that takes objects from
+  // CatalystDataModel and converts them into entities for the CatalystPolicyDomain
+  policyService.entityBuilderFactory.registerMapper('User', userModelToEntityMapper)
 
-    console.log(JSON.stringify({ level: 'info', msg: 'System Admin Token minted', token: systemToken }))
+  // Initialize token tracking
+  const tokenStore = new BunSqliteTokenStore(process.env.CATALYST_AUTH_DB || 'auth.db')
+  const tokenManager = new LocalTokenManager(keyManager, tokenStore)
 
-    // Initialize revocation store if enabled
-    const revocationEnabled = process.env.CATALYST_AUTH_REVOCATION === 'true'
-    const revocationMaxSize = Number(process.env.CATALYST_AUTH_REVOCATION_MAX_SIZE) || undefined
-    const revocationStore = revocationEnabled
-        ? new InMemoryRevocationStore({ maxSize: revocationMaxSize })
-        : undefined
+  // Mint system admin token
+  systemToken = await tokenManager.mint({
+    subject: 'system-admin',
+    entity: {
+      id: 'system',
+      name: 'System Admin',
+      type: 'service',
+    },
+    claims: {
+      role: 'admin',
+      permissions: [
+        Permission.TokenCreate,
+        Permission.TokenRevoke,
+        Permission.TokenList,
+        Permission.PeerCreate,
+        Permission.PeerUpdate,
+        Permission.PeerDelete,
+        Permission.RouteCreate,
+        Permission.RouteDelete,
+        Permission.IbgpConnect,
+        Permission.IbgpDisconnect,
+        Permission.IbgpUpdate,
+      ],
+    },
+  })
 
-    if (revocationStore) {
-        console.log(
-            JSON.stringify({
-                level: 'info',
-                msg: 'Token revocation enabled',
-                maxSize: revocationStore.maxSize,
-            })
-        )
-    }
+  console.log(
+    JSON.stringify({ level: 'info', msg: 'System Admin Token minted', token: systemToken })
+  )
 
-    // Initialize stores
-    const userStore = new InMemoryUserStore()
-    const serviceAccountStore = new InMemoryServiceAccountStore()
-    const bootstrapStore = new InMemoryBootstrapStore()
+  // Initialize revocation store if enabled
+  const revocationEnabled = process.env.CATALYST_AUTH_REVOCATION === 'true'
+  const revocationMaxSize = Number(process.env.CATALYST_AUTH_REVOCATION_MAX_SIZE) || undefined
+  const revocationStore = revocationEnabled
+    ? new InMemoryRevocationStore({ maxSize: revocationMaxSize })
+    : undefined
 
-    // Initialize services
-    const bootstrapService = new BootstrapService(userStore, bootstrapStore)
-    const loginService = new LoginService(userStore, tokenManager)
-    const apiKeyService = new ApiKeyService(serviceAccountStore)
-
-    // Initialize bootstrap with env token or generate new one
-    const envBootstrapToken = process.env.CATALYST_BOOTSTRAP_TOKEN
-    const bootstrapTtl = Number(process.env.CATALYST_BOOTSTRAP_TTL) || 24 * 60 * 60 * 1000 // 24h default
-
-    if (envBootstrapToken) {
-        const tokenHash = await hashPassword(envBootstrapToken)
-        const expiresAt = new Date(Date.now() + bootstrapTtl)
-        await bootstrapStore.set({ tokenHash, expiresAt, used: false })
-        console.log(
-            JSON.stringify({
-                level: 'info',
-                msg: 'Bootstrap initialized from env',
-                expiresAt: expiresAt.toISOString(),
-            })
-        )
-    } else {
-        const result = await bootstrapService.initializeBootstrap({ expiresInMs: bootstrapTtl })
-        console.log(
-            JSON.stringify({
-                level: 'info',
-                msg: 'Bootstrap token generated',
-                token: result.token,
-                expiresAt: result.expiresAt.toISOString(),
-            })
-        )
-    }
-
-    const app = new Hono()
-    const rpcServer = new AuthRpcServer(
-        keyManager,
-        tokenManager,
-        revocationStore,
-        bootstrapService,
-        loginService,
-        apiKeyService
+  if (revocationStore) {
+    console.log(
+      JSON.stringify({
+        level: 'info',
+        msg: 'Token revocation enabled',
+        maxSize: revocationStore.maxSize,
+      })
     )
-    rpcServer.setSystemToken(systemToken)
-    const rpcApp = createAuthRpcHandler(rpcServer)
+  }
 
-    app.get('/', (c) => c.text('Catalyst Auth Service'))
-    app.get('/health', (c) => c.json({ status: 'ok' }))
-    app.get('/.well-known/jwks.json', async (c) => {
-        const jwks = await keyManager.getJwks()
-        c.header('Cache-Control', 'public, max-age=300')
-        return c.json(jwks)
-    })
-    app.route('/rpc', rpcApp)
+  // Initialize stores
+  const userStore = new InMemoryUserStore()
+  const serviceAccountStore = new InMemoryServiceAccountStore()
+  const bootstrapStore = new InMemoryBootstrapStore()
 
-    const port = Number(process.env.PORT) || 4001
-    console.log(JSON.stringify({ level: 'info', msg: 'Auth service started', port }))
+  // Initialize services
+  const bootstrapService = new BootstrapService(userStore, bootstrapStore)
+  const loginService = new LoginService(userStore, tokenManager)
+  const apiKeyService = new ApiKeyService(serviceAccountStore)
 
-    // Graceful shutdown
-    process.on('SIGTERM', async () => {
-        console.log(JSON.stringify({ level: 'info', msg: 'Shutting down...' }))
-        await keyManager.shutdown()
-        process.exit(0)
-    })
+  // Initialize bootstrap with env token or generate new one
+  const envBootstrapToken = process.env.CATALYST_BOOTSTRAP_TOKEN
+  const bootstrapTtl = Number(process.env.CATALYST_BOOTSTRAP_TTL) || 24 * 60 * 60 * 1000 // 24h default
 
-    return {
-        app,
-        port,
-        websocket,
-        systemToken,
-    }
+  if (envBootstrapToken) {
+    const tokenHash = await hashPassword(envBootstrapToken)
+    const expiresAt = new Date(Date.now() + bootstrapTtl)
+    await bootstrapStore.set({ tokenHash, expiresAt, used: false })
+    console.log(
+      JSON.stringify({
+        level: 'info',
+        msg: 'Bootstrap initialized from env',
+        expiresAt: expiresAt.toISOString(),
+      })
+    )
+  } else {
+    const result = await bootstrapService.initializeBootstrap({ expiresInMs: bootstrapTtl })
+    console.log(
+      JSON.stringify({
+        level: 'info',
+        msg: 'Bootstrap token generated',
+        token: result.token,
+        expiresAt: result.expiresAt.toISOString(),
+      })
+    )
+  }
+
+  const app = new Hono()
+  const rpcServer = new AuthRpcServer(
+    keyManager,
+    tokenManager,
+    revocationStore,
+    bootstrapService,
+    loginService,
+    apiKeyService,
+    policyService
+  )
+  rpcServer.setSystemToken(systemToken)
+  const rpcApp = createAuthRpcHandler(rpcServer)
+
+  app.get('/', (c) => c.text('Catalyst Auth Service'))
+  app.get('/health', (c) => c.json({ status: 'ok' }))
+  app.get('/.well-known/jwks.json', async (c) => {
+    const jwks = await keyManager.getJwks()
+    c.header('Cache-Control', 'public, max-age=300')
+    return c.json(jwks)
+  })
+  app.route('/rpc', rpcApp)
+
+  const port = Number(process.env.PORT) || 4001
+  console.log(JSON.stringify({ level: 'info', msg: 'Auth service started', port }))
+
+  // Graceful shutdown
+  process.on('SIGTERM', async () => {
+    console.log(JSON.stringify({ level: 'info', msg: 'Shutting down...' }))
+    await keyManager.shutdown()
+    process.exit(0)
+  })
+
+  return {
+    app,
+    port,
+    websocket,
+    systemToken,
+  }
 }
 
 // Auto-start if this file is the entry point
 if (import.meta.path === Bun.main) {
-    startServer().catch((err) => {
-        console.error('Failed to start server:', err)
-        process.exit(1)
-    })
+  startServer().catch((err) => {
+    console.error('Failed to start server:', err)
+    process.exit(1)
+  })
 }
 
 export default {
-    fetch: async (req: Request) => {
-        // This is for Bun's default export support, though usually we'd call startServer
-        // If not started, we'd need to handle it. For now, we assume startServer is the way.
-        const result = await startServer()
-        return result.app.fetch(req)
-    },
+  fetch: async (req: Request) => {
+    // This is for Bun's default export support, though usually we'd call startServer
+    // If not started, we'd need to handle it. For now, we assume startServer is the way.
+    const result = await startServer()
+    return result.app.fetch(req)
+  },
 }


### PR DESCRIPTION
### TL;DR

Implemented Cedar-based authorization policies for the Catalyst Auth service, enabling fine-grained access control based on user roles.

## Note
    // For @team:
    // I made a simple Demo/light integration with the policy service using 
    // only UserEntity type so you can see the typesafety
    //
    // for @GABRIEL; TODO:
    // just realized that (MAYBE) I can abstract this a bit more
    // and do another class on top and be like:
    //
    // Ill give it some thought and see if it makes sense to do so.
    //
    // seems like the pattern of builder, authorized, will be very repetitive

### What changed?

- Added Cedar policy files (`schema.cedar` and `policies.cedar`) defining authorization rules for different resources (IBGP, Peer, Route, Token)
- Created entity mappers to convert user models to policy entities
- Integrated the policy engine into the auth server's RPC validation flow
- Added a policy validation script to ensure policies are valid during development
- Defined TypeScript types for the policy domain and entities

### How to test?

1. Run the policy validation script to verify the Cedar policies:
   ```
   bun run packages/auth/scripts/validate-policies.ts
   ```

### Why make this change?

This change replaces the hardcoded permission checks with a more flexible and maintainable policy-based authorization system. Using Cedar policies allows for:

1. Declarative definition of access control rules
2. Easier management of complex permission scenarios
3. Better separation of authorization logic from application code
4. More granular control over resource access based on user roles and attributes