### PR TITLE
feat: first attempt and context aware permissioning

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@catalyst/authorization": "workspace:*",
+        "@catalyst/config": "workspace:*",
         "@hono/capnweb": "^0.1.0",
         "argon2": "^0.44.0",
         "capnweb": "^0.4.0",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@hono/capnweb": "^0.1.0",
     "@catalyst/authorization": "workspace:*",
+    "@catalyst/config": "workspace:*",
     "argon2": "^0.44.0",
     "capnweb": "^0.4.0",
     "hono": "^4.11.3",

--- a/packages/auth/src/rpc/schema.ts
+++ b/packages/auth/src/rpc/schema.ts
@@ -330,7 +330,13 @@ export interface TokenHandlers {
   /** Create a new token with optional SANs and entity info */
   create(request: {
     subject: string
-    entity: { id: string; name: string; type: 'user' | 'service' }
+    entity: {
+      id: string
+      name: string
+      type: 'user' | 'service'
+      role: z.infer<typeof RoleSchema>
+      nodeId?: string
+    }
     roles: z.infer<typeof RoleSchema>[]
     sans?: string[]
     expiresIn?: string

--- a/packages/auth/tests/system-token.test.ts
+++ b/packages/auth/tests/system-token.test.ts
@@ -9,6 +9,8 @@ describe('System Admin Token', () => {
     // Use in-memory databases for tests
     process.env.CATALYST_AUTH_KEYS_DB = ':memory:'
     process.env.CATALYST_AUTH_TOKENS_DB = ':memory:'
+    process.env.CATALYST_NODE_ID = 'test-node'
+    process.env.CATALYST_PEERING_ENDPOINT = 'http://localhost:3000'
 
     // Import and start server to trigger minting
     const { startServer } = await import('../src/server.js')

--- a/packages/authorization/src/jwt/local/index.ts
+++ b/packages/authorization/src/jwt/local/index.ts
@@ -5,19 +5,25 @@ import type { IKeyManager, VerifyResult } from '../../key-manager/index.ts'
 export class LocalTokenManager implements TokenManager {
   constructor(
     private keyManager: IKeyManager,
-    private store: TokenStore
+    private store: TokenStore,
+    private nodeId?: string
   ) {}
 
   getStore(): TokenStore {
     return this.store
   }
 
-    async mint(options: MintOptions): Promise<string> {
-        const claims: Record<string, unknown> = {
-            ...options.claims,
-            entity: options.entity,
-            roles: options.roles,
-        }
+  async mint(options: MintOptions): Promise<string> {
+    // Auto-inject nodeId if configured and not already present
+    if (this.nodeId && !options.entity.nodeId) {
+      options.entity.nodeId = this.nodeId
+    }
+
+    const claims: Record<string, unknown> = {
+      ...options.claims,
+      entity: options.entity,
+      roles: options.roles,
+    }
 
     // Support certificate binding (ADR 0007)
     if (options.certificateFingerprint) {

--- a/packages/authorization/src/policy/src/authorization-engine.ts
+++ b/packages/authorization/src/policy/src/authorization-engine.ts
@@ -50,7 +50,7 @@ export class AuthorizationEngine<
    * @throws {Error} If warnings are present and `failOnWarnings` is `true`.
    * @returns {boolean} `true` if policies are valid.
    */
-  validatePolicies(opts: { failOnWarnings?: boolean } = { failOnWarnings: true }): boolean {
+  validatePolicies(): boolean {
     const validationAnswer = cedar.validate({
       schema: this.schema,
       policies: { staticPolicies: this.policies },
@@ -59,9 +59,10 @@ export class AuthorizationEngine<
     if (validationAnswer.type === 'failure') {
       throw new Error(validationAnswer.errors.map((error) => error.message).join('\n'))
     }
-    const hasWarning = validationAnswer.validationWarnings.length > 0
     const hasError = validationAnswer.validationErrors.length > 0
+    const hasWarning = validationAnswer.validationWarnings.length > 0
     const hasOtherWarnings = validationAnswer.otherWarnings.length > 0
+
     if (hasError) console.error(JSON.stringify(validationAnswer.validationErrors, null, 2))
     if (hasWarning) console.warn(JSON.stringify(validationAnswer.validationWarnings, null, 2))
     if (hasOtherWarnings) console.warn(JSON.stringify(validationAnswer.otherWarnings, null, 2))

--- a/packages/authorization/src/policy/src/definitions/admin.cedar
+++ b/packages/authorization/src/policy/src/definitions/admin.cedar
@@ -2,4 +2,8 @@ permit (
     principal is CATALYST::ADMIN,
     action,
     resource
-);
+)
+when {
+    principal.trustedDomains.contains(resource.domainId) &&
+    (principal.trustedNodes.isEmpty() || principal.trustedNodes.contains(resource.nodeId))
+};

--- a/packages/authorization/src/policy/src/definitions/data-custodian.cedar
+++ b/packages/authorization/src/policy/src/definitions/data-custodian.cedar
@@ -5,4 +5,8 @@ permit (
         CATALYST::Action::"ROUTE_DELETE"
     ],
     resource
-);
+)
+when {
+    principal.trustedDomains.contains(resource.domainId) &&
+    (principal.trustedNodes.isEmpty() || principal.trustedNodes.contains(resource.nodeId))
+};

--- a/packages/authorization/src/policy/src/definitions/node-custodian.cedar
+++ b/packages/authorization/src/policy/src/definitions/node-custodian.cedar
@@ -9,4 +9,8 @@ permit (
         CATALYST::Action::"IBGP_UPDATE"
     ],
     resource
-);
+)
+when {
+    principal.trustedDomains.contains(resource.domainId) &&
+    (principal.trustedNodes.isEmpty() || principal.trustedNodes.contains(resource.nodeId))
+};

--- a/packages/authorization/src/policy/src/definitions/node.cedar
+++ b/packages/authorization/src/policy/src/definitions/node.cedar
@@ -6,4 +6,8 @@ permit (
         CATALYST::Action::"IBGP_UPDATE"
     ],
     resource
-);
+)
+when {
+    principal.trustedDomains.contains(resource.domainId) &&
+    (principal.trustedNodes.isEmpty() || principal.trustedNodes.contains(resource.nodeId))
+};

--- a/packages/authorization/src/policy/src/definitions/schema.cedar
+++ b/packages/authorization/src/policy/src/definitions/schema.cedar
@@ -1,15 +1,65 @@
 namespace CATALYST {
-    entity ADMIN;
-    entity NODE;
-    entity DATA_CUSTODIAN;
-    entity NODE_CUSTODIAN;
-    entity USER;
+    entity ADMIN {
+        id: String,
+        name: String,
+        type: String,
+        role: String,
+        trustedNodes: Set<String>,
+        trustedDomains: Set<String>
+    };
+    entity NODE {
+        id: String,
+        name: String,
+        type: String,
+        role: String,
+        trustedNodes: Set<String>,
+        trustedDomains: Set<String>
+    };
+    entity DATA_CUSTODIAN {
+        id: String,
+        name: String,
+        type: String,
+        role: String,
+        trustedNodes: Set<String>,
+        trustedDomains: Set<String>
+    };
+    entity NODE_CUSTODIAN {
+        id: String,
+        name: String,
+        type: String,
+        role: String,
+        trustedNodes: Set<String>,
+        trustedDomains: Set<String>
+    };
+    entity USER {
+        id: String,
+        name: String,
+        type: String,
+        role: String,
+        trustedNodes: Set<String>,
+        trustedDomains: Set<String>
+    };
 
-    entity IBGP;
-    entity Peer;
-    entity Route;
-    entity Token;
-    entity AdminPanel;
+    entity IBGP {
+        nodeId: String,
+        domainId: String
+    };
+    entity Peer {
+        nodeId: String,
+        domainId: String
+    };
+    entity Route {
+        nodeId: String,
+        domainId: String
+    };
+    entity Token {
+        nodeId: String,
+        domainId: String
+    };
+    entity AdminPanel {
+        nodeId: String,
+        domainId: String
+    };
 
     action LOGIN appliesTo {
         principal: [ADMIN, NODE, DATA_CUSTODIAN, NODE_CUSTODIAN, USER],
@@ -69,5 +119,10 @@ namespace CATALYST {
     action TOKEN_LIST appliesTo {
         principal: ADMIN,
         resource: Token
+    };
+
+    action MANAGE appliesTo {
+        principal: [ADMIN, NODE, DATA_CUSTODIAN, NODE_CUSTODIAN, USER],
+        resource: AdminPanel
     };
 }

--- a/packages/authorization/src/policy/src/definitions/user.cedar
+++ b/packages/authorization/src/policy/src/definitions/user.cedar
@@ -2,4 +2,8 @@ permit (
     principal is CATALYST::USER,
     action == CATALYST::Action::"LOGIN",
     resource
-);
+)
+when {
+    principal.trustedDomains.contains(resource.domainId) &&
+    (principal.trustedNodes.isEmpty() || principal.trustedNodes.contains(resource.nodeId))
+};

--- a/packages/authorization/src/policy/src/types.ts
+++ b/packages/authorization/src/policy/src/types.ts
@@ -18,6 +18,7 @@ export enum Role {
  */
 export enum Action {
   LOGIN = 'LOGIN',
+  MANAGE = 'MANAGE',
   IBGP_CONNECT = 'IBGP_CONNECT',
   IBGP_DISCONNECT = 'IBGP_DISCONNECT',
   IBGP_UPDATE = 'IBGP_UPDATE',
@@ -139,8 +140,8 @@ export type ActionContext<
   TActionID extends ActionId<TDomain>,
 > =
   TDomain['Actions'] extends Record<string, unknown>
-  ? TDomain['Actions'][TActionID]
-  : Record<string, unknown>
+    ? TDomain['Actions'][TActionID]
+    : Record<string, unknown>
 
 /**
  * Represents an authorization request to be evaluated by the engine.
@@ -167,17 +168,17 @@ export type AuthorizationRequest<
   entities: Entity<TDomain>[] | EntityCollection<TDomain>
 } & (Record<string, never> extends ActionContext<TDomain, TActionID>
   ? {
-    /**
-     * Contextual information for the request (optional if the action requires no context).
-     */
-    context?: ActionContext<TDomain, TActionID>
-  }
+      /**
+       * Contextual information for the request (optional if the action requires no context).
+       */
+      context?: ActionContext<TDomain, TActionID>
+    }
   : {
-    /**
-     * Contextual information for the request (required if the action defines a context shape).
-     */
-    context: ActionContext<TDomain, TActionID>
-  })
+      /**
+       * Contextual information for the request (required if the action defines a context shape).
+       */
+      context: ActionContext<TDomain, TActionID>
+    })
 
 /**
  * Raw response from the authorization evaluation (internal use).
@@ -194,23 +195,23 @@ export interface AuthorizationResponse {
  */
 export type AuthorizationEngineResult =
   | {
-    /** Indicates a failure in the engine execution (e.g., internal error). */
-    type: 'failure'
-    /** List of error messages explaining the failure. */
-    errors: string[]
-  }
+      /** Indicates a failure in the engine execution (e.g., internal error). */
+      type: 'failure'
+      /** List of error messages explaining the failure. */
+      errors: string[]
+    }
   | {
-    /** Indicates the request was successfully evaluated. */
-    type: 'evaluated'
-    /** The authorization decision ('allow' or 'deny'). */
-    decision: 'allow' | 'deny'
-    /** Boolean shorthand for decision === 'allow'. */
-    allowed: boolean
-    /** IDs of the policies that determined the decision. */
-    reasons: string[]
-    /** Detailed diagnostics or warnings from the engine. */
-    diagnostics: DetailedError[]
-  }
+      /** Indicates the request was successfully evaluated. */
+      type: 'evaluated'
+      /** The authorization decision ('allow' or 'deny'). */
+      decision: 'allow' | 'deny'
+      /** Boolean shorthand for decision === 'allow'. */
+      allowed: boolean
+      /** IDs of the policies that determined the decision. */
+      reasons: string[]
+      /** Detailed diagnostics or warnings from the engine. */
+      diagnostics: DetailedError[]
+    }
 
 /**
  * Interface for the Authorization Engine.

--- a/packages/authorization/tests/jwt/local.test.ts
+++ b/packages/authorization/tests/jwt/local.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'bun:test'
+import * as jose from 'jose'
+import { LocalTokenManager } from '../../src/jwt/local/index.js'
+import { Role } from '../../src/policy/src/types.js'
+import { type IKeyManager } from '../../src/key-manager/index.js'
+import { type TokenStore } from '../../src/jwt/index.js'
+
+describe('LocalTokenManager', () => {
+  const mockKeyManager: IKeyManager = {
+    sign: async (options: { subject: string; claims?: Record<string, unknown> }) => {
+      // Create a dummy JWT for testing
+      const payload = {
+        sub: options.subject,
+        jti: 'test-jti',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        ...options.claims,
+      }
+      return new jose.SignJWT(payload)
+        .setProtectedHeader({ alg: 'HS256' })
+        .sign(new TextEncoder().encode('secret'))
+    },
+    verify: async () => ({ valid: true, payload: {} }),
+    getJwks: async () => ({ keys: [] }),
+    rotate: async () => ({ previousKeyId: '', newKeyId: '' }),
+    getCurrentKeyId: async () => 'test-kid',
+    shutdown: async () => {},
+  }
+
+  const mockStore: TokenStore = {
+    recordToken: async () => {},
+    findToken: async () => null,
+    revokeToken: async () => {},
+    revokeBySan: async () => {},
+    isRevoked: async () => false,
+    getRevocationList: async () => [],
+    listTokens: async () => [],
+  }
+
+  it('should auto-inject nodeId if configured', async () => {
+    const manager = new LocalTokenManager(mockKeyManager, mockStore, 'node-a')
+
+    const token = await manager.mint({
+      subject: 'user-1',
+      roles: [Role.USER],
+      entity: {
+        id: 'user-1',
+        name: 'alice',
+        type: 'user',
+        role: Role.USER,
+      },
+    })
+
+    const decoded = jose.decodeJwt(token)
+    const entity = decoded.entity as Record<string, unknown>
+    expect(entity.nodeId).toBe('node-a')
+  })
+
+  it('should not overwrite nodeId if explicitly provided', async () => {
+    const manager = new LocalTokenManager(mockKeyManager, mockStore, 'node-a')
+
+    const token = await manager.mint({
+      subject: 'user-1',
+      roles: [Role.USER],
+      entity: {
+        id: 'user-1',
+        name: 'alice',
+        type: 'user',
+        role: Role.USER,
+        nodeId: 'node-b', // Explicitly provided
+      },
+    })
+
+    const decoded = jose.decodeJwt(token)
+    const entity = decoded.entity as Record<string, unknown>
+    expect(entity.nodeId).toBe('node-b')
+  })
+})

--- a/packages/authorization/tests/policy/integration/e2e-comprehensive.test.ts
+++ b/packages/authorization/tests/policy/integration/e2e-comprehensive.test.ts
@@ -98,9 +98,7 @@ describe('Full E2E Verification', () => {
     // --- Step 1: Instantiate Engine ---
     const engine = new AuthorizationEngine<ECommerceDomain>(cedarSchema, cedarPolicies)
     const isValid = engine.validatePolicies()
-    expect(isValid).toBe(false) // Returns true if there are errors/warnings, confusingly named?
-    // Wait, let me check validatePolicies implementation again.
-    // It returns "hasWarning || hasError || hasOtherWarnings". So false means Good (0 errors).
+    expect(isValid).toBe(true) // Returns true if valid (no errors)
 
     // --- Step 2: Instantiate Factory and Register Mappers ---
     const factory = new EntityBuilderFactory<ECommerceDomain>()

--- a/packages/authorization/tests/policy/jwt-helper.test.ts
+++ b/packages/authorization/tests/policy/jwt-helper.test.ts
@@ -11,6 +11,7 @@ describe('jwtToEntity', () => {
         name: 'alice',
         type: 'user',
         role: Role.ADMIN,
+        nodeId: 'node-a',
       },
       roles: [Role.ADMIN, Role.USER],
       claims: {
@@ -20,11 +21,12 @@ describe('jwtToEntity', () => {
 
     const entity = jwtToEntity(payload as Record<string, unknown>)
 
-    expect(entity.uid.type).toBe('ADMIN')
+    expect(entity.uid.type).toBe('CATALYST::ADMIN')
     expect(entity.uid.id).toBe('alice')
     expect(entity.attrs.id).toBe('user-123')
     expect(entity.attrs.name).toBe('alice')
     expect(entity.attrs.orgId).toBe('org-456')
+    // nodeId is no longer mapped directly
   })
 
   it('should fallback to first role if primaryRole is missing', () => {
@@ -40,7 +42,7 @@ describe('jwtToEntity', () => {
 
     const entity = jwtToEntity(payload as Record<string, unknown>)
 
-    expect(entity.uid.type).toBe('NODE')
+    expect(entity.uid.type).toBe('CATALYST::NODE')
     expect(entity.uid.id).toBe('catalyst-node-01')
   })
 
@@ -52,7 +54,7 @@ describe('jwtToEntity', () => {
 
     const entity = jwtToEntity(payload as Record<string, unknown>)
 
-    expect(entity.uid.type).toBe('USER')
+    expect(entity.uid.type).toBe('CATALYST::USER')
     expect(entity.uid.id).toBe('user-789')
   })
 })


### PR DESCRIPTION
### TL;DR

Added domain and node isolation to the authorization system, allowing tokens to be restricted to specific domains and nodes.

### What changed?

- Enhanced the token entity model to include `trustedDomains` and `trustedNodes` attributes
- Updated Cedar policies to enforce domain and node isolation boundaries
- Modified the auth RPC server to validate tokens against the current node and domain
- Added configuration support for node name and domain ID
- Updated the token creation process to automatically inject the node ID
- Enhanced authorization checks to use the policy engine for admin panel access
- Added comprehensive tests for domain and node isolation

### How to test?

1. Create tokens with specific trusted domains and nodes:
```typescript
const token = await tokenManager.mint({
  subject: 'user-1',
  entity: {
    id: 'user-1',
    name: 'User',
    type: 'user',
    role: Role.ADMIN,
    trustedDomains: ['domain-a'],
    trustedNodes: ['node-1']
  },
  roles: [Role.ADMIN]
})
```

2. Verify that tokens are only valid within their specified domains and nodes
3. Run the updated tests to verify isolation boundaries work as expected

### Why make this change?

This change implements a critical security feature that enforces proper isolation between different domains and nodes in a multi-tenant environment. It ensures that tokens issued for one domain cannot be used to access resources in another domain, and similarly for nodes. This prevents potential privilege escalation and unauthorized access across domain boundaries.