### PR TITLE
fix: token minting uses explicit expireAt

### DIFF
--- a/CLAUDE_AGENTS.md
+++ b/CLAUDE_AGENTS.md
@@ -1,0 +1,564 @@
+# CLAUDE_AGENTS.md - Subagent Strategy for Catalyst Node
+
+This document defines the subagent strategy for AI-assisted development on Catalyst Node. It describes each agent's purpose, when to use it, and provides prompt templates for maximum effectiveness.
+
+## Philosophy
+
+**Documentation-First Development:** Before writing any code, we understand the existing context—stack scope, documentation, and ADRs. This prevents wasted effort and ensures changes align with established patterns.
+
+**Parallel Where Possible, Sequential Where Required:** Research and exploration agents run in parallel. Verification agents run sequentially (fail-fast).
+
+**Living Documentation:** Agents don't just consume docs—they help keep them current. Every implementation should consider whether docs need updates.
+
+---
+
+## Agent Catalog
+
+### 1. Stack Scope Agent
+
+**Purpose:** Understand the current Graphite stack before making changes.
+
+**When to Use:**
+
+- At the start of any implementation task
+- Before deciding what files to modify
+- When reviewing someone else's stack
+
+**Objective:** Determine what's in scope for the current PR to keep changes focused and avoid scope creep.
+
+**Agent Type:** `Explore`
+
+**Prompt Template:**
+
+```
+Analyze the current Graphite stack scope for this repository.
+
+Run `gt log short` and `gt stack` to understand:
+1. What branch am I currently on?
+2. What PRs are in my current stack (below and above)?
+3. What is the intent/theme of the current PR based on its name?
+4. What files have been modified in this specific PR (not the whole stack)?
+
+Based on this, tell me:
+- What the scope boundaries are for this PR
+- What changes would be IN scope vs OUT of scope
+- If I should consider splitting work into additional stacked PRs
+```
+
+**Example Output:**
+
+```
+Current Branch: jt/feat-add-token-rotation
+Stack Position: 2 of 3
+
+Stack Structure:
+  ┌─ jt/feat-add-revocation-ui (above)
+  ├─ jt/feat-add-token-rotation (current) ← YOU ARE HERE
+  └─ jt/refactor-auth-stores (below, merged to main)
+
+Current PR Scope:
+- Modified: packages/auth/src/token-manager.ts
+- Modified: packages/auth/src/rpc/schema.ts
+- Added: packages/auth/tests/rotation.test.ts
+
+In Scope: Token rotation logic, rotation RPC endpoint, rotation tests
+Out of Scope: UI changes (belongs in PR above), store refactoring (already in PR below)
+
+Recommendation: Keep changes focused on rotation mechanism. Any revocation-related
+changes should go in the PR above.
+```
+
+---
+
+### 2. Documentation Agent
+
+**Purpose:** Read and synthesize relevant documentation before implementation.
+
+**When to Use:**
+
+- Before any implementation work
+- When touching unfamiliar parts of the codebase
+- When the task involves architecture or security
+
+**Objective:** Understand documented intent so changes reinforce (or deliberately update) existing patterns.
+
+**Agent Type:** `Explore`
+
+**Prompt Template:**
+
+```
+Read the documentation relevant to [TASK DESCRIPTION].
+
+Check these docs based on the task area:
+- ARCHITECTURE.md - If touching system design, component interactions
+- SECURITY.md - If touching auth, crypto, peering, tokens
+- BGP_PROTOCOL.md - If touching peering, routing, propagation
+- TECH_STACK.md - If choosing libraries or patterns
+- packages/[name]/README.md - For package-specific context
+
+For each relevant doc, extract:
+1. Key patterns or requirements that apply to this task
+2. Any constraints or "don't do this" guidance
+3. Existing terminology I should use consistently
+4. Open questions or areas marked as TODO
+
+Summarize what I need to know before implementing [TASK DESCRIPTION].
+```
+
+**Example Prompt:**
+
+```
+Read the documentation relevant to adding a new RPC endpoint for key rotation.
+
+Check SECURITY.md, ARCHITECTURE.md, and packages/auth/README.md.
+
+Extract patterns for:
+- How RPC endpoints are structured
+- Security requirements for key management
+- Any existing key rotation documentation
+```
+
+---
+
+### 3. ADR Compliance Agent
+
+**Purpose:** Ensure implementation follows Architecture Decision Records.
+
+**When to Use:**
+
+- Before any implementation (part of pre-work phase)
+- When touching areas covered by ADRs (observability, storage, auth)
+- When proposing a new technical approach
+
+**Objective:** Follow established decisions. If deviating, propose an ADR amendment.
+
+**Agent Type:** `Explore`
+
+**Prompt Template:**
+
+```
+Check ADR compliance for [TASK DESCRIPTION].
+
+Read all ADRs in docs/adr/ and identify:
+1. Which ADRs are relevant to this task?
+2. What specific requirements do they impose?
+3. Does my planned approach comply with these ADRs?
+4. If not, what would need to change—my approach or the ADR?
+
+ADRs to check:
+- ADR-0001: OpenTelemetry (if adding logging, metrics, traces)
+- ADR-0002: LogTape logging (if adding any logging)
+- ADR-0003: Observability backends (if adding monitoring)
+- ADR-0004: SQLite storage (if adding persistence)
+- ADR-0007: Certificate-bound tokens (if touching JWT/peering)
+- ADR-0008: Cerbos authorization (if adding access control)
+
+Report:
+- Compliant: [list of ADRs and how we comply]
+- Non-compliant: [list of ADRs and what's wrong]
+- Recommendations: [changes needed or ADR amendments to propose]
+```
+
+**Example Prompt:**
+
+```
+Check ADR compliance for adding user activity logging to the auth service.
+
+I plan to use console.log for debugging and store logs in a JSON file.
+
+Check ADR-0001, ADR-0002, and ADR-0004 to see if this approach is compliant.
+```
+
+**Example Output:**
+
+```
+❌ Non-Compliant with ADR-0002 (Logging Library Selection)
+   Issue: Using console.log instead of LogTape
+   Required: Use LogTape with template literals
+   Fix: import { getLogger } from '@catalyst/telemetry'
+        const logger = getLogger(['auth', 'activity'])
+        logger.info`User ${userId} performed ${action}`
+
+❌ Non-Compliant with ADR-0004 (SQLite Storage)
+   Issue: Storing logs in JSON file instead of SQLite
+   Required: All persistent state must use SQLite
+   Fix: Create ActivityLogStore with SqliteStore implementation
+
+✅ Compliant with ADR-0001 if using @catalyst/telemetry
+
+Recommendation: Refactor to use LogTape + SQLite. No ADR changes needed.
+```
+
+---
+
+### 4. Verification Agent
+
+**Purpose:** Run the full verification chain after implementation.
+
+**When to Use:**
+
+- After completing implementation
+- Before committing changes
+- When CI fails and you need to reproduce locally
+
+**Objective:** Catch issues early with clear failure reporting.
+
+**Agent Type:** `Bash`
+
+**Prompt Template:**
+
+```
+Run the verification chain for changes in [PACKAGES].
+
+Execute in order, stopping on first failure:
+1. bun run lint
+2. bun run format:check
+3. tsc --noEmit
+4. bun test [package1] & bun test [package2] (parallel OK)
+5. Integration tests if cross-package changes
+6. Container tests if RPC/networking changes (needs CATALYST_CONTAINER_TESTS_ENABLED=true)
+
+For any failures, report:
+- Which step failed
+- Which package(s) affected
+- Specific file and line if available
+- The actual error message
+- Suggested fix if obvious
+
+Format failures as:
+❌ [step]: [package]
+   File: [path]
+   Error: [message]
+   Suggestion: [fix]
+```
+
+**Example Prompt:**
+
+```
+Run the verification chain for changes in @catalyst/auth and @catalyst/gateway.
+
+I modified the token signing logic and the gateway's token verification.
+Run lint, typecheck, and unit tests for both packages in parallel.
+```
+
+**Example Output:**
+
+```
+✅ Lint: passed
+✅ Format: passed
+✅ TypeScript: passed
+
+Running tests in parallel...
+
+❌ @catalyst/auth: 1 failure
+   File: packages/auth/tests/sign-token.test.ts:47
+   Error: Expected cnf claim to be present in token
+   Suggestion: Add cnf claim generation in signToken() per ADR-0007
+
+✅ @catalyst/gateway: all tests passed
+
+Summary: 1 failure in auth package. Fix cnf claim handling before commit.
+```
+
+---
+
+### 5. Cross-Package Impact Agent
+
+**Purpose:** Assess ripple effects when changing shared code.
+
+**When to Use:**
+
+- When modifying `@catalyst/config` schemas
+- When changing RPC interfaces
+- When updating shared types or utilities
+- When changing `@catalyst/sdk` public API
+
+**Objective:** Find all affected code before changes break downstream packages.
+
+**Agent Type:** `Explore`
+
+**Prompt Template:**
+
+```
+Analyze cross-package impact for changes to [FILE/SYMBOL].
+
+1. Find all imports of this file/symbol across packages
+2. Find all usages of affected types/functions
+3. Identify which packages would need updates
+4. Check if any tests would break
+5. Check if any docs reference this
+
+Report:
+- Direct dependents: [packages that import this]
+- Transitive dependents: [packages that depend on direct dependents]
+- Breaking changes: [what would break and where]
+- Required updates: [files that need modification]
+- Test coverage: [which tests exercise this code]
+```
+
+**Example Prompt:**
+
+```
+Analyze cross-package impact for changes to CatalystConfigSchema in @catalyst/config.
+
+I'm adding a new required field 'telemetryEndpoint' to the config schema.
+
+Find everywhere this schema is used and what would break.
+```
+
+**Example Output:**
+
+```
+Direct Dependents:
+- @catalyst/node (imports loadDefaultConfig)
+- @catalyst/auth (imports AuthConfigSchema)
+- @catalyst/orchestrator (imports OrchestratorConfigSchema)
+- @catalyst/cli (imports CatalystConfigSchema for validation)
+
+Breaking Changes:
+- packages/node/src/index.ts:23 - loadDefaultConfig() will fail without env var
+- packages/cli/src/commands/init.ts:45 - Config validation will reject existing configs
+- docker-compose/m0p2.yml - Missing CATALYST_TELEMETRY_ENDPOINT env var
+
+Required Updates:
+1. Add CATALYST_TELEMETRY_ENDPOINT to all docker-compose files
+2. Update CLI init command to prompt for telemetry endpoint
+3. Add telemetryEndpoint to example configs in docs/
+4. Update @catalyst/config README with new field
+
+Test Coverage:
+- packages/config/tests/schema.test.ts - Add test for new field
+- packages/node/tests/config.test.ts - Will fail, needs update
+```
+
+---
+
+### 6. Doc Sync Agent
+
+**Purpose:** Check if documentation needs updates after implementation.
+
+**When to Use:**
+
+- After completing implementation
+- Before finalizing a PR
+- When adding new features or changing behavior
+
+**Objective:** Keep documentation current with code changes.
+
+**Agent Type:** `Explore`
+
+**Prompt Template:**
+
+```
+Check if documentation needs updates after [CHANGES MADE].
+
+Review:
+1. Does CLAUDE.md need pattern updates?
+2. Do any ADRs need amendments?
+3. Does ARCHITECTURE.md need updates?
+4. Do package READMEs need updates?
+5. Are there inline code comments that are now stale?
+
+For each doc that needs updates:
+- What section needs changing?
+- What should be added/modified/removed?
+- Draft the specific changes
+
+Also check:
+- Did we establish a new pattern that should be in CLAUDE.md?
+- Did we deviate from an ADR that needs amendment?
+- Should we create a new ADR for this decision?
+```
+
+**Example Prompt:**
+
+```
+Check if documentation needs updates after adding certificate-bound token support.
+
+Changes made:
+- Added cnf claim to JWT generation
+- Added certificate thumbprint verification in token validation
+- Added new RPC endpoint: bindCertificate()
+
+Check SECURITY.md, CLAUDE.md, packages/auth/README.md, and ADR-0007.
+```
+
+---
+
+## Workflow Integration
+
+### Standard Task Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        PRE-WORK PHASE                           │
+│  (Run in parallel)                                              │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐          │
+│  │ Stack Scope  │  │Documentation │  │ADR Compliance│          │
+│  │    Agent     │  │    Agent     │  │    Agent     │          │
+│  └──────────────┘  └──────────────┘  └──────────────┘          │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                     IMPLEMENTATION PHASE                         │
+│  - Stay within stack scope                                       │
+│  - Follow documented patterns                                    │
+│  - Comply with ADRs                                             │
+│  - Use Cross-Package Impact Agent if touching shared code       │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                     VERIFICATION PHASE                           │
+│  (Sequential - stop on failure)                                 │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │ Verification Agent: lint → format → types → tests        │  │
+│  └──────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                      DOC SYNC PHASE                              │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │ Doc Sync Agent: Check for needed documentation updates    │  │
+│  └──────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Prompt Writing Best Practices
+
+**1. Be Specific About Scope**
+
+```
+❌ Bad:  "Check the docs"
+✅ Good: "Read SECURITY.md and ADR-0007, focusing on JWT claim requirements
+         for the token rotation feature I'm implementing"
+```
+
+**2. State Your Intent**
+
+```
+❌ Bad:  "What does the auth package do?"
+✅ Good: "I need to add a token rotation endpoint. What existing patterns
+         in @catalyst/auth should I follow for RPC endpoints?"
+```
+
+**3. Provide Context**
+
+```
+❌ Bad:  "Run the tests"
+✅ Good: "Run tests for @catalyst/auth after I modified signToken() to
+         include the cnf claim. Focus on token signing and verification tests."
+```
+
+**4. Request Actionable Output**
+
+```
+❌ Bad:  "Is this ADR compliant?"
+✅ Good: "Check ADR-0002 compliance for my logging approach. If non-compliant,
+         provide the specific code changes needed to fix it."
+```
+
+**5. Chain Agents Logically**
+
+```
+✅ Good workflow:
+   1. Stack Scope Agent → Know what's in scope
+   2. Documentation Agent → Understand patterns (informed by scope)
+   3. ADR Compliance Agent → Verify approach (informed by docs)
+   4. [Implementation]
+   5. Cross-Package Impact Agent → If I touched shared code
+   6. Verification Agent → Run checks
+   7. Doc Sync Agent → Update docs if needed
+```
+
+---
+
+## Example Scenarios
+
+### Scenario 1: Adding a New RPC Endpoint
+
+**Task:** Add `rotateKey()` RPC endpoint to auth service
+
+**Agent Sequence:**
+
+```
+1. Stack Scope Agent:
+   "What's the scope of my current PR? I want to add a key rotation endpoint."
+
+2. Documentation + ADR Agents (parallel):
+   - "Read SECURITY.md for key rotation requirements"
+   - "Check ADR-0007 for certificate-bound token implications on key rotation"
+
+3. [Implement the endpoint following patterns discovered]
+
+4. Verification Agent:
+   "Run verification for @catalyst/auth. I added rotateKey() RPC endpoint."
+
+5. Doc Sync Agent:
+   "Check if SECURITY.md or packages/auth/README.md need updates for the
+    new rotateKey() endpoint."
+```
+
+### Scenario 2: Modifying Shared Config Schema
+
+**Task:** Add `telemetry.samplingRate` to CatalystConfigSchema
+
+**Agent Sequence:**
+
+```
+1. Cross-Package Impact Agent:
+   "I'm adding telemetry.samplingRate to CatalystConfigSchema.
+    Find all packages that would be affected."
+
+2. ADR Compliance Agent:
+   "Check if adding telemetry config aligns with ADR-0001 OpenTelemetry strategy."
+
+3. [Implement changes across all affected packages]
+
+4. Verification Agent:
+   "Run verification for @catalyst/config, @catalyst/node, @catalyst/auth,
+    and @catalyst/orchestrator. I modified the shared config schema."
+
+5. Doc Sync Agent:
+   "Check if CLAUDE.md environment variables section needs the new
+    CATALYST_TELEMETRY_SAMPLING_RATE variable documented."
+```
+
+### Scenario 3: Investigating a Test Failure
+
+**Task:** CI failed on topology tests
+
+**Agent Sequence:**
+
+```
+1. Stack Scope Agent:
+   "What changes are in my current stack that might affect topology tests?"
+
+2. Verification Agent:
+   "Run topology tests locally with verbose output.
+    Focus on packages/orchestrator topology tests."
+
+3. Documentation Agent:
+   "Read ARCHITECTURE.md section on orchestrator topology and
+    BGP_PROTOCOL.md to understand expected behavior."
+
+4. [Fix the issue]
+
+5. Verification Agent:
+   "Re-run full verification chain to confirm the fix."
+```
+
+---
+
+## Maintaining This Document
+
+This document should evolve as we learn what works:
+
+1. **Add new agents** when recurring patterns emerge
+2. **Refine prompts** based on what produces best results
+3. **Add scenarios** for common task types
+4. **Remove/update** agents that aren't useful
+
+When updating, also check if CLAUDE.md's Subagent Strategy section needs corresponding updates.

--- a/packages/auth/tests/jwt.unit.test.ts
+++ b/packages/auth/tests/jwt.unit.test.ts
@@ -1,378 +1,374 @@
-import { describe, it, expect, beforeAll } from 'bun:test';
-import { generateKeyPair, type KeyPair, ALGORITHM } from '../src/keys.js';
+import { describe, it, expect, beforeAll } from 'bun:test'
+import { generateKeyPair, type KeyPair, ALGORITHM } from '../src/keys.js'
 import {
-    signToken,
-    verifyToken,
-    decodeToken,
-    type SignOptions,
-    type VerifyResult,
-} from '../src/jwt.js';
+  signToken,
+  verifyToken,
+  decodeToken,
+  type SignOptions,
+  type VerifyResult,
+} from '../src/jwt.js'
 
 /**
  * Helper to decode token and assert it's valid, returning typed payload/header
  */
 function expectDecoded(token: string) {
-    const decoded = decodeToken(token);
-    expect(decoded).not.toBeNull();
-    return decoded!;
+  const decoded = decodeToken(token)
+  expect(decoded).not.toBeNull()
+  return decoded!
 }
 
 /**
  * Helper to assert verification succeeded and return typed payload
  */
 function expectValid(result: VerifyResult) {
-    expect(result.valid).toBe(true);
-    return (result as { valid: true; payload: Record<string, unknown> }).payload;
+  expect(result.valid).toBe(true)
+  return (result as { valid: true; payload: Record<string, unknown> }).payload
 }
 
 /**
  * Helper to assert verification failed and return error
  */
 function expectInvalid(result: VerifyResult) {
-    expect(result.valid).toBe(false);
-    return (result as { valid: false; error: string }).error;
+  expect(result.valid).toBe(false)
+  return (result as { valid: false; error: string }).error
 }
 
 /**
  * Base64url encode (RFC 4648) - proper JWT encoding
  */
 function base64urlEncode(str: string): string {
-    return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
 }
 
 /**
  * Base64url decode (RFC 4648)
  */
 function base64urlDecode(str: string): string {
-    const padded = str + '='.repeat((4 - (str.length % 4)) % 4);
-    return atob(padded.replace(/-/g, '+').replace(/_/g, '/'));
+  const padded = str + '='.repeat((4 - (str.length % 4)) % 4)
+  return atob(padded.replace(/-/g, '+').replace(/_/g, '/'))
 }
 
 describe('jwt', () => {
-    let keyPair: KeyPair;
-    let otherKeyPair: KeyPair;
+  let keyPair: KeyPair
+  let otherKeyPair: KeyPair
 
-    beforeAll(async () => {
-        keyPair = await generateKeyPair();
-        otherKeyPair = await generateKeyPair();
-    });
+  beforeAll(async () => {
+    keyPair = await generateKeyPair()
+    otherKeyPair = await generateKeyPair()
+  })
 
-    describe('signToken', () => {
-        it('should sign a token with required options', async () => {
-            const token = await signToken(keyPair, { subject: 'user-123' });
+  describe('signToken', () => {
+    it('should sign a token with required options', async () => {
+      const token = await signToken(keyPair, { subject: 'user-123' })
 
-            expect(token).toBeString();
-            expect(token.split('.')).toHaveLength(3);
+      expect(token).toBeString()
+      expect(token.split('.')).toHaveLength(3)
 
-            const { header, payload } = expectDecoded(token);
-            expect(payload.sub).toBe('user-123');
-            expect(payload.iss).toBe('catalyst-auth');
-            expect(payload.iat).toBeNumber();
-            expect(payload.exp).toBeNumber();
-            expect(payload.jti).toBeString();
-            expect(header.kid).toBe(keyPair.kid);
-            expect(header.alg).toBe(ALGORITHM);
-        });
+      const { header, payload } = expectDecoded(token)
+      expect(payload.sub).toBe('user-123')
+      expect(payload.iss).toBe('catalyst-auth')
+      expect(payload.iat).toBeNumber()
+      expect(payload.exp).toBeNumber()
+      expect(payload.jti).toBeString()
+      expect(header.kid).toBe(keyPair.kid)
+      expect(header.alg).toBe(ALGORITHM)
+    })
 
-        it('should include audience when provided', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                audience: 'my-service',
-            });
+    it('should include audience when provided', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        audience: 'my-service',
+      })
 
-            const { payload } = expectDecoded(token);
-            expect(payload.aud).toBe('my-service');
-        });
+      const { payload } = expectDecoded(token)
+      expect(payload.aud).toBe('my-service')
+    })
 
-        it('should support array audience', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                audience: ['service-a', 'service-b'],
-            });
+    it('should support array audience', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        audience: ['service-a', 'service-b'],
+      })
 
-            const { payload } = expectDecoded(token);
-            expect(payload.aud).toEqual(['service-a', 'service-b']);
-        });
+      const { payload } = expectDecoded(token)
+      expect(payload.aud).toEqual(['service-a', 'service-b'])
+    })
 
-        it('should include custom claims', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                claims: {
-                    role: 'admin',
-                    permissions: ['read', 'write'],
-                },
-            });
+    it('should include custom claims', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        claims: {
+          role: 'admin',
+          permissions: ['read', 'write'],
+        },
+      })
 
-            const { payload } = expectDecoded(token);
-            expect(payload.role).toBe('admin');
-            expect(payload.permissions).toEqual(['read', 'write']);
-        });
+      const { payload } = expectDecoded(token)
+      expect(payload.role).toBe('admin')
+      expect(payload.permissions).toEqual(['read', 'write'])
+    })
 
-        it('should respect custom expiration', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                expiresIn: '5m',
-            });
+    it('should respect custom expiration', async () => {
+      const now = Date.now()
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        expiresAt: now + 5 * 60 * 1000,
+      })
 
-            const { payload } = expectDecoded(token);
-            const iat = payload.iat as number;
-            const exp = payload.exp as number;
-            expect(exp - iat).toBe(300); // 5 minutes
-        });
+      const { payload } = expectDecoded(token)
+      const exp = payload.exp as number
+      // exp is in seconds, need to allow for slight timing difference
+      // We check if it is roughly 5 minutes from now (within 2 seconds)
+      const expectedExp = Math.floor((now + 300000) / 1000)
+      expect(Math.abs(exp - expectedExp)).toBeLessThan(2)
+    })
 
-        it('should reject invalid options', async () => {
-            await expect(
-                signToken(keyPair, {} as SignOptions)
-            ).rejects.toThrow();
-        });
+    it('should reject invalid options', async () => {
+      await expect(signToken(keyPair, {} as SignOptions)).rejects.toThrow()
+    })
 
-        it('should generate unique jti for each token', async () => {
-            const token1 = await signToken(keyPair, { subject: 'user-123' });
-            const token2 = await signToken(keyPair, { subject: 'user-123' });
+    it('should generate unique jti for each token', async () => {
+      const token1 = await signToken(keyPair, { subject: 'user-123' })
+      const token2 = await signToken(keyPair, { subject: 'user-123' })
 
-            const { payload: p1 } = expectDecoded(token1);
-            const { payload: p2 } = expectDecoded(token2);
-            expect(p1.jti).not.toBe(p2.jti);
-        });
+      const { payload: p1 } = expectDecoded(token1)
+      const { payload: p2 } = expectDecoded(token2)
+      expect(p1.jti).not.toBe(p2.jti)
+    })
 
-        it('should reject expiration exceeding maximum lifetime', async () => {
-            await expect(
-                signToken(keyPair, {
-                    subject: 'user-123',
-                    expiresIn: '400d', // > 52 weeks max
-                })
-            ).rejects.toThrow('exceeds maximum allowed');
-        });
+    it('should reject expiration exceeding maximum lifetime', async () => {
+      await expect(
+        signToken(keyPair, {
+          subject: 'user-123',
+          expiresAt: Date.now() + 400 * 24 * 60 * 60 * 1000, // > 52 weeks max
+        })
+      ).rejects.toThrow('exceeds maximum allowed')
+    })
 
-        it('should reject invalid expiration format', async () => {
-            await expect(
-                signToken(keyPair, { subject: 'user-123', expiresIn: '100y' })
-            ).rejects.toThrow('Invalid expiration format');
+    it('should reject past expiration', async () => {
+      await expect(
+        signToken(keyPair, { subject: 'user-123', expiresAt: Date.now() - 1000 })
+      ).rejects.toThrow('must be in the future')
+    })
 
-            await expect(
-                signToken(keyPair, { subject: 'user-123', expiresIn: 'invalid' })
-            ).rejects.toThrow('Invalid expiration format');
-        });
+    it('should accept expiration at maximum lifetime', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        expiresAt: Date.now() + 364 * 24 * 60 * 60 * 1000,
+      })
+      expect(token).toBeString()
+    })
 
-        it('should accept expiration at maximum lifetime', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                expiresIn: '364d',
-            });
-            expect(token).toBeString();
-        });
+    it('should strip reserved claims from custom claims', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        claims: {
+          iss: 'evil-issuer',
+          sub: 'evil-subject',
+          exp: 9999999999,
+          iat: 0,
+          jti: 'evil-jti',
+          role: 'admin',
+        },
+      })
 
-        it('should strip reserved claims from custom claims', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                claims: {
-                    iss: 'evil-issuer',
-                    sub: 'evil-subject',
-                    exp: 9999999999,
-                    iat: 0,
-                    jti: 'evil-jti',
-                    role: 'admin',
-                },
-            });
+      const { payload } = expectDecoded(token)
+      expect(payload.iss).toBe('catalyst-auth')
+      expect(payload.sub).toBe('user-123')
+      expect(payload.jti).not.toBe('evil-jti')
+      expect(payload.role).toBe('admin')
+    })
+  })
 
-            const { payload } = expectDecoded(token);
-            expect(payload.iss).toBe('catalyst-auth');
-            expect(payload.sub).toBe('user-123');
-            expect(payload.jti).not.toBe('evil-jti');
-            expect(payload.role).toBe('admin');
-        });
-    });
+  describe('verifyToken', () => {
+    it('should verify a valid token', async () => {
+      const token = await signToken(keyPair, { subject: 'user-123' })
+      const result = await verifyToken(keyPair, token)
 
-    describe('verifyToken', () => {
-        it('should verify a valid token', async () => {
-            const token = await signToken(keyPair, { subject: 'user-123' });
-            const result = await verifyToken(keyPair, token);
+      const payload = expectValid(result)
+      expect(payload.sub).toBe('user-123')
+    })
 
-            const payload = expectValid(result);
-            expect(payload.sub).toBe('user-123');
-        });
+    it('should return payload with all claims', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        claims: { role: 'admin' },
+      })
 
-        it('should return payload with all claims', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                claims: { role: 'admin' },
-            });
+      const payload = expectValid(await verifyToken(keyPair, token))
+      expect(payload.sub).toBe('user-123')
+      expect(payload.role).toBe('admin')
+      expect(payload.iss).toBe('catalyst-auth')
+      expect(payload.jti).toBeString()
+    })
 
-            const payload = expectValid(await verifyToken(keyPair, token));
-            expect(payload.sub).toBe('user-123');
-            expect(payload.role).toBe('admin');
-            expect(payload.iss).toBe('catalyst-auth');
-            expect(payload.jti).toBeString();
-        });
+    it('should reject token signed with different key', async () => {
+      const token = await signToken(otherKeyPair, { subject: 'user-123' })
+      const result = await verifyToken(keyPair, token)
 
-        it('should reject token signed with different key', async () => {
-            const token = await signToken(otherKeyPair, { subject: 'user-123' });
-            const result = await verifyToken(keyPair, token);
+      const error = expectInvalid(result)
+      expect(error).toBe('Invalid token')
+    })
 
-            const error = expectInvalid(result);
-            expect(error).toBe('Invalid token');
-        });
+    it('should reject expired token', async () => {
+      // Create a token that's already expired by tampering with exp
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+      })
 
-        it('should reject expired token', async () => {
-            // Create a token that's already expired by tampering with exp
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                expiresIn: '1h',
-            });
+      // Tamper with exp to make it expired (set to past timestamp)
+      const parts = token.split('.')
+      const payload = JSON.parse(base64urlDecode(parts[1]))
+      payload.exp = Math.floor(Date.now() / 1000) - 3600 // 1 hour ago
+      parts[1] = base64urlEncode(JSON.stringify(payload))
+      const expiredToken = parts.join('.')
 
-            // Tamper with exp to make it expired (set to past timestamp)
-            const parts = token.split('.');
-            const payload = JSON.parse(base64urlDecode(parts[1]));
-            payload.exp = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
-            parts[1] = base64urlEncode(JSON.stringify(payload));
-            const expiredToken = parts.join('.');
+      // This will fail signature verification (tampered), not expiration
+      // But that's fine - the point is it rejects invalid tokens
+      const result = await verifyToken(keyPair, expiredToken)
+      expectInvalid(result)
+    })
 
-            // This will fail signature verification (tampered), not expiration
-            // But that's fine - the point is it rejects invalid tokens
-            const result = await verifyToken(keyPair, expiredToken);
-            expectInvalid(result);
-        });
+    it('should reject malformed token', async () => {
+      const error = expectInvalid(await verifyToken(keyPair, 'not-a-valid-token'))
+      expect(error).toBe('Invalid token')
+    })
 
-        it('should reject malformed token', async () => {
-            const error = expectInvalid(await verifyToken(keyPair, 'not-a-valid-token'));
-            expect(error).toBe('Invalid token');
-        });
+    it('should reject token with tampered payload', async () => {
+      const token = await signToken(keyPair, { subject: 'user-123' })
 
-        it('should reject token with tampered payload', async () => {
-            const token = await signToken(keyPair, { subject: 'user-123' });
+      const parts = token.split('.')
+      const payload = JSON.parse(base64urlDecode(parts[1]))
+      payload.sub = 'user-456'
+      parts[1] = base64urlEncode(JSON.stringify(payload))
+      const tamperedToken = parts.join('.')
 
-            const parts = token.split('.');
-            const payload = JSON.parse(base64urlDecode(parts[1]));
-            payload.sub = 'user-456';
-            parts[1] = base64urlEncode(JSON.stringify(payload));
-            const tamperedToken = parts.join('.');
+      expectInvalid(await verifyToken(keyPair, tamperedToken))
+    })
 
-            expectInvalid(await verifyToken(keyPair, tamperedToken));
-        });
+    it('should reject empty string token', async () => {
+      const error = expectInvalid(await verifyToken(keyPair, ''))
+      expect(error).toBe('Invalid token')
+    })
 
-        it('should reject empty string token', async () => {
-            const error = expectInvalid(await verifyToken(keyPair, ''));
-            expect(error).toBe('Invalid token');
-        });
+    describe('audience validation', () => {
+      it('should accept token with matching audience', async () => {
+        const token = await signToken(keyPair, {
+          subject: 'user-123',
+          audience: 'my-service',
+        })
 
-        describe('audience validation', () => {
-            it('should accept token with matching audience', async () => {
-                const token = await signToken(keyPair, {
-                    subject: 'user-123',
-                    audience: 'my-service',
-                });
+        const result = await verifyToken(keyPair, token, { audience: 'my-service' })
+        expectValid(result)
+      })
 
-                const result = await verifyToken(keyPair, token, { audience: 'my-service' });
-                expectValid(result);
-            });
+      it('should accept token when audience is in array', async () => {
+        const token = await signToken(keyPair, {
+          subject: 'user-123',
+          audience: ['service-a', 'service-b'],
+        })
 
-            it('should accept token when audience is in array', async () => {
-                const token = await signToken(keyPair, {
-                    subject: 'user-123',
-                    audience: ['service-a', 'service-b'],
-                });
+        const result = await verifyToken(keyPair, token, { audience: 'service-a' })
+        expectValid(result)
+      })
 
-                const result = await verifyToken(keyPair, token, { audience: 'service-a' });
-                expectValid(result);
-            });
+      it('should reject token with wrong audience', async () => {
+        const token = await signToken(keyPair, {
+          subject: 'user-123',
+          audience: 'service-a',
+        })
 
-            it('should reject token with wrong audience', async () => {
-                const token = await signToken(keyPair, {
-                    subject: 'user-123',
-                    audience: 'service-a',
-                });
+        const result = await verifyToken(keyPair, token, { audience: 'service-b' })
+        expectInvalid(result)
+      })
 
-                const result = await verifyToken(keyPair, token, { audience: 'service-b' });
-                expectInvalid(result);
-            });
+      it('should reject token without audience when audience required', async () => {
+        const token = await signToken(keyPair, { subject: 'user-123' })
 
-            it('should reject token without audience when audience required', async () => {
-                const token = await signToken(keyPair, { subject: 'user-123' });
+        const result = await verifyToken(keyPair, token, { audience: 'my-service' })
+        expectInvalid(result)
+      })
 
-                const result = await verifyToken(keyPair, token, { audience: 'my-service' });
-                expectInvalid(result);
-            });
+      it('should accept token with audience when not checking', async () => {
+        const token = await signToken(keyPair, {
+          subject: 'user-123',
+          audience: 'any-service',
+        })
 
-            it('should accept token with audience when not checking', async () => {
-                const token = await signToken(keyPair, {
-                    subject: 'user-123',
-                    audience: 'any-service',
-                });
+        expectValid(await verifyToken(keyPair, token))
+      })
+    })
+  })
 
-                expectValid(await verifyToken(keyPair, token));
-            });
-        });
-    });
+  describe('decodeToken', () => {
+    it('should decode a valid token without verification', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        claims: { role: 'admin' },
+      })
 
-    describe('decodeToken', () => {
-        it('should decode a valid token without verification', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                claims: { role: 'admin' },
-            });
+      const { header, payload } = expectDecoded(token)
+      expect(header.alg).toBe(ALGORITHM)
+      expect(header.kid).toBe(keyPair.kid)
+      expect(payload.sub).toBe('user-123')
+      expect(payload.role).toBe('admin')
+    })
 
-            const { header, payload } = expectDecoded(token);
-            expect(header.alg).toBe(ALGORITHM);
-            expect(header.kid).toBe(keyPair.kid);
-            expect(payload.sub).toBe('user-123');
-            expect(payload.role).toBe('admin');
-        });
+    it('should decode token signed with different key', async () => {
+      const token = await signToken(otherKeyPair, { subject: 'user-123' })
 
-        it('should decode token signed with different key', async () => {
-            const token = await signToken(otherKeyPair, { subject: 'user-123' });
+      const { header, payload } = expectDecoded(token)
+      expect(payload.sub).toBe('user-123')
+      expect(header.kid).toBe(otherKeyPair.kid)
+    })
 
-            const { header, payload } = expectDecoded(token);
-            expect(payload.sub).toBe('user-123');
-            expect(header.kid).toBe(otherKeyPair.kid);
-        });
+    it('should return null for invalid tokens', () => {
+      expect(decodeToken('not-a-valid-token')).toBeNull()
+      expect(decodeToken('')).toBeNull()
+      expect(decodeToken('invalid.base64.here!!!')).toBeNull()
+      expect(decodeToken('only.two')).toBeNull()
+      expect(decodeToken('one')).toBeNull()
+      expect(decodeToken('a.b.c.d')).toBeNull()
+    })
+  })
 
-        it('should return null for invalid tokens', () => {
-            expect(decodeToken('not-a-valid-token')).toBeNull();
-            expect(decodeToken('')).toBeNull();
-            expect(decodeToken('invalid.base64.here!!!')).toBeNull();
-            expect(decodeToken('only.two')).toBeNull();
-            expect(decodeToken('one')).toBeNull();
-            expect(decodeToken('a.b.c.d')).toBeNull();
-        });
-    });
+  describe('edge cases', () => {
+    it('should handle unicode in claims', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        claims: { name: '日本語テスト', emoji: '🔐🎉' },
+      })
 
-    describe('edge cases', () => {
-        it('should handle unicode in claims', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                claims: { name: '日本語テスト', emoji: '🔐🎉' },
-            });
+      const payload = expectValid(await verifyToken(keyPair, token))
+      expect(payload.name).toBe('日本語テスト')
+      expect(payload.emoji).toBe('🔐🎉')
+    })
 
-            const payload = expectValid(await verifyToken(keyPair, token));
-            expect(payload.name).toBe('日本語テスト');
-            expect(payload.emoji).toBe('🔐🎉');
-        });
+    it('should handle nested objects in claims', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        claims: { metadata: { nested: { deep: 'value' } } },
+      })
 
-        it('should handle nested objects in claims', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                claims: { metadata: { nested: { deep: 'value' } } },
-            });
+      const payload = expectValid(await verifyToken(keyPair, token))
+      expect(payload.metadata).toEqual({ nested: { deep: 'value' } })
+    })
 
-            const payload = expectValid(await verifyToken(keyPair, token));
-            expect(payload.metadata).toEqual({ nested: { deep: 'value' } });
-        });
+    it('should handle empty claims object', async () => {
+      const token = await signToken(keyPair, {
+        subject: 'user-123',
+        claims: {},
+      })
 
-        it('should handle empty claims object', async () => {
-            const token = await signToken(keyPair, {
-                subject: 'user-123',
-                claims: {},
-            });
+      expectValid(await verifyToken(keyPair, token))
+    })
 
-            expectValid(await verifyToken(keyPair, token));
-        });
+    it('should handle very long subject', async () => {
+      const longSubject = 'x'.repeat(1000)
+      const token = await signToken(keyPair, { subject: longSubject })
 
-        it('should handle very long subject', async () => {
-            const longSubject = 'x'.repeat(1000);
-            const token = await signToken(keyPair, { subject: longSubject });
-
-            const payload = expectValid(await verifyToken(keyPair, token));
-            expect(payload.sub).toBe(longSubject);
-        });
-    });
-});
+      const payload = expectValid(await verifyToken(keyPair, token))
+      expect(payload.sub).toBe(longSubject)
+    })
+  })
+})

--- a/packages/authorization/src/jwt/index.ts
+++ b/packages/authorization/src/jwt/index.ts
@@ -35,7 +35,8 @@ export interface TokenRecord {
 export interface MintOptions {
   subject: string
   audience?: string | string[]
-  expiresIn?: string
+  /** Expiration time in milliseconds (unix timestamp * 1000) */
+  expiresAt?: number
   claims?: Record<string, unknown>
   /** Roles assigned to the token (mandatory) */
   roles: Role[]

--- a/packages/authorization/src/jwt/local/index.ts
+++ b/packages/authorization/src/jwt/local/index.ts
@@ -35,7 +35,7 @@ export class LocalTokenManager implements TokenManager {
     const token = await this.keyManager.sign({
       subject: options.subject,
       audience: options.audience,
-      expiresIn: options.expiresIn,
+      expiresAt: options.expiresAt,
       claims,
     })
 

--- a/packages/authorization/src/key-manager/index.ts
+++ b/packages/authorization/src/key-manager/index.ts
@@ -4,78 +4,79 @@ import type { JSONWebKeySet } from 'jose'
  * Options for signing a JWT
  */
 export interface SignOptions {
-    subject: string
-    audience?: string | string[]
-    expiresIn?: string // e.g., '1h', '7d', '30m'
-    claims?: Record<string, unknown>
+  subject: string
+  audience?: string | string[]
+  /** Expiration time in milliseconds (unix timestamp * 1000) */
+  expiresAt?: number
+  claims?: Record<string, unknown>
 }
 
 /**
  * Options for verifying a JWT
  */
 export interface VerifyOptions {
-    audience?: string | string[]
+  audience?: string | string[]
 }
 
 /**
  * Result of token verification
  */
 export type VerifyResult =
-    | { valid: true; payload: Record<string, unknown> }
-    | { valid: false; error: string }
+  | { valid: true; payload: Record<string, unknown> }
+  | { valid: false; error: string }
 
 /**
  * Options for key rotation
  */
 export interface RotateOptions {
-    immediate?: boolean
-    gracePeriodMs?: number
+  immediate?: boolean
+  gracePeriodMs?: number
 }
 
 /**
  * Result of a key rotation operation
  */
 export interface RotationResult {
-    previousKeyId: string
-    newKeyId: string
-    gracePeriodEndsAt?: Date
+  previousKeyId: string
+  newKeyId: string
+  gracePeriodEndsAt?: Date
 }
 
 /**
  * Core KeyManager interface for all key management operations.
  */
 export interface IKeyManager {
-    /** Sign a JWT with the current key */
-    sign(options: SignOptions): Promise<string>
+  /** Sign a JWT with the current key */
+  sign(options: SignOptions): Promise<string>
 
-    /** Verify a JWT against managed keys */
-    verify(token: string, options?: VerifyOptions): Promise<VerifyResult>
+  /** Verify a JWT against managed keys */
+  verify(token: string, options?: VerifyOptions): Promise<VerifyResult>
 
-    /** Get the JSON Web Key Set containing all valid public keys */
-    getJwks(): Promise<JSONWebKeySet>
+  /** Get the JSON Web Key Set containing all valid public keys */
+  getJwks(): Promise<JSONWebKeySet>
 
-    /** Get the key ID of the current signing key */
-    getCurrentKeyId(): Promise<string>
+  /** Get the key ID of the current signing key */
+  getCurrentKeyId(): Promise<string>
 
-    /** Rotate to a new signing key */
-    rotate(options?: RotateOptions): Promise<RotationResult>
+  /** Rotate to a new signing key */
+  rotate(options?: RotateOptions): Promise<RotationResult>
 
-    /** Initialize the key manager */
-    initialize(): Promise<void>
+  /** Initialize the key manager */
+  initialize(): Promise<void>
 
-    /** Shutdown the key manager */
-    shutdown(): Promise<void>
+  /** Shutdown the key manager */
+  shutdown(): Promise<void>
 
-    /** Check if the key manager has been initialized */
-    isInitialized(): boolean
+  /** Check if the key manager has been initialized */
+  isInitialized(): boolean
 }
 
 /**
  * Interface for persisting key material.
  */
 export interface IKeyStore {
-    /** Save all keys as a JWKS */
-    saveKeys(jwks: JSONWebKeySet): Promise<void>
-    /** Load keys as a JWKS */
-    loadKeys(): Promise<JSONWebKeySet | null>
+  /** Save all keys as a JWKS */
+  saveKeys(jwks: JSONWebKeySet): Promise<void>
+  /** Load keys as a JWKS */
+  loadKeys(): Promise<JSONWebKeySet | null>
 }

--- a/packages/authorization/src/key-manager/persistent.ts
+++ b/packages/authorization/src/key-manager/persistent.ts
@@ -125,7 +125,7 @@ export class PersistentLocalKeyManager implements IKeyManager {
       .setSubject(options.subject)
       .setIssuedAt()
       .setJti(crypto.randomUUID())
-      .setExpirationTime(options.expiresIn ?? '1h')
+      .setExpirationTime(Math.floor((options.expiresAt ?? Date.now() + 3600000) / 1000))
       .setAudience(options.audience ?? [])
 
     return builder.sign(this.currentKey.privateKey)

--- a/packages/authorization/tests/jwt/local.test.ts
+++ b/packages/authorization/tests/jwt/local.test.ts
@@ -7,7 +7,11 @@ import { type TokenStore } from '../../src/jwt/index.js'
 
 describe('LocalTokenManager', () => {
   const mockKeyManager: IKeyManager = {
-    sign: async (options: { subject: string; claims?: Record<string, unknown> }) => {
+    sign: async (options: {
+      subject: string
+      claims?: Record<string, unknown>
+      expiresAt?: number
+    }) => {
       // Create a dummy JWT for testing
       const payload = {
         sub: options.subject,
@@ -24,6 +28,8 @@ describe('LocalTokenManager', () => {
     rotate: async () => ({ previousKeyId: '', newKeyId: '' }),
     getCurrentKeyId: async () => 'test-kid',
     shutdown: async () => {},
+    initialize: async () => {},
+    isInitialized: () => true,
   }
 
   const mockStore: TokenStore = {


### PR DESCRIPTION
### TL;DR

Added Architecture Decision Records (ADRs) documentation and subagent strategy for AI-assisted development, while modernizing JWT token handling to use millisecond timestamps.

### What changed?

- Added comprehensive `CLAUDE_AGENTS.md` document defining subagent strategy for AI-assisted development
- Updated `CLAUDE.md` with ADR information and subagent strategy overview
- Refactored JWT token handling to use millisecond-based timestamps:
  - Changed `expiresIn` string parameter to `expiresAt` timestamp in milliseconds
  - Updated all related interfaces and implementations in auth packages
  - Removed duration string parsing in favor of explicit timestamps
  - Modified tests to use the new timestamp-based approach

### How to test?

1. Review the new `CLAUDE_AGENTS.md` documentation for completeness
2. Verify JWT token functionality:
   ```
   cd packages/auth
   bun test jwt.unit.test.ts
   cd ../authorization
   bun test jwt/local.test.ts
   ```
3. Test login functionality to ensure tokens are generated correctly:
   ```
   bun run dev
   # Use the CLI to login and verify token expiration
   ```

### Why make this change?

- **Documentation improvements**: The new subagent strategy provides a structured approach for AI-assisted development, ensuring consistent patterns and documentation maintenance.
- **JWT modernization**: Moving from string-based durations to explicit timestamps:
  - Eliminates parsing complexity and potential errors
  - Provides more precise control over token expiration
  - Aligns with standard timestamp handling in the rest of the codebase
  - Makes token rotation and expiration logic more straightforward