### PR TITLE
feat: moving config our for simplicity of configuring multiple services

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -106,6 +106,13 @@
         "typescript": "catalog:dev",
       },
     },
+    "packages/config": {
+      "name": "@catalyst/config",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "catalog:",
+      },
+    },
     "packages/examples": {
       "name": "@catalyst/examples",
       "version": "0.0.0",
@@ -170,6 +177,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@catalyst/auth": "workspace:*",
+        "@catalyst/config": "workspace:*",
         "@hono/capnweb": "catalog:",
         "capnweb": "catalog:",
         "hono": "catalog:",
@@ -340,6 +348,8 @@
     "@catalyst/authorization": ["@catalyst/authorization@workspace:packages/authorization"],
 
     "@catalyst/cli": ["@catalyst/cli@workspace:packages/cli"],
+
+    "@catalyst/config": ["@catalyst/config@workspace:packages/config"],
 
     "@catalyst/examples": ["@catalyst/examples@workspace:packages/examples"],
 

--- a/packages/auth/Dockerfile
+++ b/packages/auth/Dockerfile
@@ -7,24 +7,27 @@ COPY package.json bun.lock ./
 # Copy workspace package.json files needed for dependency resolution
 COPY packages/auth/package.json packages/auth/package.json
 COPY packages/authorization/package.json packages/authorization/package.json
+COPY packages/config/package.json packages/config/package.json
 
 # Install dependencies into temp directory
 # This will cache them and speed up future builds
 FROM base AS install
 RUN mkdir -p /temp/dev
 COPY package.json bun.lock /temp/dev/
-RUN mkdir -p /temp/dev/packages/auth /temp/dev/packages/authorization
+RUN mkdir -p /temp/dev/packages/auth /temp/dev/packages/authorization /temp/dev/packages/config
 COPY packages/auth/package.json /temp/dev/packages/auth/
 COPY packages/authorization/package.json /temp/dev/packages/authorization/
+COPY packages/config/package.json /temp/dev/packages/config/
 # ensure all workspace packages are at least defined to satisfy bun
 RUN cd /temp/dev && bun install --ignore-scripts
 
 # Install with --production (exclude devDependencies)
 RUN mkdir -p /temp/prod
 COPY package.json bun.lock /temp/prod/
-RUN mkdir -p /temp/prod/packages/auth /temp/prod/packages/authorization
+RUN mkdir -p /temp/prod/packages/auth /temp/prod/packages/authorization /temp/prod/packages/config
 COPY packages/auth/package.json /temp/prod/packages/auth/
 COPY packages/authorization/package.json /temp/prod/packages/authorization/
+COPY packages/config/package.json /temp/prod/packages/config/
 # cant use production flag becuase of frozen-lockfile error: for now just omit dev dependencies
 # manually but let lockfile changes
 RUN cd /temp/prod && bun install --omit=dev --ignore-scripts
@@ -35,6 +38,7 @@ FROM base AS prerelease
 COPY --from=install /temp/dev/node_modules node_modules
 COPY packages/auth packages/auth
 COPY packages/authorization packages/authorization
+COPY packages/config packages/config
 
 # [optional] tests & build
 ENV NODE_ENV=production

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@catalyst/config",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "zod": "catalog:"
+  }
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod'
+
+/**
+ * Shared Node Identity Schema
+ */
+export const NodeConfigSchema = z.object({
+  name: z.string(),
+  domains: z.array(z.string()),
+  endpoint: z.string().optional(),
+  labels: z.record(z.string(), z.string()).optional(),
+})
+
+export type NodeConfig = z.infer<typeof NodeConfigSchema>
+
+/**
+ * Orchestrator Specific Configuration
+ */
+export const OrchestratorConfigSchema = z.object({
+  ibgp: z
+    .object({
+      secret: z.string().optional(),
+    })
+    .optional(),
+  gqlGatewayConfig: z
+    .object({
+      endpoint: z.string(),
+    })
+    .optional(),
+})
+
+export type OrchestratorConfig = z.infer<typeof OrchestratorConfigSchema>
+
+/**
+ * Top-level Catalyst System Configuration
+ */
+export const CatalystConfigSchema = z.object({
+  node: NodeConfigSchema,
+  orchestrator: OrchestratorConfigSchema.optional(),
+})
+
+export type CatalystConfig = z.infer<typeof CatalystConfigSchema>

--- a/packages/orchestrator/Dockerfile
+++ b/packages/orchestrator/Dockerfile
@@ -9,12 +9,14 @@ COPY package.json bun.lock ./
 COPY packages/orchestrator/package.json packages/orchestrator/package.json
 COPY packages/auth/package.json packages/auth/package.json
 COPY packages/authorization/package.json packages/authorization/package.json
+COPY packages/config/package.json packages/config/package.json
 
 # Install dependencies (cache dependencies)
 RUN bun install --omit=dev --ignore-scripts
 
 COPY packages/auth packages/auth
 COPY packages/authorization packages/authorization
+COPY packages/config packages/config
 
 # Install dependencies
 WORKDIR /app/packages/orchestrator

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@catalyst/auth": "workspace:*",
+    "@catalyst/config": "workspace:*",
     "@hono/capnweb": "catalog:",
     "capnweb": "catalog:",
     "hono": "catalog:",

--- a/packages/orchestrator/src/routing/state.ts
+++ b/packages/orchestrator/src/routing/state.ts
@@ -1,11 +1,9 @@
 import type { DataChannelDefinition } from './datachannel.js'
 import { z } from 'zod'
 
-export const PeerInfoSchema = z.object({
-  name: z.string(),
-  endpoint: z.string(),
-  domains: z.array(z.string()),
-})
+import { NodeConfigSchema } from '@catalyst/config'
+
+export const PeerInfoSchema = NodeConfigSchema
 
 export type PeerInfo = z.infer<typeof PeerInfoSchema>
 

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -1,11 +1,14 @@
 import type { Action } from './schema.js'
 import type { RouteTable } from './routing/state.js'
 import { z } from 'zod'
-import { PeerInfoSchema } from './routing/state.js'
 import { Permission, type Role } from '@catalyst/auth'
 
+import { NodeConfigSchema } from '@catalyst/config'
+
 export const OrchestratorConfigSchema = z.object({
-  node: PeerInfoSchema,
+  node: NodeConfigSchema.extend({
+    endpoint: z.string(), // Orchestrator requires an endpoint for its own node
+  }),
   ibgp: z
     .object({
       secret: z.string().optional(),


### PR DESCRIPTION
### TL;DR

Added a new `@catalyst/config` package with shared configuration schemas for node identity and orchestrator configuration.

### What changed?

- Created a new `@catalyst/config` package with TypeScript configuration schemas using Zod
- Defined shared schemas for node configuration, orchestrator-specific configuration, and top-level Catalyst system configuration
- Updated the orchestrator package to use these shared schemas instead of its own definitions
- Added the new package as a dependency to the orchestrator
- Updated Dockerfiles to include the new package

### How to test?

1. Build the project to ensure the new package compiles correctly
2. Verify that the orchestrator can use the imported schemas from `@catalyst/config`
3. Check that the TypeScript types are properly inferred when using the schemas

### Why make this change?

This change centralizes configuration schemas in a dedicated package, promoting reuse across the Catalyst system. By defining these schemas in one place, we ensure consistency in configuration validation and typing across different components, reducing duplication and making it easier to maintain and evolve the configuration structure.