### PR TITLE
feat: moving orchestrator to use config

### DIFF
--- a/packages/auth/src/key-manager/types.ts
+++ b/packages/auth/src/key-manager/types.ts
@@ -1,11 +1,10 @@
-import type { JSONWebKeySet } from 'jose'
 import type {
   IKeyManager as IBaseKeyManager,
   SignOptions,
   VerifyOptions,
   VerifyResult,
   RotateOptions,
-  RotationResult
+  RotationResult,
 } from '@catalyst/authorization'
 
 // Re-export for convenience
@@ -38,4 +37,4 @@ export interface KeyManagerConfig {
 /**
  * Core KeyManager interface for all key management operations.
  */
-export interface IKeyManager extends IBaseKeyManager { }
+export type IKeyManager = IBaseKeyManager

--- a/packages/auth/src/policies/types.ts
+++ b/packages/auth/src/policies/types.ts
@@ -1,5 +1,5 @@
 import type { AuthorizationDomain, AuthorizationEngine } from '@catalyst/authorization'
-import { Action, Role } from '@catalyst/authorization'
+import type { Action, Role } from '@catalyst/authorization'
 
 export type IBGPEntity = {
   name: string

--- a/packages/authorization/tests/policy/jwt-helper.test.ts
+++ b/packages/authorization/tests/policy/jwt-helper.test.ts
@@ -3,56 +3,56 @@ import { Role } from '../../src/policy/src/types.js'
 import { jwtToEntity } from '../../src/jwt/index.js'
 
 describe('jwtToEntity', () => {
-    it('should map a JWT payload to a Cedar Entity with primary role and name', () => {
-        const payload = {
-            sub: 'user-123',
-            entity: {
-                id: 'user-123',
-                name: 'alice',
-                type: 'user',
-                role: Role.ADMIN
-            },
-            roles: [Role.ADMIN, Role.USER],
-            claims: {
-                orgId: 'org-456'
-            }
-        }
+  it('should map a JWT payload to a Cedar Entity with primary role and name', () => {
+    const payload = {
+      sub: 'user-123',
+      entity: {
+        id: 'user-123',
+        name: 'alice',
+        type: 'user',
+        role: Role.ADMIN,
+      },
+      roles: [Role.ADMIN, Role.USER],
+      claims: {
+        orgId: 'org-456',
+      },
+    }
 
-        const entity = jwtToEntity(payload as any)
+    const entity = jwtToEntity(payload as Record<string, unknown>)
 
-        expect(entity.uid.type).toBe('ADMIN')
-        expect(entity.uid.id).toBe('alice')
-        expect(entity.attrs.id).toBe('user-123')
-        expect(entity.attrs.name).toBe('alice')
-        expect(entity.attrs.orgId).toBe('org-456')
-    })
+    expect(entity.uid.type).toBe('ADMIN')
+    expect(entity.uid.id).toBe('alice')
+    expect(entity.attrs.id).toBe('user-123')
+    expect(entity.attrs.name).toBe('alice')
+    expect(entity.attrs.orgId).toBe('org-456')
+  })
 
-    it('should fallback to first role if primaryRole is missing', () => {
-        const payload = {
-            sub: 'node-01',
-            entity: {
-                id: 'node-01',
-                name: 'catalyst-node-01',
-                type: 'node'
-            },
-            roles: [Role.NODE]
-        }
+  it('should fallback to first role if primaryRole is missing', () => {
+    const payload = {
+      sub: 'node-01',
+      entity: {
+        id: 'node-01',
+        name: 'catalyst-node-01',
+        type: 'node',
+      },
+      roles: [Role.NODE],
+    }
 
-        const entity = jwtToEntity(payload as any)
+    const entity = jwtToEntity(payload as Record<string, unknown>)
 
-        expect(entity.uid.type).toBe('NODE')
-        expect(entity.uid.id).toBe('catalyst-node-01')
-    })
+    expect(entity.uid.type).toBe('NODE')
+    expect(entity.uid.id).toBe('catalyst-node-01')
+  })
 
-    it('should fallback to sub if entity.name is missing', () => {
-        const payload = {
-            sub: 'user-789',
-            roles: [Role.USER]
-        }
+  it('should fallback to sub if entity.name is missing', () => {
+    const payload = {
+      sub: 'user-789',
+      roles: [Role.USER],
+    }
 
-        const entity = jwtToEntity(payload as any)
+    const entity = jwtToEntity(payload as Record<string, unknown>)
 
-        expect(entity.uid.type).toBe('USER')
-        expect(entity.uid.id).toBe('user-789')
-    })
+    expect(entity.uid.type).toBe('USER')
+    expect(entity.uid.id).toBe('user-789')
+  })
 })

--- a/packages/cli/tests/service.unit.test.ts
+++ b/packages/cli/tests/service.unit.test.ts
@@ -7,7 +7,7 @@ const mockApplyAction = mock((_action: unknown) =>
   Promise.resolve({ success: true, error: undefined as string | undefined })
 )
 const mockListLocalRoutes = mock(() =>
-  Promise.resolve({ routes: { local: [] as any[], internal: [] as any[] } })
+  Promise.resolve({ routes: { local: [] as unknown[], internal: [] as unknown[] } })
 )
 
 const mockCreateClient = mock(() =>

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,29 @@
+# @catalyst/config
+
+Centralized configuration management for the Catalyst Node system.
+
+## Environment Variables
+
+| Variable                            | Config Path                              | Description                                  | Default        |
+| ----------------------------------- | ---------------------------------------- | -------------------------------------------- | -------------- |
+| `PORT`                              | `port`                                   | The port the service will listen on          | `3000`         |
+| `CATALYST_NODE_ID`                  | `node.name`                              | **Required.** FQDN of the node               | -              |
+| `CATALYST_PEERING_ENDPOINT`         | `node.endpoint`                          | **Required.** Reachable endpoint for peering | -              |
+| `CATALYST_DOMAINS`                  | `node.domains`                           | Comma-separated list of managed domains      | `[]`           |
+| `CATALYST_PEERING_SECRET`           | `orchestrator.ibgp.secret`               | Secret for iBGP peering                      | `valid-secret` |
+| `CATALYST_GQL_GATEWAY_ENDPOINT`     | `orchestrator.gqlGatewayConfig.endpoint` | GraphQL Gateway endpoint                     | -              |
+| `CATALYST_AUTH_KEYS_DB`             | `auth.keysDb`                            | SQLite DB for keys                           | `keys.db`      |
+| `CATALYST_AUTH_TOKENS_DB`           | `auth.tokensDb`                          | SQLite DB for tokens                         | `tokens.db`    |
+| `CATALYST_AUTH_REVOCATION`          | `auth.revocation.enabled`                | Enable token revocation (`true`/`false`)     | `false`        |
+| `CATALYST_AUTH_REVOCATION_MAX_SIZE` | `auth.revocation.maxSize`                | Max size for revocation store                | -              |
+| `CATALYST_BOOTSTRAP_TOKEN`          | `auth.bootstrap.token`                   | Pre-defined bootstrap token                  | -              |
+| `CATALYST_BOOTSTRAP_TTL`            | `auth.bootstrap.ttl`                     | TTL for bootstrap token in ms                | `86400000`     |
+
+## Usage
+
+```typescript
+import { loadDefaultConfig } from '@catalyst/config'
+
+const config = loadDefaultConfig()
+console.log(`Starting node ${config.node.name} on port ${config.port}`)
+```

--- a/packages/orchestrator/README.md
+++ b/packages/orchestrator/README.md
@@ -2,6 +2,10 @@
 
 The **Catalyst Orchestrator** is the central control plane for the Catalyst network. It manages the lifecycle of services, handles configuration updates via RPC, and orchestrates the stitching of GraphQL schemas across the federation.
 
+## ⚙️ Configuration
+
+The orchestrator is configured via environment variables. For a full list of available options, see the [Centralized Configuration Documentation](../config/README.md).
+
 ## 🔌 Plugins
 
 The Orchestrator uses a robust **Plugin System** to extend functionality. A pipeline of plugins processes every action received by the RPC server.


### PR DESCRIPTION
### TL;DR

Improved type safety and configuration management across the Catalyst system with centralized configuration handling.

### What changed?

- Added centralized configuration management in `@catalyst/config` package with environment variable support
- Created comprehensive documentation for configuration options in `packages/config/README.md`
- Fixed type imports across packages (using `type` imports where appropriate)
- Enhanced JWT entity handling to properly set role information
- Updated the orchestrator to use the new centralized configuration system
- Fixed type issues in the auth RPC server and JWT helper functions
- Improved code consistency with proper type annotations

### How to test?

1. Verify the orchestrator starts correctly using the new configuration system:
   ```
   CATALYST_NODE_ID=test-node.local CATALYST_PEERING_ENDPOINT=http://localhost:3000 npm run start:orchestrator
   ```

2. Test the auth service with proper role assignment:
   ```
   curl -X POST http://localhost:3000/auth/login -d '{"username":"admin","password":"password"}'
   ```

3. Verify configuration documentation matches implementation by checking environment variables against the config schema

### Why make this change?

This change establishes a centralized configuration system that makes the Catalyst platform more maintainable and consistent. By standardizing how configuration is loaded and validated, we reduce duplication and potential errors across services. The improved type safety helps catch issues at compile time rather than runtime, and the documentation makes it easier for developers to understand available configuration options.