### PR TITLE
feat: embracing cedar and adding existing roles as principals

### DIFF
--- a/packages/authorization/src/jwt/local/index.ts
+++ b/packages/authorization/src/jwt/local/index.ts
@@ -12,12 +12,12 @@ export class LocalTokenManager implements TokenManager {
     return this.store
   }
 
-  async mint(options: MintOptions): Promise<string> {
-    const claims: Record<string, unknown> = {
-      ...options.claims,
-      entity: options.entity,
-      roles: options.roles,
-    }
+    async mint(options: MintOptions): Promise<string> {
+        const claims: Record<string, unknown> = {
+            ...options.claims,
+            entity: options.entity,
+            roles: options.roles,
+        }
 
     // Support certificate binding (ADR 0007)
     if (options.certificateFingerprint) {

--- a/packages/authorization/src/policy/README.md
+++ b/packages/authorization/src/policy/README.md
@@ -121,15 +121,82 @@ flowchart LR
     Engine --> Decision[Allow / Deny]
 ```
 
+## Catalyst Standard Domain
+
+The library provides a set of standardized Roles and Actions specifically designed for the Catalyst ecosystem.
+
+### Roles (Principal Types)
+
+| Role | Description | Principal Example |
+|------|-------------|-------------------|
+| `ADMIN` | Full system access | `CATALYST::ADMIN::"adminuser"` |
+| `NODE` | Network infrastructure nodes | `CATALYST::NODE::"node-01"` |
+| `NODE_CUSTODIAN` | Peer management authority | `CATALYST::NODE_CUSTODIAN::"manager"` |
+| `DATA_CUSTODIAN` | Route management authority | `CATALYST::DATA_CUSTODIAN::"traffic-eng"` |
+| `USER` | Standard end users | `CATALYST::USER::"alice"` |
+
+### Actions
+
+| Action | Description |
+|--------|-------------|
+| `LOGIN` | User authentication |
+| `IBGP_CONNECT` | Establish iBGP peering |
+| `IBGP_DISCONNECT` | Terminate iBGP peering |
+| `IBGP_UPDATE` | Advertise routes via iBGP |
+| `PEER_CREATE` / `PEER_DELETE` | Manage infrastructure peers |
+| `ROUTE_CREATE` / `ROUTE_DELETE` | Manage local data routes |
+| `TOKEN_CREATE` / `TOKEN_REVOKE` | Manage JWT lifecycles |
+
+### Policy Examples
+
+Using the CATALYST semantic model, policies become highly readable:
+
+#### 1. Global Admin Access
+```cedar
+permit (
+    principal is CATALYST::ADMIN,
+    action,
+    resource
+);
+```
+
+#### 2. Restricting Node Capabilities
+Nodes should only be able to perform iBGP related actions.
+```cedar
+permit (
+    principal is CATALYST::NODE,
+    action in [
+        CATALYST::Action::"IBGP_CONNECT",
+        CATALYST::Action::"IBGP_DISCONNECT",
+        CATALYST::Action::"IBGP_UPDATE"
+    ],
+    resource
+);
+```
+
+#### 3. Data Custodian Route Management
+```cedar
+permit (
+    principal is CATALYST::DATA_CUSTODIAN,
+    action in [
+        CATALYST::Action::"ROUTE_CREATE",
+        CATALYST::Action::"ROUTE_DELETE"
+    ],
+    resource
+);
+```
+
+#### 4. Conditional Access (Self-Revocation)
+```cedar
+permit (
+    principal,
+    action == CATALYST::Action::"TOKEN_REVOKE",
+    resource is CATALYST::Token
+)
+when { resource.ownerId == principal.id };
+```
+
+---
+
 ## Documentation
-
-For more in-depth details, check the `docs/` folder:
-
-- [Architecture Overview](docs/ARCHITECTURE.md): High-level design and class relationships.
-- [Cedar Context](docs/CEDAR_CONTEXT.md): How to work with authorization context.
-- [Custom Entity Providers](docs/CUSTOM_ENTITY_PROVIDERS.md): Creating custom providers and mappers.
-
-## Examples
-
-- [Todo App](examples/todo-app/index.ts): Simple ABAC example with public/private lists.
-- [Marketplace](examples/marketplace/index.ts): Demonstrates transforming DB models into Cedar entities using mappers.
+...

--- a/packages/authorization/tests/policy/jwt-helper.test.ts
+++ b/packages/authorization/tests/policy/jwt-helper.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'bun:test'
+import { Role } from '../../src/policy/src/types.js'
+import { jwtToEntity } from '../../src/jwt/index.js'
+
+describe('jwtToEntity', () => {
+    it('should map a JWT payload to a Cedar Entity with primary role and name', () => {
+        const payload = {
+            sub: 'user-123',
+            entity: {
+                id: 'user-123',
+                name: 'alice',
+                type: 'user',
+                role: Role.ADMIN
+            },
+            roles: [Role.ADMIN, Role.USER],
+            claims: {
+                orgId: 'org-456'
+            }
+        }
+
+        const entity = jwtToEntity(payload as any)
+
+        expect(entity.uid.type).toBe('ADMIN')
+        expect(entity.uid.id).toBe('alice')
+        expect(entity.attrs.id).toBe('user-123')
+        expect(entity.attrs.name).toBe('alice')
+        expect(entity.attrs.orgId).toBe('org-456')
+    })
+
+    it('should fallback to first role if primaryRole is missing', () => {
+        const payload = {
+            sub: 'node-01',
+            entity: {
+                id: 'node-01',
+                name: 'catalyst-node-01',
+                type: 'node'
+            },
+            roles: [Role.NODE]
+        }
+
+        const entity = jwtToEntity(payload as any)
+
+        expect(entity.uid.type).toBe('NODE')
+        expect(entity.uid.id).toBe('catalyst-node-01')
+    })
+
+    it('should fallback to sub if entity.name is missing', () => {
+        const payload = {
+            sub: 'user-789',
+            roles: [Role.USER]
+        }
+
+        const entity = jwtToEntity(payload as any)
+
+        expect(entity.uid.type).toBe('USER')
+        expect(entity.uid.id).toBe('user-789')
+    })
+})


### PR DESCRIPTION
### TL;DR

Added Cedar entity mapping for JWT tokens and standardized roles/actions for the authorization system.

### What changed?

- Defined standardized roles (`ADMIN`, `NODE`, `NODE_CUSTODIAN`, `DATA_CUSTODIAN`, `USER`) and actions (`LOGIN`, `IBGP_CONNECT`, etc.) as enums in the policy types
- Created a `jwtToEntity` helper function to convert JWT payloads into Cedar entities
- Updated the JWT interface to include a required `role` field in the entity object
- Enhanced the policy README with documentation on the Catalyst standard domain, including role descriptions and policy examples
- Added tests for the JWT to Cedar entity mapping functionality

### How to test?

1. Create a JWT token with an entity that includes a role:
```typescript
const token = await tokenManager.mint({
  entity: {
    id: 'user-123',
    name: 'alice',
    type: 'user',
    role: Role.ADMIN
  },
  roles: [Role.ADMIN]
})
```

2. Convert the JWT payload to a Cedar entity:
```typescript
const payload = verifyJwt(token)
const entity = jwtToEntity(payload)
```

3. Verify the entity has the correct principal type and attributes:
```typescript
// Should be CATALYST::ADMIN::"alice"
console.log(entity.uid.type) // ADMIN
console.log(entity.uid.id)   // alice
```

### Why make this change?

This change implements the authorization model described in ADR 0007, mapping JWT identities to Cedar principals with standardized roles. By defining a consistent domain model with specific roles and actions, we can create more readable and maintainable authorization policies. The JWT to entity mapping provides a clean integration between our authentication and authorization systems.