### PR TITLE
chore: using bun catalog

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,10 +51,10 @@
       "name": "@catalyst/auth",
       "version": "0.0.0",
       "dependencies": {
-        "@catalyst/authorization": "workspace:*",
-        "@catalyst/config": "workspace:*",
+        "@catalyst/authorization": "catalog:",
+        "@catalyst/config": "catalog:",
         "@hono/capnweb": "^0.1.0",
-        "argon2": "^0.44.0",
+        "argon2": "catalog:",
         "capnweb": "^0.4.0",
         "hono": "^4.11.3",
         "jose": "^6.0.0",
@@ -62,9 +62,9 @@
       },
       "devDependencies": {
         "@types/bun": "catalog:dev",
-        "@types/node": "^20.11.0",
+        "@types/node": "catalog:dev",
         "testcontainers": "catalog:testing",
-        "typescript": "^5.3.3",
+        "typescript": "catalog:dev",
         "vitest": "^1.2.1",
       },
     },
@@ -72,14 +72,14 @@
       "name": "@catalyst/authorization",
       "version": "0.0.0",
       "dependencies": {
-        "@cedar-policy/cedar-wasm": "^4.8.2",
-        "jose": "^6.0.0",
+        "@cedar-policy/cedar-wasm": "catalog:",
+        "jose": "catalog:",
         "zod": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:dev",
-        "@types/node": "^20.11.0",
-        "typescript": "^5.3.3",
+        "@types/node": "catalog:dev",
+        "typescript": "catalog:dev",
       },
     },
     "packages/cli": {
@@ -89,19 +89,19 @@
         "catalyst": "./src/index.ts",
       },
       "dependencies": {
-        "@catalyst/orchestrator": "workspace:*",
+        "@catalyst/orchestrator": "catalog:",
         "capnweb": "catalog:",
-        "chalk": "^5.3.0",
+        "chalk": "catalog:",
         "commander": "catalog:",
-        "inquirer": "^9.2.14",
-        "ws": "^8.19.0",
+        "inquirer": "catalog:",
+        "ws": "catalog:",
         "zod": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:dev",
-        "@types/inquirer": "^9.0.7",
+        "@types/inquirer": "catalog:dev",
         "@types/node": "catalog:dev",
-        "@types/ws": "^8.18.1",
+        "@types/ws": "catalog:dev",
         "testcontainers": "catalog:testing",
         "tsx": "catalog:dev",
         "typescript": "catalog:dev",
@@ -112,6 +112,10 @@
       "version": "0.1.0",
       "dependencies": {
         "zod": "catalog:",
+      },
+      "devDependencies": {
+        "@types/node": "catalog:dev",
+        "typescript": "catalog:dev",
       },
     },
     "packages/examples": {
@@ -163,7 +167,7 @@
         "graphql": "catalog:",
         "graphql-yoga": "catalog:",
         "hono": "catalog:",
-        "ip": "^2.0.1",
+        "ip": "catalog:",
       },
       "devDependencies": {
         "@types/node": "catalog:dev",
@@ -177,8 +181,8 @@
       "name": "@catalyst/orchestrator",
       "version": "0.0.0",
       "dependencies": {
-        "@catalyst/auth": "workspace:*",
-        "@catalyst/config": "workspace:*",
+        "@catalyst/auth": "catalog:",
+        "@catalyst/config": "catalog:",
         "@hono/capnweb": "catalog:",
         "capnweb": "catalog:",
         "hono": "catalog:",
@@ -212,6 +216,16 @@
   },
   "catalog": {
     "@aws-sdk/client-s3": "^3.964.0",
+    "@catalyst/auth": "workspace:*",
+    "@catalyst/authorization": "workspace:*",
+    "@catalyst/cli": "workspace:*",
+    "@catalyst/config": "workspace:*",
+    "@catalyst/examples": "workspace:*",
+    "@catalyst/gateway": "workspace:*",
+    "@catalyst/node": "workspace:*",
+    "@catalyst/orchestrator": "workspace:*",
+    "@catalyst/sdk": "workspace:*",
+    "@cedar-policy/cedar-wasm": "^4.8.2",
     "@graphql-tools/delegate": "^12.0.4",
     "@graphql-tools/schema": "^10.0.31",
     "@graphql-tools/stitch": "^10.1.8",
@@ -220,18 +234,25 @@
     "@graphql-tools/wrap": "^11.1.4",
     "@hono/capnweb": "^0.1.0",
     "@hono/node-server": "^1.19.7",
+    "argon2": "^0.44.0",
     "capnweb": "^0.4.0",
+    "chalk": "^5.3.0",
     "commander": "^14.0.2",
     "graphql": "16.12.0",
     "graphql-yoga": "^5.18.0",
     "hono": "^4.11.3",
+    "inquirer": "^9.2.14",
+    "ip": "^2.0.1",
     "jose": "^6.0.0",
+    "ws": "^8.19.0",
     "zod": "^4.0.0",
   },
   "catalogs": {
     "dev": {
       "@types/bun": "^1.3.6",
+      "@types/inquirer": "^9.0.7",
       "@types/node": "^25.0.3",
+      "@types/ws": "^8.18.1",
       "tsup": "^8.5.1",
       "tsx": "^4.7.1",
       "typescript": "^5.9.3",
@@ -1542,11 +1563,13 @@
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "@catalyst/auth/@types/node": ["@types/node@20.19.30", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g=="],
+    "@catalyst/auth/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
-    "@catalyst/authorization/@types/node": ["@types/node@20.19.30", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g=="],
+    "@catalyst/authorization/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
     "@catalyst/cli/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
+
+    "@catalyst/config/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
     "@catalyst/examples/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
 
@@ -1688,7 +1711,13 @@
 
     "@aws-sdk/signature-v4-multi-region/@aws-sdk/middleware-sdk-s3/@aws-sdk/util-arn-parser": ["@aws-sdk/util-arn-parser@3.972.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-RM5Mmo/KJ593iMSrALlHEOcc9YOIyOsDmS5x2NLOMdEmzv1o00fcpAkCQ02IGu1eFneBFT7uX0Mpag0HI+Cz2g=="],
 
+    "@catalyst/auth/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@catalyst/authorization/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "@catalyst/cli/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@catalyst/config/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@catalyst/examples/vitest/@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,22 @@
       "@graphql-tools/wrap": "^11.1.4",
       "@graphql-tools/stitching-directives": "^4.0.10",
       "@aws-sdk/client-s3": "^3.964.0",
-      "jose": "^6.0.0"
+      "jose": "^6.0.0",
+      "argon2": "^0.44.0",
+      "@cedar-policy/cedar-wasm": "^4.8.2",
+      "chalk": "^5.3.0",
+      "inquirer": "^9.2.14",
+      "ws": "^8.19.0",
+      "ip": "^2.0.1",
+      "@catalyst/auth": "workspace:*",
+      "@catalyst/authorization": "workspace:*",
+      "@catalyst/cli": "workspace:*",
+      "@catalyst/config": "workspace:*",
+      "@catalyst/examples": "workspace:*",
+      "@catalyst/gateway": "workspace:*",
+      "@catalyst/node": "workspace:*",
+      "@catalyst/orchestrator": "workspace:*",
+      "@catalyst/sdk": "workspace:*"
     },
     "catalogs": {
       "dev": {
@@ -39,7 +54,9 @@
         "@types/node": "^25.0.3",
         "@types/bun": "^1.3.6",
         "tsup": "^8.5.1",
-        "tsx": "^4.7.1"
+        "tsx": "^4.7.1",
+        "@types/inquirer": "^9.0.7",
+        "@types/ws": "^8.18.1"
       },
       "testing": {
         "vitest": "^4.0.16",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -16,9 +16,9 @@
   },
   "dependencies": {
     "@hono/capnweb": "^0.1.0",
-    "@catalyst/authorization": "workspace:*",
-    "@catalyst/config": "workspace:*",
-    "argon2": "^0.44.0",
+    "@catalyst/authorization": "catalog:",
+    "@catalyst/config": "catalog:",
+    "argon2": "catalog:",
     "capnweb": "^0.4.0",
     "hono": "^4.11.3",
     "jose": "^6.0.0",
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "@types/bun": "catalog:dev",
-    "@types/node": "^20.11.0",
+    "@types/node": "catalog:dev",
     "testcontainers": "catalog:testing",
-    "typescript": "^5.3.3",
+    "typescript": "catalog:dev",
     "vitest": "^1.2.1"
   }
 }

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -9,13 +9,13 @@
   },
   "private": true,
   "dependencies": {
-    "jose": "^6.0.0",
+    "jose": "catalog:",
     "zod": "catalog:",
-    "@cedar-policy/cedar-wasm": "^4.8.2"
+    "@cedar-policy/cedar-wasm": "catalog:"
   },
   "devDependencies": {
     "@types/bun": "catalog:dev",
-    "@types/node": "^20.11.0",
-    "typescript": "^5.3.3"
+    "@types/node": "catalog:dev",
+    "typescript": "catalog:dev"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,17 +12,17 @@
   },
   "dependencies": {
     "capnweb": "catalog:",
-    "chalk": "^5.3.0",
+    "chalk": "catalog:",
     "commander": "catalog:",
-    "inquirer": "^9.2.14",
-    "ws": "^8.19.0",
+    "inquirer": "catalog:",
+    "ws": "catalog:",
     "zod": "catalog:",
-    "@catalyst/orchestrator": "workspace:*"
+    "@catalyst/orchestrator": "catalog:"
   },
   "devDependencies": {
-    "@types/inquirer": "^9.0.7",
+    "@types/inquirer": "catalog:dev",
     "@types/node": "catalog:dev",
-    "@types/ws": "^8.18.1",
+    "@types/ws": "catalog:dev",
     "@types/bun": "catalog:dev",
     "testcontainers": "catalog:testing",
     "tsx": "catalog:dev",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -16,5 +16,9 @@
   },
   "dependencies": {
     "zod": "catalog:"
+  },
+  "devDependencies": {
+    "typescript": "catalog:dev",
+    "@types/node": "catalog:dev"
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -29,6 +29,6 @@
     "graphql": "catalog:",
     "graphql-yoga": "catalog:",
     "hono": "catalog:",
-    "ip": "^2.0.1"
+    "ip": "catalog:"
   }
 }

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -10,8 +10,8 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@catalyst/auth": "workspace:*",
-    "@catalyst/config": "workspace:*",
+    "@catalyst/auth": "catalog:",
+    "@catalyst/config": "catalog:",
     "@hono/capnweb": "catalog:",
     "capnweb": "catalog:",
     "hono": "catalog:",


### PR DESCRIPTION
### TL;DR

Standardize dependency management by moving workspace dependencies to the catalog system.

### What changed?

- Moved all workspace dependencies (`workspace:*`) to use the catalog system (`catalog:`) for internal packages
- Added all internal packages to the root `package.json` catalog section
- Added missing dependencies to the catalog
- Standardized development dependencies to use `catalog:dev` instead of pinned versions
- Added missing dev dependencies to the `packages/config` package

### How to test?

1. Run `bun install` to verify dependencies resolve correctly
2. Run tests to ensure all functionality works as expected
3. Build the project to confirm there are no dependency-related issues

### Why make this change?

This change improves dependency management by centralizing version control in the catalog system. Using the catalog approach for internal dependencies ensures consistent versioning across the project and simplifies maintenance. It also makes it easier to update shared dependencies by changing them in a single location rather than in multiple package.json files.