### PR TITLE
feat: wokring on making token minting more strict

### DIFF
--- a/packages/auth/src/login.ts
+++ b/packages/auth/src/login.ts
@@ -1,5 +1,5 @@
 import type { UserStore } from './stores/types.js'
-import type { TokenManager } from '@catalyst/authorization'
+import { type TokenManager, type Role } from '@catalyst/authorization'
 import { verifyPassword, DUMMY_HASH } from './password.js'
 
 /**
@@ -33,7 +33,7 @@ export class LoginService {
   constructor(
     private userStore: UserStore,
     private tokenManager: TokenManager
-  ) { }
+  ) {}
 
   /**
    * Authenticate user and issue JWT
@@ -58,7 +58,7 @@ export class LoginService {
     const token = await this.tokenManager.mint({
       subject: user.id,
       expiresIn: DEFAULT_TOKEN_EXPIRY,
-      roles: user.roles as any,
+      roles: user.roles as Role[],
       entity: {
         id: user.id,
         name: user.email,

--- a/packages/auth/src/rpc/schema.ts
+++ b/packages/auth/src/rpc/schema.ts
@@ -1,12 +1,7 @@
 import { z } from 'zod'
+import { type TokenRecord } from '@catalyst/authorization'
 
-export const RoleSchema = z.enum([
-  'ADMIN',
-  'NODE',
-  'NODE_CUSTODIAN',
-  'DATA_CUSTODIAN',
-  'USER',
-])
+export const RoleSchema = z.enum(['ADMIN', 'NODE', 'NODE_CUSTODIAN', 'DATA_CUSTODIAN', 'USER'])
 
 /**
  * SignToken Request/Response schemas
@@ -343,7 +338,7 @@ export interface TokenHandlers {
   /** Revoke a token by JTI or SAN */
   revoke(request: { jti?: string; san?: string }): Promise<void>
   /** List tokens with optional filters */
-  list(request: { certificateFingerprint?: string; san?: string }): Promise<any[]>
+  list(request: { certificateFingerprint?: string; san?: string }): Promise<TokenRecord[]>
 }
 
 export interface CertHandlers {
@@ -352,7 +347,7 @@ export interface CertHandlers {
   /** Rotate to a new signing key */
   rotate(request?: { immediate?: boolean; gracePeriodMs?: number }): Promise<RotateResponse>
   /** List all tokens minted against a specific certificate */
-  getTokensByCert(request: { fingerprint: string }): Promise<any[]>
+  getTokensByCert(request: { fingerprint: string }): Promise<TokenRecord[]>
 }
 
 export interface ValidationHandlers {

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -7,18 +7,17 @@ import { Hono } from 'hono'
 import { websocket } from 'hono/bun'
 import { ApiKeyService } from './api-key-service.js'
 import { BootstrapService } from './bootstrap.js'
-import { createKeyManagerFromEnv } from './key-manager/factory.js'
 import { AuthRpcServer, createAuthRpcHandler } from './rpc/server.js'
 import {
-    InMemoryUserStore,
-    InMemoryServiceAccountStore,
-    InMemoryBootstrapStore,
+  InMemoryUserStore,
+  InMemoryServiceAccountStore,
+  InMemoryBootstrapStore,
 } from './stores/memory.js'
 import {
-    LocalTokenManager,
-    BunSqliteTokenStore,
-    BunSqliteKeyStore,
-    PersistentLocalKeyManager,
+  LocalTokenManager,
+  BunSqliteTokenStore,
+  BunSqliteKeyStore,
+  PersistentLocalKeyManager,
 } from '@catalyst/authorization'
 import { BootstrapService } from './bootstrap.js'
 import { LoginService } from './login.js'
@@ -44,10 +43,10 @@ export let systemToken: string | undefined
  * Initializes and starts the Auth service.
  */
 export async function startServer() {
-    // Initialize Key persistence
-    const keyStore = new BunSqliteKeyStore(process.env.CATALYST_AUTH_KEYS_DB || 'keys.db')
-    const keyManager = new PersistentLocalKeyManager(keyStore)
-    await keyManager.initialize()
+  // Initialize Key persistence
+  const keyStore = new BunSqliteKeyStore(process.env.CATALYST_AUTH_KEYS_DB || 'keys.db')
+  const keyManager = new PersistentLocalKeyManager(keyStore)
+  await keyManager.initialize()
 
   const currentKid = await keyManager.getCurrentKeyId()
   console.log(JSON.stringify({ level: 'info', msg: 'KeyManager initialized', kid: currentKid }))
@@ -67,21 +66,21 @@ export async function startServer() {
   // CatalystDataModel and converts them into entities for the CatalystPolicyDomain
   policyService.entityBuilderFactory.registerMapper('User', userModelToEntityMapper)
 
-    // Initialize token tracking
-    const tokenStore = new BunSqliteTokenStore(process.env.CATALYST_AUTH_TOKENS_DB || 'tokens.db')
-    const tokenManager = new LocalTokenManager(keyManager, tokenStore)
+  // Initialize token tracking
+  const tokenStore = new BunSqliteTokenStore(process.env.CATALYST_AUTH_TOKENS_DB || 'tokens.db')
+  const tokenManager = new LocalTokenManager(keyManager, tokenStore)
 
-    // Mint system admin token
-    systemToken = await tokenManager.mint({
-        subject: 'bootstrap',
-        entity: {
-            id: 'system',
-            name: 'System Admin',
-            type: 'service',
-        },
-        roles: ['ADMIN'],
-        expiresIn: '365d',
-    })
+  // Mint system admin token
+  systemToken = await tokenManager.mint({
+    subject: 'bootstrap',
+    entity: {
+      id: 'system',
+      name: 'System Admin',
+      type: 'service',
+    },
+    roles: ['ADMIN'],
+    expiresIn: '365d',
+  })
 
   console.log(
     JSON.stringify({ level: 'info', msg: 'System Admin Token minted', token: systemToken })
@@ -108,7 +107,15 @@ export async function startServer() {
   const userStore = new InMemoryUserStore()
   const serviceAccountStore = new InMemoryServiceAccountStore()
   const bootstrapStore = new InMemoryBootstrapStore()
+  // Initialize stores
+  const userStore = new InMemoryUserStore()
+  const serviceAccountStore = new InMemoryServiceAccountStore()
+  const bootstrapStore = new InMemoryBootstrapStore()
 
+  // Initialize services
+  const bootstrapService = new BootstrapService(userStore, bootstrapStore)
+  const loginService = new LoginService(userStore, tokenManager)
+  const apiKeyService = new ApiKeyService(serviceAccountStore)
   // Initialize services
   const bootstrapService = new BootstrapService(userStore, bootstrapStore)
   const loginService = new LoginService(userStore, tokenManager)
@@ -117,7 +124,32 @@ export async function startServer() {
   // Initialize bootstrap with env token or generate new one
   const envBootstrapToken = process.env.CATALYST_BOOTSTRAP_TOKEN
   const bootstrapTtl = Number(process.env.CATALYST_BOOTSTRAP_TTL) || 24 * 60 * 60 * 1000 // 24h default
+  // Initialize bootstrap with env token or generate new one
+  const envBootstrapToken = process.env.CATALYST_BOOTSTRAP_TOKEN
+  const bootstrapTtl = Number(process.env.CATALYST_BOOTSTRAP_TTL) || 24 * 60 * 60 * 1000 // 24h default
 
+  if (envBootstrapToken) {
+    const tokenHash = await hashPassword(envBootstrapToken)
+    const expiresAt = new Date(Date.now() + bootstrapTtl)
+    await bootstrapStore.set({ tokenHash, expiresAt, used: false })
+    console.log(
+      JSON.stringify({
+        level: 'info',
+        msg: 'Bootstrap initialized from env',
+        expiresAt: expiresAt.toISOString(),
+      })
+    )
+  } else {
+    const result = await bootstrapService.initializeBootstrap({ expiresInMs: bootstrapTtl })
+    console.log(
+      JSON.stringify({
+        level: 'info',
+        msg: 'Bootstrap token generated',
+        token: result.token,
+        expiresAt: result.expiresAt.toISOString(),
+      })
+    )
+  }
   if (envBootstrapToken) {
     const tokenHash = await hashPassword(envBootstrapToken)
     const expiresAt = new Date(Date.now() + bootstrapTtl)
@@ -145,11 +177,11 @@ export async function startServer() {
   const rpcServer = new AuthRpcServer(
     keyManager,
     tokenManager,
-    revocationStore,
     bootstrapService,
     loginService,
     apiKeyService,
-    policyService
+    policyService,
+    
   )
   rpcServer.setSystemToken(systemToken)
   const rpcApp = createAuthRpcHandler(rpcServer)
@@ -162,7 +194,17 @@ export async function startServer() {
     return c.json(jwks)
   })
   app.route('/rpc', rpcApp)
+  app.get('/', (c) => c.text('Catalyst Auth Service'))
+  app.get('/health', (c) => c.json({ status: 'ok' }))
+  app.get('/.well-known/jwks.json', async (c) => {
+    const jwks = await keyManager.getJwks()
+    c.header('Cache-Control', 'public, max-age=300')
+    return c.json(jwks)
+  })
+  app.route('/rpc', rpcApp)
 
+  const port = Number(process.env.PORT) || 4001
+  console.log(JSON.stringify({ level: 'info', msg: 'Auth service started', port }))
   const port = Number(process.env.PORT) || 4001
   console.log(JSON.stringify({ level: 'info', msg: 'Auth service started', port }))
 
@@ -172,7 +214,19 @@ export async function startServer() {
     await keyManager.shutdown()
     process.exit(0)
   })
+  // Graceful shutdown
+  process.on('SIGTERM', async () => {
+    console.log(JSON.stringify({ level: 'info', msg: 'Shutting down...' }))
+    await keyManager.shutdown()
+    process.exit(0)
+  })
 
+  return {
+    app,
+    port,
+    websocket,
+    systemToken,
+  }
   return {
     app,
     port,

--- a/packages/auth/tests/system-token.test.ts
+++ b/packages/auth/tests/system-token.test.ts
@@ -1,36 +1,39 @@
 import { describe, it, expect, beforeAll } from 'bun:test'
+import type * as jose from 'jose'
 import { decodeToken } from '../src/jwt.js'
-import { Permission } from '../src/permissions.js'
 
 describe('System Admin Token', () => {
-    let systemToken: string
+  let systemToken: string
 
-    beforeAll(async () => {
-        // Use in-memory databases for tests
-        process.env.CATALYST_AUTH_KEYS_DB = ':memory:'
-        process.env.CATALYST_AUTH_TOKENS_DB = ':memory:'
+  beforeAll(async () => {
+    // Use in-memory databases for tests
+    process.env.CATALYST_AUTH_KEYS_DB = ':memory:'
+    process.env.CATALYST_AUTH_TOKENS_DB = ':memory:'
 
-        // Import and start server to trigger minting
-        const { startServer } = await import('../src/server.js')
-        const result = await startServer()
-        systemToken = result.systemToken!
-    })
+    // Import and start server to trigger minting
+    const { startServer } = await import('../src/server.js')
+    const result = await startServer()
+    systemToken = result.systemToken!
+  })
 
-    it('should be minted and available after startup', () => {
-        expect(systemToken).toBeDefined()
-        expect(typeof systemToken).toBe('string')
-        expect(systemToken.length).toBeGreaterThan(10)
-    })
+  it('should be minted and available after startup', () => {
+    expect(systemToken).toBeDefined()
+    expect(typeof systemToken).toBe('string')
+    expect(systemToken.length).toBeGreaterThan(10)
+  })
 
-    it('should contain expected administrative claims', () => {
-        const result = decodeToken(systemToken)
-        expect(result).toBeDefined()
-        const payload = result?.payload as any
-        expect(payload).toBeDefined()
+  it('should contain expected administrative claims', () => {
+    const result = decodeToken(systemToken)
+    expect(result).toBeDefined()
+    const payload = result?.payload as jose.JWTPayload & {
+      roles: string[]
+      entity: { id: string; type: string }
+    }
+    expect(payload).toBeDefined()
 
-        expect(payload.sub).toBe('bootstrap')
-        expect(payload.roles).toEqual(['ADMIN'])
-        expect(payload.entity?.id).toBe('system')
-        expect(payload.entity?.type).toBe('service')
-    })
+    expect(payload.sub).toBe('bootstrap')
+    expect(payload.roles).toEqual(['ADMIN'])
+    expect(payload.entity?.id).toBe('system')
+    expect(payload.entity?.type).toBe('service')
+  })
 })

--- a/packages/authorization/src/jwt/index.ts
+++ b/packages/authorization/src/jwt/index.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { type IKeyManager, type VerifyResult } from '../key-manager/index.js'
+import { type VerifyResult } from '../key-manager/index.js'
 
 /**
  * Entity types that can own a token
@@ -10,79 +10,73 @@ export type EntityType = z.infer<typeof EntityTypeEnum>
 /**
  * Standardized roles for the system
  */
-export const RoleEnum = z.enum([
-    'ADMIN',
-    'NODE',
-    'NODE_CUSTODIAN',
-    'DATA_CUSTODIAN',
-    'USER',
-])
+export const RoleEnum = z.enum(['ADMIN', 'NODE', 'NODE_CUSTODIAN', 'DATA_CUSTODIAN', 'USER'])
 export type Role = z.infer<typeof RoleEnum>
 
 /**
  * Record of a minted token for tracking
  */
 export interface TokenRecord {
-    jti: string
-    expiry: number
-    cfn?: string // SHA-256 thumbprint for certificate-bound tokens
-    sans: string[] // Subject Alternative Names
-    entityId: string
-    entityName: string
-    entityType: EntityType
-    revoked: boolean
+  jti: string
+  expiry: number
+  cfn?: string // SHA-256 thumbprint for certificate-bound tokens
+  sans: string[] // Subject Alternative Names
+  entityId: string
+  entityName: string
+  entityType: EntityType
+  revoked: boolean
 }
 
 /**
  * Options for minting a new token
  */
 export interface MintOptions {
-    subject: string
-    audience?: string | string[]
-    expiresIn?: string
-    claims?: Record<string, unknown>
-    /** Roles assigned to the token (mandatory) */
-    roles: Role[]
-    /** Certificate fingerprint for binding (ADR 0007) */
-    certificateFingerprint?: string
-    /** Subject Alternative Names for the token */
-    sans?: string[]
-    /** Information about the entity using the token */
-    entity: {
-        id: string
-        name: string
-        type: EntityType
-    }
+  subject: string
+  audience?: string | string[]
+  expiresIn?: string
+  claims?: Record<string, unknown>
+  /** Roles assigned to the token (mandatory) */
+  roles: Role[]
+  /** Certificate fingerprint for binding (ADR 0007) */
+  certificateFingerprint?: string
+  /** Subject Alternative Names for the token */
+  sans?: string[]
+  /** Information about the entity using the token */
+  entity: {
+    id: string
+    name: string
+    type: EntityType
+  }
 }
 
 /**
  * TokenStore interface for persistence of token metadata
  */
 export interface TokenStore {
-    /** Record a newly minted token */
-    recordToken(record: TokenRecord): Promise<void>
-    /** Find a token by its JTI (JWT ID) */
-    findToken(jti: string): Promise<TokenRecord | null>
-    /** Revoke a token by JTI */
-    revokeToken(jti: string): Promise<void>
-    /** Revoke all tokens associated with a SAN */
-    revokeBySan(san: string): Promise<void>
-    /** Check if a token is revoked */
-    isRevoked(jti: string): Promise<boolean>
-    /** Get all unexpired revoked tokens (for CRL/VRL) */
-    getRevocationList(): Promise<string[]>
-    /** List tokens, optionally filtered by cert fingerprint or SAN */
-    listTokens(filter?: { certificateFingerprint?: string; san?: string }): Promise<TokenRecord[]>
+  /** Record a newly minted token */
+  recordToken(record: TokenRecord): Promise<void>
+  /** Find a token by its JTI (JWT ID) */
+  findToken(jti: string): Promise<TokenRecord | null>
+  /** Revoke a token by JTI */
+  revokeToken(jti: string): Promise<void>
+  /** Revoke all tokens associated with a SAN */
+  revokeBySan(san: string): Promise<void>
+  /** Check if a token is revoked */
+  isRevoked(jti: string): Promise<boolean>
+  /** Get all unexpired revoked tokens (for CRL/VRL) */
+  getRevocationList(): Promise<string[]>
+  /** List tokens, optionally filtered by cert fingerprint or SAN */
+  listTokens(filter?: { certificateFingerprint?: string; san?: string }): Promise<TokenRecord[]>
 }
 
 /**
  * TokenManager interface for high-level token lifecycle management
  */
 export interface TokenManager {
-    /** Mint a new token and track it */
-    mint(options: MintOptions): Promise<string>
-    /** Revoke a token by JTI or SAN */
-    revoke(options: { jti?: string; san?: string }): Promise<void>
-    /** Verify a token and check its tracking status */
-    verify(token: string, options?: { audience?: string | string[] }): Promise<VerifyResult>
+  /** Mint a new token and track it */
+  mint(options: MintOptions): Promise<string>
+  /** Revoke a token by JTI or SAN */
+  revoke(options: { jti?: string; san?: string }): Promise<void>
+  /** Verify a token and check its tracking status */
+  verify(token: string, options?: { audience?: string | string[] }): Promise<VerifyResult>
 }

--- a/packages/authorization/src/jwt/local/index.ts
+++ b/packages/authorization/src/jwt/local/index.ts
@@ -1,85 +1,83 @@
 import * as jose from 'jose'
-import type {
-    TokenManager,
-    TokenStore,
-    MintOptions,
-    TokenRecord,
-    EntityType,
-} from '../index.js'
+import type { TokenManager, TokenStore, MintOptions, TokenRecord } from '../index.js'
 import type { IKeyManager, VerifyResult } from '../../key-manager/index.ts'
 
 export class LocalTokenManager implements TokenManager {
-    constructor(
-        private keyManager: IKeyManager,
-        private store: TokenStore
-    ) { }
+  constructor(
+    private keyManager: IKeyManager,
+    private store: TokenStore
+  ) {}
 
-    async mint(options: MintOptions): Promise<string> {
-        const claims: Record<string, unknown> = {
-            ...options.claims,
-            entity: options.entity,
-            roles: options.roles
-        }
+  getStore(): TokenStore {
+    return this.store
+  }
 
-        // Support certificate binding (ADR 0007)
-        if (options.certificateFingerprint) {
-            claims.cnf = {
-                'x5t#S256': options.certificateFingerprint,
-            }
-        }
-
-        const token = await this.keyManager.sign({
-            subject: options.subject,
-            audience: options.audience,
-            expiresIn: options.expiresIn,
-            claims,
-        })
-
-        const decoded = jose.decodeJwt(token)
-        if (!decoded.jti || !decoded.exp) {
-            throw new Error('Minted token missing required claims (jti, exp)')
-        }
-
-        const record: TokenRecord = {
-            jti: decoded.jti,
-            expiry: decoded.exp,
-            cfn: options.certificateFingerprint,
-            sans: options.sans ?? [],
-            entityId: options.entity.id,
-            entityName: options.entity.name,
-            entityType: options.entity.type,
-            revoked: false,
-        }
-
-        await this.store.recordToken(record)
-
-        return token
+  async mint(options: MintOptions): Promise<string> {
+    const claims: Record<string, unknown> = {
+      ...options.claims,
+      entity: options.entity,
+      roles: options.roles,
     }
 
-    async revoke(options: { jti?: string; san?: string }): Promise<void> {
-        if (options.jti) {
-            await this.store.revokeToken(options.jti)
-        }
-        if (options.san) {
-            await this.store.revokeBySan(options.san)
-        }
+    // Support certificate binding (ADR 0007)
+    if (options.certificateFingerprint) {
+      claims.cnf = {
+        'x5t#S256': options.certificateFingerprint,
+      }
     }
 
-    async verify(token: string, options?: { audience?: string | string[] }): Promise<VerifyResult> {
-        const result = await this.keyManager.verify(token, options)
-        if (!result.valid) return result
+    const token = await this.keyManager.sign({
+      subject: options.subject,
+      audience: options.audience,
+      expiresIn: options.expiresIn,
+      claims,
+    })
 
-        const jti = result.payload.jti as string
-        if (!jti) {
-            return { valid: false, error: 'Token missing jti' }
-        }
-
-        // Check if token is revoked in the store
-        const isRevoked = await this.store.isRevoked(jti)
-        if (isRevoked) {
-            return { valid: false, error: 'Token is revoked' }
-        }
-
-        return result
+    const decoded = jose.decodeJwt(token)
+    if (!decoded.jti || !decoded.exp) {
+      throw new Error('Minted token missing required claims (jti, exp)')
     }
+
+    const record: TokenRecord = {
+      jti: decoded.jti,
+      expiry: decoded.exp,
+      cfn: options.certificateFingerprint,
+      sans: options.sans ?? [],
+      entityId: options.entity.id,
+      entityName: options.entity.name,
+      entityType: options.entity.type,
+      revoked: false,
+    }
+
+    await this.store.recordToken(record)
+
+    return token
+  }
+
+  async revoke(options: { jti?: string; san?: string }): Promise<void> {
+    if (options.jti) {
+      await this.store.revokeToken(options.jti)
+    }
+    if (options.san) {
+      await this.store.revokeBySan(options.san)
+    }
+  }
+
+  async verify(token: string, options?: { audience?: string | string[] }): Promise<VerifyResult> {
+    const result = await this.keyManager.verify(token, options)
+    if (!result.valid) return result
+
+    const jti = result.payload.jti as string
+    if (!jti) {
+      return { valid: false, error: 'Token missing jti' }
+    }
+
+    // Check if token is revoked in the store
+    const isRevoked = await this.store.isRevoked(jti)
+    if (isRevoked) {
+      return { valid: false, error: 'Token is revoked' }
+    }
+
+    return result
+  }
 }

--- a/packages/authorization/src/jwt/local/sqlite-store.ts
+++ b/packages/authorization/src/jwt/local/sqlite-store.ts
@@ -1,16 +1,27 @@
 import { Database } from 'bun:sqlite'
 import type { TokenStore, TokenRecord, EntityType } from '../index.js'
 
+interface TokenRow {
+  jti: string
+  expiry: number
+  cfn: string | null
+  sans: string
+  entity_id: string
+  entity_name: string
+  entity_type: string
+  revoked: number
+}
+
 export class BunSqliteTokenStore implements TokenStore {
-    private db: Database
+  private db: Database
 
-    constructor(path: string = ':memory:') {
-        this.db = new Database(path)
-        this.initialize()
-    }
+  constructor(path: string = ':memory:') {
+    this.db = new Database(path)
+    this.initialize()
+  }
 
-    private initialize() {
-        this.db.run(`
+  private initialize() {
+    this.db.run(`
       CREATE TABLE IF NOT EXISTS tokens (
         jti TEXT PRIMARY KEY,
         expiry INTEGER NOT NULL,
@@ -22,90 +33,95 @@ export class BunSqliteTokenStore implements TokenStore {
         revoked INTEGER NOT NULL DEFAULT 0 -- 0=false, 1=true
       )
     `)
-        this.db.run(`CREATE INDEX IF NOT EXISTS idx_tokens_expiry ON tokens(expiry)`)
-        this.db.run(`CREATE INDEX IF NOT EXISTS idx_tokens_cfn ON tokens(cfn)`)
-    }
+    this.db.run(`CREATE INDEX IF NOT EXISTS idx_tokens_expiry ON tokens(expiry)`)
+    this.db.run(`CREATE INDEX IF NOT EXISTS idx_tokens_cfn ON tokens(cfn)`)
+  }
 
-    async recordToken(record: TokenRecord): Promise<void> {
-        const stmt = this.db.prepare(`
+  async recordToken(record: TokenRecord): Promise<void> {
+    const stmt = this.db.prepare(`
       INSERT INTO tokens (jti, expiry, cfn, sans, entity_id, entity_name, entity_type, revoked)
       VALUES ($jti, $expiry, $cfn, $sans, $entityId, $entityName, $entityType, $revoked)
     `)
-        stmt.run({
-            $jti: record.jti,
-            $expiry: record.expiry,
-            $cfn: record.cfn ?? null,
-            $sans: JSON.stringify(record.sans),
-            $entityId: record.entityId,
-            $entityName: record.entityName,
-            $entityType: record.entityType,
-            $revoked: record.revoked ? 1 : 0,
-        })
+    stmt.run({
+      $jti: record.jti,
+      $expiry: record.expiry,
+      $cfn: record.cfn ?? null,
+      $sans: JSON.stringify(record.sans),
+      $entityId: record.entityId,
+      $entityName: record.entityName,
+      $entityType: record.entityType,
+      $revoked: record.revoked ? 1 : 0,
+    })
+  }
+
+  async findToken(jti: string): Promise<TokenRecord | null> {
+    const stmt = this.db.prepare('SELECT * FROM tokens WHERE jti = $jti')
+    const result = stmt.get({ $jti: jti }) as TokenRow | null
+    if (!result) return null
+
+    return {
+      jti: result.jti,
+      expiry: result.expiry,
+      cfn: result.cfn || undefined,
+      sans: JSON.parse(result.sans),
+      entityId: result.entity_id,
+      entityName: result.entity_name,
+      entityType: result.entity_type as EntityType,
+      revoked: result.revoked === 1,
+    }
+  }
+
+  async revokeToken(jti: string): Promise<void> {
+    this.db.run('UPDATE tokens SET revoked = 1 WHERE jti = ?', [jti])
+  }
+
+  async revokeBySan(san: string): Promise<void> {
+    // Simple LIKE search for JSON array string
+    this.db.run('UPDATE tokens SET revoked = 1 WHERE sans LIKE ?', [`%${san}%`])
+  }
+
+  async isRevoked(jti: string): Promise<boolean> {
+    const stmt = this.db.prepare('SELECT revoked FROM tokens WHERE jti = $jti')
+    const row = stmt.get({ $jti: jti }) as { revoked: number } | null
+    return row ? row.revoked === 1 : false
+  }
+
+  async getRevocationList(): Promise<string[]> {
+    const now = Math.floor(Date.now() / 1000)
+    const rows = this.db
+      .query('SELECT jti FROM tokens WHERE revoked = 1 AND expiry > ?')
+      .all(now) as { jti: string }[]
+    return rows.map((r) => r.jti)
+  }
+
+  async listTokens(filter?: {
+    certificateFingerprint?: string
+    san?: string
+  }): Promise<TokenRecord[]> {
+    let query = 'SELECT * FROM tokens WHERE 1=1'
+    const params: Record<string, string | number | null> = {}
+
+    if (filter?.certificateFingerprint) {
+      query += ' AND cfn = $cfn'
+      params.$cfn = filter.certificateFingerprint
     }
 
-    async findToken(jti: string): Promise<TokenRecord | null> {
-        const stmt = this.db.prepare('SELECT * FROM tokens WHERE jti = $jti')
-        const result = stmt.get({ $jti: jti }) as any
-        if (!result) return null
-
-        return {
-            jti: result.jti,
-            expiry: result.expiry,
-            cfn: result.cfn || undefined,
-            sans: JSON.parse(result.sans),
-            entityId: result.entity_id,
-            entityName: result.entity_name,
-            entityType: result.entity_type as EntityType,
-            revoked: result.revoked === 1,
-        }
+    if (filter?.san) {
+      query += ' AND sans LIKE $san'
+      params.$san = `%${filter.san}%`
     }
 
-    async revokeToken(jti: string): Promise<void> {
-        this.db.run('UPDATE tokens SET revoked = 1 WHERE jti = ?', [jti])
-    }
-
-    async revokeBySan(san: string): Promise<void> {
-        // Simple LIKE search for JSON array string
-        this.db.run("UPDATE tokens SET revoked = 1 WHERE sans LIKE ?", [`%${san}%`])
-    }
-
-    async isRevoked(jti: string): Promise<boolean> {
-        const stmt = this.db.prepare('SELECT revoked FROM tokens WHERE jti = $jti')
-        const row = stmt.get({ $jti: jti }) as any
-        return row ? row.revoked === 1 : false
-    }
-
-    async getRevocationList(): Promise<string[]> {
-        const now = Math.floor(Date.now() / 1000)
-        const rows = this.db.query('SELECT jti FROM tokens WHERE revoked = 1 AND expiry > ?').all(now) as any[]
-        return rows.map(r => r.jti)
-    }
-
-    async listTokens(filter?: { certificateFingerprint?: string; san?: string }): Promise<TokenRecord[]> {
-        let query = 'SELECT * FROM tokens WHERE 1=1'
-        const params: Record<string, any> = {}
-
-        if (filter?.certificateFingerprint) {
-            query += ' AND cfn = $cfn'
-            params.$cfn = filter.certificateFingerprint
-        }
-
-        if (filter?.san) {
-            query += ' AND sans LIKE $san'
-            params.$san = `%${filter.san}%`
-        }
-
-        const stmt = this.db.prepare(query)
-        const rows = stmt.all(params) as any[]
-        return rows.map(row => ({
-            jti: row.jti,
-            expiry: row.expiry,
-            cfn: row.cfn || undefined,
-            sans: JSON.parse(row.sans),
-            entityId: row.entity_id,
-            entityName: row.entity_name,
-            entityType: row.entity_type as EntityType,
-            revoked: row.revoked === 1,
-        }))
-    }
+    const stmt = this.db.prepare(query)
+    const rows = stmt.all(params) as TokenRow[]
+    return rows.map((row) => ({
+      jti: row.jti,
+      expiry: row.expiry,
+      cfn: row.cfn || undefined,
+      sans: JSON.parse(row.sans),
+      entityId: row.entity_id,
+      entityName: row.entity_name,
+      entityType: row.entity_type as EntityType,
+      revoked: row.revoked === 1,
+    }))
+  }
 }

--- a/packages/authorization/src/key-manager/persistent.ts
+++ b/packages/authorization/src/key-manager/persistent.ts
@@ -1,192 +1,206 @@
 import * as jose from 'jose'
 import type {
-    IKeyManager,
-    IKeyStore,
-    SignOptions,
-    VerifyOptions,
-    VerifyResult,
-    RotateOptions,
-    RotationResult
+  IKeyManager,
+  IKeyStore,
+  SignOptions,
+  VerifyOptions,
+  VerifyResult,
+  RotateOptions,
+  RotationResult,
 } from './index.js'
 
 const ALGORITHM = 'ES384'
 const DEFAULT_GRACE_PERIOD_MS = 24 * 60 * 60 * 1000
 
 interface ManagedKey {
-    privateKey: jose.CryptoKey
-    publicKey: jose.CryptoKey
-    kid: string
-    createdAt: number
-    expiresAt?: number
+  privateKey: jose.CryptoKey
+  publicKey: jose.CryptoKey
+  kid: string
+  createdAt: number
+  expiresAt?: number
 }
 
 export class PersistentLocalKeyManager implements IKeyManager {
-    private currentKey: ManagedKey | null = null
-    private previousKeys: ManagedKey[] = []
-    private initialized = false
+  private currentKey: ManagedKey | null = null
+  private previousKeys: ManagedKey[] = []
+  private initialized = false
 
-    constructor(
-        private store: IKeyStore,
-        private options: { gracePeriodMs?: number } = {}
-    ) { }
+  constructor(
+    private store: IKeyStore,
+    private options: { gracePeriodMs?: number } = {}
+  ) {}
 
-    isInitialized(): boolean {
-        return this.initialized
-    }
+  isInitialized(): boolean {
+    return this.initialized
+  }
 
-    async initialize(): Promise<void> {
-        if (this.initialized) return
+  async initialize(): Promise<void> {
+    if (this.initialized) return
 
-        const savedJwks = await this.store.loadKeys()
-        if (savedJwks && savedJwks.keys.length > 0) {
-            // Load existing keys
-            for (const jwk of savedJwks.keys) {
-                const privateKey = (await jose.importJWK(jwk, ALGORITHM)) as jose.CryptoKey
-                const publicKeyJwk = { ...jwk, d: undefined, p: undefined, q: undefined, dp: undefined, dq: undefined, qi: undefined }
-                const publicKey = (await jose.importJWK(publicKeyJwk, ALGORITHM)) as jose.CryptoKey
+    const savedJwks = await this.store.loadKeys()
+    if (savedJwks && savedJwks.keys.length > 0) {
+      // Load existing keys
+      for (const jwk of savedJwks.keys) {
+        const privateKey = (await jose.importJWK(jwk, ALGORITHM)) as jose.CryptoKey
+        const publicKeyJwk = {
+          ...jwk,
+          d: undefined,
+          p: undefined,
+          q: undefined,
+          dp: undefined,
+          dq: undefined,
+          qi: undefined,
+        }
+        const publicKey = (await jose.importJWK(publicKeyJwk, ALGORITHM)) as jose.CryptoKey
 
-                const managed: ManagedKey = {
-                    privateKey,
-                    publicKey,
-                    kid: jwk.kid!,
-                    createdAt: (jwk as any).iat || Date.now(),
-                    expiresAt: (jwk as any).exp,
-                }
-
-                if (!managed.expiresAt) {
-                    this.currentKey = managed
-                } else {
-                    this.previousKeys.push(managed)
-                }
-            }
+        const managed: ManagedKey = {
+          privateKey,
+          publicKey,
+          kid: jwk.kid!,
+          createdAt: (jwk as jose.JWK & { iat?: number }).iat || Date.now(),
+          expiresAt: (jwk as jose.JWK & { exp?: number }).exp,
         }
 
-        if (!this.currentKey) {
-            // Generate initial key
-            await this.generateNewKey()
-        }
-
-        this.initialized = true
-    }
-
-    private async generateNewKey(): Promise<ManagedKey> {
-        const { publicKey, privateKey } = await jose.generateKeyPair(ALGORITHM, {
-            extractable: true,
-        })
-        const publicKeyJwk = await jose.exportJWK(publicKey)
-        const kid = await jose.calculateJwkThumbprint(publicKeyJwk, 'sha256')
-
-        const newKey: ManagedKey = {
-            privateKey: privateKey as jose.CryptoKey,
-            publicKey: publicKey as jose.CryptoKey,
-            kid,
-            createdAt: Date.now(),
-        }
-
-        this.currentKey = newKey
-        await this.persist()
-        return newKey
-    }
-
-    private async persist(): Promise<void> {
-        const keys: jose.JWK[] = []
-
-        if (this.currentKey) {
-            const jwk = await jose.exportJWK(this.currentKey.privateKey)
-            keys.push({ ...jwk, kid: this.currentKey.kid, iat: this.currentKey.createdAt } as any)
-        }
-
-        for (const prev of this.previousKeys) {
-            const jwk = await jose.exportJWK(prev.privateKey)
-            keys.push({
-                ...jwk,
-                kid: prev.kid,
-                iat: prev.createdAt,
-                exp: prev.expiresAt
-            } as any)
-        }
-
-        await this.store.saveKeys({ keys })
-    }
-
-    async sign(options: SignOptions): Promise<string> {
-        if (!this.currentKey) throw new Error('Not initialized')
-
-        const builder = new jose.SignJWT(options.claims ?? {})
-            .setProtectedHeader({ alg: ALGORITHM, kid: this.currentKey.kid })
-            .setSubject(options.subject)
-            .setIssuedAt()
-            .setJti(crypto.randomUUID())
-            .setExpirationTime(options.expiresIn ?? '1h')
-            .setAudience(options.audience ?? [])
-
-        return builder.sign(this.currentKey.privateKey)
-    }
-
-    async verify(token: string, options?: VerifyOptions): Promise<VerifyResult> {
-        try {
-            const result = await jose.jwtVerify(token, async (header) => {
-                if (this.currentKey?.kid === header.kid) return this.currentKey.publicKey
-                const prev = this.previousKeys.find(k => k.kid === header.kid)
-                if (prev) return prev.publicKey
-                throw new Error('Key not found')
-            }, {
-                audience: options?.audience,
-                algorithms: [ALGORITHM],
-            })
-
-            return { valid: true, payload: result.payload as Record<string, unknown> }
-        } catch (err: any) {
-            return { valid: false, error: err.message }
-        }
-    }
-
-    async getJwks(): Promise<jose.JSONWebKeySet> {
-        const keys: jose.JWK[] = []
-        if (this.currentKey) {
-            const jwk = await jose.exportJWK(this.currentKey.publicKey)
-            keys.push({ ...jwk, kid: this.currentKey.kid, use: 'sig', alg: ALGORITHM })
-        }
-        for (const prev of this.previousKeys) {
-            const jwk = await jose.exportJWK(prev.publicKey)
-            keys.push({ ...jwk, kid: prev.kid, use: 'sig', alg: ALGORITHM })
-        }
-        return { keys }
-    }
-
-    async getCurrentKeyId(): Promise<string> {
-        if (!this.currentKey) throw new Error('Not initialized')
-        return this.currentKey.kid
-    }
-
-    async rotate(options?: RotateOptions): Promise<RotationResult> {
-        const immediate = options?.immediate ?? false
-        const gracePeriodMs = options?.gracePeriodMs ?? this.options.gracePeriodMs ?? DEFAULT_GRACE_PERIOD_MS
-
-        const oldKey = this.currentKey
-        if (!oldKey) throw new Error('Not initialized')
-
-        const newKey = await this.generateNewKey()
-
-        if (!immediate) {
-            oldKey.expiresAt = Date.now() + gracePeriodMs
-            this.previousKeys.push(oldKey)
+        if (!managed.expiresAt) {
+          this.currentKey = managed
         } else {
-            this.previousKeys = []
+          this.previousKeys.push(managed)
         }
-
-        await this.persist()
-
-        return {
-            previousKeyId: oldKey.kid,
-            newKeyId: newKey.kid,
-            gracePeriodEndsAt: oldKey.expiresAt ? new Date(oldKey.expiresAt) : undefined,
-        }
+      }
     }
 
-    async shutdown(): Promise<void> {
-        this.currentKey = null
-        this.previousKeys = []
-        this.initialized = false
+    if (!this.currentKey) {
+      // Generate initial key
+      await this.generateNewKey()
     }
+
+    this.initialized = true
+  }
+
+  private async generateNewKey(): Promise<ManagedKey> {
+    const { publicKey, privateKey } = await jose.generateKeyPair(ALGORITHM, {
+      extractable: true,
+    })
+    const publicKeyJwk = await jose.exportJWK(publicKey)
+    const kid = await jose.calculateJwkThumbprint(publicKeyJwk, 'sha256')
+
+    const newKey: ManagedKey = {
+      privateKey: privateKey as jose.CryptoKey,
+      publicKey: publicKey as jose.CryptoKey,
+      kid,
+      createdAt: Date.now(),
+    }
+
+    this.currentKey = newKey
+    await this.persist()
+    return newKey
+  }
+
+  private async persist(): Promise<void> {
+    const keys: jose.JWK[] = []
+
+    if (this.currentKey) {
+      const jwk = await jose.exportJWK(this.currentKey.privateKey)
+      keys.push({ ...jwk, kid: this.currentKey.kid, iat: this.currentKey.createdAt } as jose.JWK)
+    }
+
+    for (const prev of this.previousKeys) {
+      const jwk = await jose.exportJWK(prev.privateKey)
+      keys.push({
+        ...jwk,
+        kid: prev.kid,
+        iat: prev.createdAt,
+        exp: prev.expiresAt,
+      } as jose.JWK)
+    }
+
+    await this.store.saveKeys({ keys })
+  }
+
+  async sign(options: SignOptions): Promise<string> {
+    if (!this.currentKey) throw new Error('Not initialized')
+
+    const builder = new jose.SignJWT(options.claims ?? {})
+      .setProtectedHeader({ alg: ALGORITHM, kid: this.currentKey.kid })
+      .setSubject(options.subject)
+      .setIssuedAt()
+      .setJti(crypto.randomUUID())
+      .setExpirationTime(options.expiresIn ?? '1h')
+      .setAudience(options.audience ?? [])
+
+    return builder.sign(this.currentKey.privateKey)
+  }
+
+  async verify(token: string, options?: VerifyOptions): Promise<VerifyResult> {
+    try {
+      const result = await jose.jwtVerify(
+        token,
+        async (header) => {
+          if (this.currentKey && this.currentKey.kid === header.kid)
+            return this.currentKey.publicKey
+          const prev = this.previousKeys.find((k) => k.kid === header.kid)
+          if (prev) return prev.publicKey
+          throw new Error('Key not found')
+        },
+        {
+          audience: options?.audience,
+          algorithms: [ALGORITHM],
+        }
+      )
+
+      return { valid: true, payload: result.payload as Record<string, unknown> }
+    } catch (err: unknown) {
+      return { valid: false, error: err instanceof Error ? err.message : String(err) }
+    }
+  }
+
+  async getJwks(): Promise<jose.JSONWebKeySet> {
+    const keys: jose.JWK[] = []
+    if (this.currentKey) {
+      const jwk = await jose.exportJWK(this.currentKey.publicKey)
+      keys.push({ ...jwk, kid: this.currentKey.kid, use: 'sig', alg: ALGORITHM })
+    }
+    for (const prev of this.previousKeys) {
+      const jwk = await jose.exportJWK(prev.publicKey)
+      keys.push({ ...jwk, kid: prev.kid, use: 'sig', alg: ALGORITHM })
+    }
+    return { keys }
+  }
+
+  async getCurrentKeyId(): Promise<string> {
+    if (!this.currentKey) throw new Error('Not initialized')
+    return this.currentKey.kid
+  }
+
+  async rotate(options?: RotateOptions): Promise<RotationResult> {
+    const immediate = options?.immediate ?? false
+    const gracePeriodMs =
+      options?.gracePeriodMs ?? this.options.gracePeriodMs ?? DEFAULT_GRACE_PERIOD_MS
+
+    const oldKey = this.currentKey
+    if (!oldKey) throw new Error('Not initialized')
+
+    const newKey = await this.generateNewKey()
+
+    if (!immediate) {
+      oldKey.expiresAt = Date.now() + gracePeriodMs
+      this.previousKeys.push(oldKey)
+    } else {
+      this.previousKeys = []
+    }
+
+    await this.persist()
+
+    return {
+      previousKeyId: oldKey.kid,
+      newKeyId: newKey.kid,
+      gracePeriodEndsAt: oldKey.expiresAt ? new Date(oldKey.expiresAt) : undefined,
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    this.currentKey = null
+    this.previousKeys = []
+    this.initialized = false
+  }
 }

--- a/packages/authorization/tests/persistence.unit.test.ts
+++ b/packages/authorization/tests/persistence.unit.test.ts
@@ -1,127 +1,121 @@
 import { describe, it, expect, beforeEach } from 'bun:test'
-import {
-    BunSqliteTokenStore,
-    BunSqliteKeyStore,
-    PersistentLocalKeyManager,
-    LocalTokenManager
-} from '../src/index.js'
-import * as jose from 'jose'
+import { BunSqliteTokenStore, BunSqliteKeyStore, PersistentLocalKeyManager } from '../src/index.js'
 
 describe('Authorization Persistence', () => {
-    describe('BunSqliteTokenStore', () => {
-        let store: BunSqliteTokenStore
+  describe('BunSqliteTokenStore', () => {
+    let store: BunSqliteTokenStore
 
-        beforeEach(() => {
-            store = new BunSqliteTokenStore(':memory:')
-        })
-
-        it('should record and find tokens', async () => {
-            const record = {
-                jti: 'test-jti',
-                expiry: Math.floor(Date.now() / 1000) + 3600,
-                sans: ['web.example.com'],
-                entityId: 'user1',
-                entityName: 'User One',
-                entityType: 'user' as const,
-                revoked: false
-            }
-
-            await store.recordToken(record)
-            const found = await store.findToken('test-jti')
-            expect(found).toEqual(record)
-        })
-
-        it('should revoke tokens by JTI', async () => {
-            await store.recordToken({
-                jti: 'jti1',
-                expiry: 9999999999,
-                sans: [],
-                entityId: 'e1',
-                entityName: 'n1',
-                entityType: 'service' as const,
-                revoked: false
-            })
-
-            expect(await store.isRevoked('jti1')).toBe(false)
-            await store.revokeToken('jti1')
-            expect(await store.isRevoked('jti1')).toBe(true)
-        })
-
-        it('should revoke tokens by SAN', async () => {
-            await store.recordToken({
-                jti: 'jti2',
-                expiry: 9999999999,
-                sans: ['app1.internal'],
-                entityId: 'e2',
-                entityName: 'n2',
-                entityType: 'service' as const,
-                revoked: false
-            })
-
-            expect(await store.isRevoked('jti2')).toBe(false)
-            await store.revokeBySan('app1.internal')
-            expect(await store.isRevoked('jti2')).toBe(true)
-        })
-
-        it('should list tokens with filters', async () => {
-            await store.recordToken({
-                jti: 't1',
-                expiry: 9999999999,
-                cfn: 'cert1',
-                sans: ['san1'],
-                entityId: 'e1',
-                entityName: 'n1',
-                entityType: 'service' as const,
-                revoked: false
-            })
-
-            const byCert = await store.listTokens({ certificateFingerprint: 'cert1' })
-            expect(byCert).toHaveLength(1)
-            expect(byCert[0].jti).toBe('t1')
-
-            const bySan = await store.listTokens({ san: 'san1' })
-            expect(bySan).toHaveLength(1)
-            expect(bySan[0].jti).toBe('t1')
-        })
+    beforeEach(() => {
+      store = new BunSqliteTokenStore(':memory:')
     })
 
-    describe('BunSqliteKeyStore and PersistentLocalKeyManager', () => {
-        it('should persist and reload keys', async () => {
-            const keyStore = new BunSqliteKeyStore(':memory:')
-            const manager1 = new PersistentLocalKeyManager(keyStore)
-            await manager1.initialize()
+    it('should record and find tokens', async () => {
+      const record = {
+        jti: 'test-jti',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        sans: ['web.example.com'],
+        entityId: 'user1',
+        entityName: 'User One',
+        entityType: 'user' as const,
+        revoked: false,
+      }
 
-            const kid1 = await manager1.getCurrentKeyId()
-
-            // Second manager using same store should see same kid
-            const manager2 = new PersistentLocalKeyManager(keyStore)
-            await manager2.initialize()
-            const kid2 = await manager2.getCurrentKeyId()
-
-            expect(kid1).toBe(kid2)
-        })
-
-        it('should handle rotation with persistence', async () => {
-            const keyStore = new BunSqliteKeyStore(':memory:')
-            const manager = new PersistentLocalKeyManager(keyStore)
-            await manager.initialize()
-
-            const oldKid = await manager.getCurrentKeyId()
-            await manager.rotate({ immediate: false })
-            const newKid = await manager.getCurrentKeyId()
-
-            expect(oldKid).not.toBe(newKid)
-
-            // Verify both kids are in JWKS
-            const jwks = await manager.getJwks()
-            const kids = jwks.keys.map(k => k.kid)
-            expect(kids).toContain(oldKid)
-            expect(kids).toContain(newKid)
-
-            // Reload and verify
-            const manager2 = new PersistentLocalKeyManager(keyStore)
-            await manager2.initialize()
-            expect(await manager2.getCurrentKeyId()).toBe(newKid)
-        })
+      await store.recordToken(record)
+      const found = await store.findToken('test-jti')
+      expect(found).toEqual(record)
     })
+
+    it('should revoke tokens by JTI', async () => {
+      await store.recordToken({
+        jti: 'jti1',
+        expiry: 9999999999,
+        sans: [],
+        entityId: 'e1',
+        entityName: 'n1',
+        entityType: 'service' as const,
+        revoked: false,
+      })
+
+      expect(await store.isRevoked('jti1')).toBe(false)
+      await store.revokeToken('jti1')
+      expect(await store.isRevoked('jti1')).toBe(true)
+    })
+
+    it('should revoke tokens by SAN', async () => {
+      await store.recordToken({
+        jti: 'jti2',
+        expiry: 9999999999,
+        sans: ['app1.internal'],
+        entityId: 'e2',
+        entityName: 'n2',
+        entityType: 'service' as const,
+        revoked: false,
+      })
+
+      expect(await store.isRevoked('jti2')).toBe(false)
+      await store.revokeBySan('app1.internal')
+      expect(await store.isRevoked('jti2')).toBe(true)
+    })
+
+    it('should list tokens with filters', async () => {
+      await store.recordToken({
+        jti: 't1',
+        expiry: 9999999999,
+        cfn: 'cert1',
+        sans: ['san1'],
+        entityId: 'e1',
+        entityName: 'n1',
+        entityType: 'service' as const,
+        revoked: false,
+      })
+
+      const byCert = await store.listTokens({ certificateFingerprint: 'cert1' })
+      expect(byCert).toHaveLength(1)
+      expect(byCert[0].jti).toBe('t1')
+
+      const bySan = await store.listTokens({ san: 'san1' })
+      expect(bySan).toHaveLength(1)
+      expect(bySan[0].jti).toBe('t1')
+    })
+  })
+
+  describe('BunSqliteKeyStore and PersistentLocalKeyManager', () => {
+    it('should persist and reload keys', async () => {
+      const keyStore = new BunSqliteKeyStore(':memory:')
+      const manager1 = new PersistentLocalKeyManager(keyStore)
+      await manager1.initialize()
+
+      const kid1 = await manager1.getCurrentKeyId()
+
+      // Second manager using same store should see same kid
+      const manager2 = new PersistentLocalKeyManager(keyStore)
+      await manager2.initialize()
+      const kid2 = await manager2.getCurrentKeyId()
+
+      expect(kid1).toBe(kid2)
+    })
+
+    it('should handle rotation with persistence', async () => {
+      const keyStore = new BunSqliteKeyStore(':memory:')
+      const manager = new PersistentLocalKeyManager(keyStore)
+      await manager.initialize()
+
+      const oldKid = await manager.getCurrentKeyId()
+      await manager.rotate({ immediate: false })
+      const newKid = await manager.getCurrentKeyId()
+
+      expect(oldKid).not.toBe(newKid)
+
+      // Verify both kids are in JWKS
+      const jwks = await manager.getJwks()
+      const kids = jwks.keys.map((k) => k.kid)
+      expect(kids).toContain(oldKid)
+      expect(kids).toContain(newKid)
+
+      // Reload and verify
+      const manager2 = new PersistentLocalKeyManager(keyStore)
+      await manager2.initialize()
+      expect(await manager2.getCurrentKeyId()).toBe(newKid)
+    })
+  })
 })


### PR DESCRIPTION
### TL;DR

Improved TypeScript type safety across the auth and authorization packages by properly typing TokenManager interfaces and implementing proper type checking for roles and token records.

### What changed?

- Properly imported and used the `Role` type from `@catalyst/authorization` instead of using `any`
- Added proper return type for token-related API methods that previously returned `any[]`
- Added a `getStore()` method to `LocalTokenManager` to safely access the token store
- Improved type safety in the RPC server by checking if `tokenManager` is an instance of `LocalTokenManager` before accessing its store
- Fixed TypeScript errors in the key manager implementation
- Improved code formatting and consistency across files

### How to test?

1. Run the TypeScript compiler to verify no type errors exist
2. Run existing tests to ensure functionality is preserved
3. Test token management operations to verify they work correctly with the improved type safety

### Why make this change?

This change eliminates the use of `any` types which were causing potential type safety issues. By properly typing the interfaces and implementations, we reduce the risk of runtime errors and improve code maintainability. The changes also make the codebase more robust by adding proper type checking before accessing internal properties of the token manager.