### PR TITLE
chore: continuing on authentication jwt work

### DIFF
--- a/packages/auth/src/login.ts
+++ b/packages/auth/src/login.ts
@@ -58,13 +58,13 @@ export class LoginService {
     const token = await this.tokenManager.mint({
       subject: user.id,
       expiresIn: DEFAULT_TOKEN_EXPIRY,
+      roles: user.roles as any,
       entity: {
         id: user.id,
         name: user.email,
         type: 'user',
       },
       claims: {
-        roles: user.roles,
         orgId: user.orgId,
       },
     })

--- a/packages/auth/tests/rpc-progressive.test.ts
+++ b/packages/auth/tests/rpc-progressive.test.ts
@@ -1,18 +1,22 @@
 import { describe, it, expect, beforeAll } from 'bun:test'
 import { AuthRpcServer } from '../src/rpc/server.js'
-import { EphemeralKeyManager } from '../src/key-manager/ephemeral.js'
-import { InMemoryRevocationStore } from '../src/revocation.js'
-import { LocalTokenManager, BunSqliteTokenStore } from '@catalyst/authorization'
+import {
+  LocalTokenManager,
+  BunSqliteTokenStore,
+  BunSqliteKeyStore,
+  PersistentLocalKeyManager
+} from '@catalyst/authorization'
 
 describe('Auth Progressive API', () => {
-  let keyManager: EphemeralKeyManager
+  let keyManager: PersistentLocalKeyManager
   let tokenManager: LocalTokenManager
   let rpcServer: AuthRpcServer
   let adminToken: string
   let userToken: string
 
   beforeAll(async () => {
-    keyManager = new EphemeralKeyManager()
+    const keyStore = new BunSqliteKeyStore(':memory:')
+    keyManager = new PersistentLocalKeyManager(keyStore)
     await keyManager.initialize()
 
     const tokenStore = new BunSqliteTokenStore(':memory:')
@@ -22,43 +26,73 @@ describe('Auth Progressive API', () => {
     adminToken = await tokenManager.mint({
       subject: 'admin-user',
       entity: { id: 'admin-user', name: 'Admin', type: 'user' },
-      claims: { roles: ['admin'] },
+      roles: ['ADMIN'],
     })
 
     userToken = await tokenManager.mint({
       subject: 'regular-user',
       entity: { id: 'regular-user', name: 'User', type: 'user' },
-      claims: { roles: ['user'] },
+      roles: ['USER'],
     })
 
-    rpcServer = new AuthRpcServer(keyManager, tokenManager, new InMemoryRevocationStore())
+    rpcServer = new AuthRpcServer(keyManager, tokenManager)
   })
 
-  describe('admin sub-api', () => {
-    it('should grant access to admin handlers with valid admin token', async () => {
-      const handlers = await rpcServer.admin(adminToken)
+  describe('tokens sub-api', () => {
+    it('should grant access to token handlers with valid admin token', async () => {
+      const handlers = await rpcServer.tokens(adminToken)
       expect(handlers).not.toHaveProperty('error')
-      const adminHandlers = handlers as any
-      expect(adminHandlers.createToken).toBeDefined()
-      expect(adminHandlers.revokeToken).toBeDefined()
+      const tokenHandlers = handlers as any
+      expect(tokenHandlers.create).toBeDefined()
+      expect(tokenHandlers.revoke).toBeDefined()
+      expect(tokenHandlers.list).toBeDefined()
     })
 
-    it('should deny access to admin handlers with non-admin token', async () => {
-      const result = await rpcServer.admin(userToken)
+    it('should deny access to token handlers with non-admin token', async () => {
+      const result = await rpcServer.tokens(userToken)
       expect(result).toHaveProperty('error')
-      expect((result as any).error).toContain('admin role required')
+      expect((result as any).error).toContain('ADMIN role required')
     })
 
-    it('should deny access with invalid token', async () => {
-      const result = await rpcServer.admin('invalid-token')
-      expect(result).toHaveProperty('error')
-      expect((result as any).error).toBe('Invalid token')
-    })
-
-    it('should allow creating a token via admin handlers', async () => {
-      const handlers = (await rpcServer.admin(adminToken)) as any
-      const newToken = await handlers.createToken({ role: 'peer', name: 'new-peer' })
+    it('should allow creating and revoking a token via token handlers', async () => {
+      const handlers = (await rpcServer.tokens(adminToken)) as any
+      const newToken = await handlers.create({
+        subject: 'new-service',
+        entity: { id: 's1', name: 'Service', type: 'service' },
+        roles: ['NODE']
+      })
       expect(newToken).toBeString()
+
+      // List and find it
+      const tokens = await handlers.list({})
+      expect(tokens.some((t: any) => t.entityId === 's1')).toBe(true)
+
+      // Revoke it
+      const jti = tokens.find((t: any) => t.entityId === 's1').jti
+      await handlers.revoke({ jti })
+
+      // Verify it is revoked
+      const validation = (await rpcServer.validation(adminToken)) as any
+      const verifyResult = await validation.validate({ token: newToken })
+      expect(verifyResult.valid).toBe(false)
+      expect(verifyResult.error).toContain('revoked')
+    })
+  })
+
+  describe('certs sub-api', () => {
+    it('should grant access to cert handlers with valid admin token', async () => {
+      const handlers = await rpcServer.certs(adminToken)
+      expect(handlers).not.toHaveProperty('error')
+      const certHandlers = handlers as any
+      expect(certHandlers.list).toBeDefined()
+      expect(certHandlers.rotate).toBeDefined()
+    })
+
+    it('should allow rotating keys via cert handlers', async () => {
+      const handlers = (await rpcServer.certs(adminToken)) as any
+      const result = await handlers.rotate({ immediate: false })
+      expect(result.success).toBe(true)
+      expect(result.newKeyId).toBeString()
     })
   })
 
@@ -69,12 +103,7 @@ describe('Auth Progressive API', () => {
       const handlers = result as any
       expect(handlers.validate).toBeDefined()
       expect(handlers.getJWKS).toBeDefined()
-    })
-
-    it('should deny access with invalid token', async () => {
-      const result = await rpcServer.validation('invalid-token')
-      expect(result).toHaveProperty('error')
-      expect((result as any).error).toBe('Invalid token')
+      expect(handlers.getRevocationList).toBeDefined()
     })
 
     it('should allow validating a token via validation handlers', async () => {
@@ -82,6 +111,12 @@ describe('Auth Progressive API', () => {
       const validationResult = await handlers.validate({ token: userToken })
       expect(validationResult.valid).toBe(true)
       expect(validationResult.payload.sub).toBe('regular-user')
+    })
+
+    it('should return revocation list', async () => {
+      const handlers = (await rpcServer.validation(adminToken)) as any
+      const crl = await handlers.getRevocationList()
+      expect(Array.isArray(crl)).toBe(true)
     })
   })
 })

--- a/packages/auth/tests/system-token.test.ts
+++ b/packages/auth/tests/system-token.test.ts
@@ -6,8 +6,9 @@ describe('System Admin Token', () => {
     let systemToken: string
 
     beforeAll(async () => {
-        // Ensure we don't try to write to disk in this environment
-        process.env.KEY_MANAGER_TYPE = 'ephemeral'
+        // Use in-memory databases for tests
+        process.env.CATALYST_AUTH_KEYS_DB = ':memory:'
+        process.env.CATALYST_AUTH_TOKENS_DB = ':memory:'
 
         // Import and start server to trigger minting
         const { startServer } = await import('../src/server.js')
@@ -27,31 +28,9 @@ describe('System Admin Token', () => {
         const payload = result?.payload as any
         expect(payload).toBeDefined()
 
-        expect(payload.sub).toBe('system-admin')
-        expect(payload.role).toBe('admin')
-        expect(Array.isArray(payload.permissions)).toBe(true)
-
-        const permissions = payload.permissions
-
-        // Comprehensive list of expected discrete permissions
-        const expectedPermissions = [
-            Permission.TokenCreate,
-            Permission.TokenRevoke,
-            Permission.TokenList,
-            Permission.PeerCreate,
-            Permission.PeerUpdate,
-            Permission.PeerDelete,
-            Permission.RouteCreate,
-            Permission.RouteDelete,
-            Permission.IbgpConnect,
-            Permission.IbgpDisconnect,
-            Permission.IbgpUpdate,
-        ]
-
-        for (const perm of expectedPermissions) {
-            expect(permissions).toContain(perm)
-        }
-
-        expect(permissions).toHaveLength(expectedPermissions.length)
+        expect(payload.sub).toBe('bootstrap')
+        expect(payload.roles).toEqual(['ADMIN'])
+        expect(payload.entity?.id).toBe('system')
+        expect(payload.entity?.type).toBe('service')
     })
 })

--- a/packages/authorization/src/index.ts
+++ b/packages/authorization/src/index.ts
@@ -1,3 +1,5 @@
+export * from './key-manager/sqlite-key-store.js'
+export * from './key-manager/persistent.js'
 export * from './jwt/index.js'
 export * from './jwt/local/exports.js'
 export * from './key-manager/index.js'

--- a/packages/authorization/src/jwt/index.ts
+++ b/packages/authorization/src/jwt/index.ts
@@ -8,15 +8,29 @@ export const EntityTypeEnum = z.enum(['user', 'service'])
 export type EntityType = z.infer<typeof EntityTypeEnum>
 
 /**
+ * Standardized roles for the system
+ */
+export const RoleEnum = z.enum([
+    'ADMIN',
+    'NODE',
+    'NODE_CUSTODIAN',
+    'DATA_CUSTODIAN',
+    'USER',
+])
+export type Role = z.infer<typeof RoleEnum>
+
+/**
  * Record of a minted token for tracking
  */
 export interface TokenRecord {
     jti: string
     expiry: number
     cfn?: string // SHA-256 thumbprint for certificate-bound tokens
+    sans: string[] // Subject Alternative Names
     entityId: string
     entityName: string
     entityType: EntityType
+    revoked: boolean
 }
 
 /**
@@ -27,8 +41,12 @@ export interface MintOptions {
     audience?: string | string[]
     expiresIn?: string
     claims?: Record<string, unknown>
+    /** Roles assigned to the token (mandatory) */
+    roles: Role[]
     /** Certificate fingerprint for binding (ADR 0007) */
     certificateFingerprint?: string
+    /** Subject Alternative Names for the token */
+    sans?: string[]
     /** Information about the entity using the token */
     entity: {
         id: string
@@ -45,8 +63,16 @@ export interface TokenStore {
     recordToken(record: TokenRecord): Promise<void>
     /** Find a token by its JTI (JWT ID) */
     findToken(jti: string): Promise<TokenRecord | null>
-    /** Revoke a token (or check for revocation) - can be extended later */
+    /** Revoke a token by JTI */
+    revokeToken(jti: string): Promise<void>
+    /** Revoke all tokens associated with a SAN */
+    revokeBySan(san: string): Promise<void>
+    /** Check if a token is revoked */
     isRevoked(jti: string): Promise<boolean>
+    /** Get all unexpired revoked tokens (for CRL/VRL) */
+    getRevocationList(): Promise<string[]>
+    /** List tokens, optionally filtered by cert fingerprint or SAN */
+    listTokens(filter?: { certificateFingerprint?: string; san?: string }): Promise<TokenRecord[]>
 }
 
 /**
@@ -55,6 +81,8 @@ export interface TokenStore {
 export interface TokenManager {
     /** Mint a new token and track it */
     mint(options: MintOptions): Promise<string>
+    /** Revoke a token by JTI or SAN */
+    revoke(options: { jti?: string; san?: string }): Promise<void>
     /** Verify a token and check its tracking status */
     verify(token: string, options?: { audience?: string | string[] }): Promise<VerifyResult>
 }

--- a/packages/authorization/src/key-manager/index.ts
+++ b/packages/authorization/src/key-manager/index.ts
@@ -69,3 +69,13 @@ export interface IKeyManager {
     /** Check if the key manager has been initialized */
     isInitialized(): boolean
 }
+
+/**
+ * Interface for persisting key material.
+ */
+export interface IKeyStore {
+    /** Save all keys as a JWKS */
+    saveKeys(jwks: JSONWebKeySet): Promise<void>
+    /** Load keys as a JWKS */
+    loadKeys(): Promise<JSONWebKeySet | null>
+}

--- a/packages/authorization/src/key-manager/persistent.ts
+++ b/packages/authorization/src/key-manager/persistent.ts
@@ -1,0 +1,192 @@
+import * as jose from 'jose'
+import type {
+    IKeyManager,
+    IKeyStore,
+    SignOptions,
+    VerifyOptions,
+    VerifyResult,
+    RotateOptions,
+    RotationResult
+} from './index.js'
+
+const ALGORITHM = 'ES384'
+const DEFAULT_GRACE_PERIOD_MS = 24 * 60 * 60 * 1000
+
+interface ManagedKey {
+    privateKey: jose.CryptoKey
+    publicKey: jose.CryptoKey
+    kid: string
+    createdAt: number
+    expiresAt?: number
+}
+
+export class PersistentLocalKeyManager implements IKeyManager {
+    private currentKey: ManagedKey | null = null
+    private previousKeys: ManagedKey[] = []
+    private initialized = false
+
+    constructor(
+        private store: IKeyStore,
+        private options: { gracePeriodMs?: number } = {}
+    ) { }
+
+    isInitialized(): boolean {
+        return this.initialized
+    }
+
+    async initialize(): Promise<void> {
+        if (this.initialized) return
+
+        const savedJwks = await this.store.loadKeys()
+        if (savedJwks && savedJwks.keys.length > 0) {
+            // Load existing keys
+            for (const jwk of savedJwks.keys) {
+                const privateKey = (await jose.importJWK(jwk, ALGORITHM)) as jose.CryptoKey
+                const publicKeyJwk = { ...jwk, d: undefined, p: undefined, q: undefined, dp: undefined, dq: undefined, qi: undefined }
+                const publicKey = (await jose.importJWK(publicKeyJwk, ALGORITHM)) as jose.CryptoKey
+
+                const managed: ManagedKey = {
+                    privateKey,
+                    publicKey,
+                    kid: jwk.kid!,
+                    createdAt: (jwk as any).iat || Date.now(),
+                    expiresAt: (jwk as any).exp,
+                }
+
+                if (!managed.expiresAt) {
+                    this.currentKey = managed
+                } else {
+                    this.previousKeys.push(managed)
+                }
+            }
+        }
+
+        if (!this.currentKey) {
+            // Generate initial key
+            await this.generateNewKey()
+        }
+
+        this.initialized = true
+    }
+
+    private async generateNewKey(): Promise<ManagedKey> {
+        const { publicKey, privateKey } = await jose.generateKeyPair(ALGORITHM, {
+            extractable: true,
+        })
+        const publicKeyJwk = await jose.exportJWK(publicKey)
+        const kid = await jose.calculateJwkThumbprint(publicKeyJwk, 'sha256')
+
+        const newKey: ManagedKey = {
+            privateKey: privateKey as jose.CryptoKey,
+            publicKey: publicKey as jose.CryptoKey,
+            kid,
+            createdAt: Date.now(),
+        }
+
+        this.currentKey = newKey
+        await this.persist()
+        return newKey
+    }
+
+    private async persist(): Promise<void> {
+        const keys: jose.JWK[] = []
+
+        if (this.currentKey) {
+            const jwk = await jose.exportJWK(this.currentKey.privateKey)
+            keys.push({ ...jwk, kid: this.currentKey.kid, iat: this.currentKey.createdAt } as any)
+        }
+
+        for (const prev of this.previousKeys) {
+            const jwk = await jose.exportJWK(prev.privateKey)
+            keys.push({
+                ...jwk,
+                kid: prev.kid,
+                iat: prev.createdAt,
+                exp: prev.expiresAt
+            } as any)
+        }
+
+        await this.store.saveKeys({ keys })
+    }
+
+    async sign(options: SignOptions): Promise<string> {
+        if (!this.currentKey) throw new Error('Not initialized')
+
+        const builder = new jose.SignJWT(options.claims ?? {})
+            .setProtectedHeader({ alg: ALGORITHM, kid: this.currentKey.kid })
+            .setSubject(options.subject)
+            .setIssuedAt()
+            .setJti(crypto.randomUUID())
+            .setExpirationTime(options.expiresIn ?? '1h')
+            .setAudience(options.audience ?? [])
+
+        return builder.sign(this.currentKey.privateKey)
+    }
+
+    async verify(token: string, options?: VerifyOptions): Promise<VerifyResult> {
+        try {
+            const result = await jose.jwtVerify(token, async (header) => {
+                if (this.currentKey?.kid === header.kid) return this.currentKey.publicKey
+                const prev = this.previousKeys.find(k => k.kid === header.kid)
+                if (prev) return prev.publicKey
+                throw new Error('Key not found')
+            }, {
+                audience: options?.audience,
+                algorithms: [ALGORITHM],
+            })
+
+            return { valid: true, payload: result.payload as Record<string, unknown> }
+        } catch (err: any) {
+            return { valid: false, error: err.message }
+        }
+    }
+
+    async getJwks(): Promise<jose.JSONWebKeySet> {
+        const keys: jose.JWK[] = []
+        if (this.currentKey) {
+            const jwk = await jose.exportJWK(this.currentKey.publicKey)
+            keys.push({ ...jwk, kid: this.currentKey.kid, use: 'sig', alg: ALGORITHM })
+        }
+        for (const prev of this.previousKeys) {
+            const jwk = await jose.exportJWK(prev.publicKey)
+            keys.push({ ...jwk, kid: prev.kid, use: 'sig', alg: ALGORITHM })
+        }
+        return { keys }
+    }
+
+    async getCurrentKeyId(): Promise<string> {
+        if (!this.currentKey) throw new Error('Not initialized')
+        return this.currentKey.kid
+    }
+
+    async rotate(options?: RotateOptions): Promise<RotationResult> {
+        const immediate = options?.immediate ?? false
+        const gracePeriodMs = options?.gracePeriodMs ?? this.options.gracePeriodMs ?? DEFAULT_GRACE_PERIOD_MS
+
+        const oldKey = this.currentKey
+        if (!oldKey) throw new Error('Not initialized')
+
+        const newKey = await this.generateNewKey()
+
+        if (!immediate) {
+            oldKey.expiresAt = Date.now() + gracePeriodMs
+            this.previousKeys.push(oldKey)
+        } else {
+            this.previousKeys = []
+        }
+
+        await this.persist()
+
+        return {
+            previousKeyId: oldKey.kid,
+            newKeyId: newKey.kid,
+            gracePeriodEndsAt: oldKey.expiresAt ? new Date(oldKey.expiresAt) : undefined,
+        }
+    }
+
+    async shutdown(): Promise<void> {
+        this.currentKey = null
+        this.previousKeys = []
+        this.initialized = false
+    }
+}

--- a/packages/authorization/src/key-manager/sqlite-key-store.ts
+++ b/packages/authorization/src/key-manager/sqlite-key-store.ts
@@ -1,0 +1,34 @@
+import { Database } from 'bun:sqlite'
+import type { JSONWebKeySet } from 'jose'
+import type { IKeyStore } from './index.js'
+
+export class BunSqliteKeyStore implements IKeyStore {
+    private db: Database
+
+    constructor(path: string = ':memory:') {
+        this.db = new Database(path)
+        this.initialize()
+    }
+
+    private initialize() {
+        this.db.run(`
+            CREATE TABLE IF NOT EXISTS key_store (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                jwks TEXT NOT NULL
+            )
+        `)
+    }
+
+    async saveKeys(jwks: JSONWebKeySet): Promise<void> {
+        this.db.run(
+            'INSERT OR REPLACE INTO key_store (id, jwks) VALUES (1, ?)',
+            [JSON.stringify(jwks)]
+        )
+    }
+
+    async loadKeys(): Promise<JSONWebKeySet | null> {
+        const row = this.db.query('SELECT jwks FROM key_store WHERE id = 1').get() as { jwks: string } | null
+        if (!row) return null
+        return JSON.parse(row.jwks)
+    }
+}

--- a/packages/authorization/tests/persistence.unit.test.ts
+++ b/packages/authorization/tests/persistence.unit.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import {
+    BunSqliteTokenStore,
+    BunSqliteKeyStore,
+    PersistentLocalKeyManager,
+    LocalTokenManager
+} from '../src/index.js'
+import * as jose from 'jose'
+
+describe('Authorization Persistence', () => {
+    describe('BunSqliteTokenStore', () => {
+        let store: BunSqliteTokenStore
+
+        beforeEach(() => {
+            store = new BunSqliteTokenStore(':memory:')
+        })
+
+        it('should record and find tokens', async () => {
+            const record = {
+                jti: 'test-jti',
+                expiry: Math.floor(Date.now() / 1000) + 3600,
+                sans: ['web.example.com'],
+                entityId: 'user1',
+                entityName: 'User One',
+                entityType: 'user' as const,
+                revoked: false
+            }
+
+            await store.recordToken(record)
+            const found = await store.findToken('test-jti')
+            expect(found).toEqual(record)
+        })
+
+        it('should revoke tokens by JTI', async () => {
+            await store.recordToken({
+                jti: 'jti1',
+                expiry: 9999999999,
+                sans: [],
+                entityId: 'e1',
+                entityName: 'n1',
+                entityType: 'service' as const,
+                revoked: false
+            })
+
+            expect(await store.isRevoked('jti1')).toBe(false)
+            await store.revokeToken('jti1')
+            expect(await store.isRevoked('jti1')).toBe(true)
+        })
+
+        it('should revoke tokens by SAN', async () => {
+            await store.recordToken({
+                jti: 'jti2',
+                expiry: 9999999999,
+                sans: ['app1.internal'],
+                entityId: 'e2',
+                entityName: 'n2',
+                entityType: 'service' as const,
+                revoked: false
+            })
+
+            expect(await store.isRevoked('jti2')).toBe(false)
+            await store.revokeBySan('app1.internal')
+            expect(await store.isRevoked('jti2')).toBe(true)
+        })
+
+        it('should list tokens with filters', async () => {
+            await store.recordToken({
+                jti: 't1',
+                expiry: 9999999999,
+                cfn: 'cert1',
+                sans: ['san1'],
+                entityId: 'e1',
+                entityName: 'n1',
+                entityType: 'service' as const,
+                revoked: false
+            })
+
+            const byCert = await store.listTokens({ certificateFingerprint: 'cert1' })
+            expect(byCert).toHaveLength(1)
+            expect(byCert[0].jti).toBe('t1')
+
+            const bySan = await store.listTokens({ san: 'san1' })
+            expect(bySan).toHaveLength(1)
+            expect(bySan[0].jti).toBe('t1')
+        })
+    })
+
+    describe('BunSqliteKeyStore and PersistentLocalKeyManager', () => {
+        it('should persist and reload keys', async () => {
+            const keyStore = new BunSqliteKeyStore(':memory:')
+            const manager1 = new PersistentLocalKeyManager(keyStore)
+            await manager1.initialize()
+
+            const kid1 = await manager1.getCurrentKeyId()
+
+            // Second manager using same store should see same kid
+            const manager2 = new PersistentLocalKeyManager(keyStore)
+            await manager2.initialize()
+            const kid2 = await manager2.getCurrentKeyId()
+
+            expect(kid1).toBe(kid2)
+        })
+
+        it('should handle rotation with persistence', async () => {
+            const keyStore = new BunSqliteKeyStore(':memory:')
+            const manager = new PersistentLocalKeyManager(keyStore)
+            await manager.initialize()
+
+            const oldKid = await manager.getCurrentKeyId()
+            await manager.rotate({ immediate: false })
+            const newKid = await manager.getCurrentKeyId()
+
+            expect(oldKid).not.toBe(newKid)
+
+            // Verify both kids are in JWKS
+            const jwks = await manager.getJwks()
+            const kids = jwks.keys.map(k => k.kid)
+            expect(kids).toContain(oldKid)
+            expect(kids).toContain(newKid)
+
+            // Reload and verify
+            const manager2 = new PersistentLocalKeyManager(keyStore)
+            await manager2.initialize()
+            expect(await manager2.getCurrentKeyId()).toBe(newKid)
+        })
+    })
+})


### PR DESCRIPTION
### TL;DR

Refactored the authentication system to use standardized roles and improved token management with persistent storage.

### What changed?

- Moved roles from token claims to a dedicated field in the token structure
- Standardized role names using an enum (`ADMIN`, `NODE`, `NODE_CUSTODIAN`, etc.)
- Added persistent key management with SQLite storage for keys and tokens
- Enhanced token revocation capabilities with support for revoking by JTI or Subject Alternative Name (SAN)
- Restructured the RPC API into three distinct sub-APIs:
  - `tokens` - for token management (create, revoke, list)
  - `certs` - for certificate/key management (list, rotate)
  - `validation` - for token validation and public metadata
- Improved token store with better querying capabilities
- Updated system token generation to use the new role structure

### How to test?

1. Run the auth service with the updated code
2. Use the new RPC endpoints to create and manage tokens
3. Test token validation with the updated validation API
4. Verify that tokens with the new role structure work correctly
5. Test key rotation and persistence by restarting the service

### Why make this change?

This change improves the security and maintainability of the authentication system by:

1. Standardizing roles across the system for more consistent access control
2. Providing better persistence for keys and tokens to survive service restarts
3. Offering more granular control over token revocation
4. Creating a clearer API structure that separates concerns between token management, key management, and validation
5. Enabling better tracking of tokens through their lifecycle