### PR TITLE
docs: clarify Graphite workflow and fix markdown code fences

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -124,6 +124,18 @@ Claude: [Direct answer without workflow orchestration]
         Access tokens are short-lived tokens used for API requests...
 ```
 
+## Model Strategy
+
+Agents and workflows use different models based on task complexity:
+
+| Model      | Used For                                                                         | Rationale                                                 |
+| ---------- | -------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| **Haiku**  | verification, stack-scope                                                        | Fast, cheap — just running commands and parsing           |
+| **Sonnet** | orchestrator, pre-work, documentation, adr-compliance, doc-sync, pr-fix, cleanup | Good balance of speed and capability                      |
+| **Opus**   | cross-package-impact, architecture, migration, new-feature                       | Complex reasoning, trade-off analysis, multi-file changes |
+
+**Cost optimization:** Simple tasks (git commands, running tests) use Haiku. Most workflows use Sonnet. Only tasks requiring deep reasoning (architecture decisions, cross-package migrations) use Opus.
+
 ## Related Documentation
 
 - `../CLAUDE.md` - Main development guide and coding patterns

--- a/.claude/agents/adr-compliance.md
+++ b/.claude/agents/adr-compliance.md
@@ -1,3 +1,8 @@
+---
+name: ADR Compliance
+description: Check Architecture Decision Record compliance
+---
+
 # ADR Compliance Agent
 
 ## Description
@@ -68,25 +73,22 @@ ADR Compliance Check: User Activity Logging
    import { getLogger } from '@catalyst/telemetry'
    const logger = getLogger(['auth', 'activity'])
    logger.info`User ${userId} performed ${action}`
-````
+   ```
 
 ❌ Non-Compliant: ADR-0004 (SQLite Storage Backend)
-Issue: Storing logs in JSON file instead of SQLite
-Required: All persistent state must use SQLite via bun:sqlite
-Fix: Create ActivityLogStore implementing the Store interface
-with SqliteStore backend
+   Issue: Storing logs in JSON file instead of SQLite
+   Required: All persistent state must use SQLite via bun:sqlite
+   Fix: Create ActivityLogStore implementing the Store interface
+   with SqliteStore backend
 
 ✅ Compliant: ADR-0001 (OpenTelemetry)
-Using @catalyst/telemetry satisfies OTEL requirements
+   Using @catalyst/telemetry satisfies OTEL requirements
 
 N/A: ADR-0007 (Certificate-Bound Tokens)
-Activity logging doesn't involve JWT tokens
+   Activity logging doesn't involve JWT tokens
 
 N/A: ADR-0008 (Permission Policy Schema)
-Activity logging doesn't require authorization checks
+   Activity logging doesn't require authorization checks
 
 Recommendation: Refactor to use LogTape + SQLite. No ADR amendments needed.
-
-```
-
-```
+````

--- a/.claude/agents/cross-package-impact.md
+++ b/.claude/agents/cross-package-impact.md
@@ -1,3 +1,8 @@
+---
+name: Cross-Package Impact
+description: Assess ripple effects of shared code changes
+---
+
 # Cross-Package Impact Agent
 
 ## Description

--- a/.claude/agents/doc-sync.md
+++ b/.claude/agents/doc-sync.md
@@ -1,3 +1,8 @@
+---
+name: Doc Sync
+description: Check if documentation needs updates
+---
+
 # Doc Sync Agent
 
 ## Description
@@ -77,7 +82,7 @@ Changes made:
 
 **Expected Output:**
 
-```
+````
 Documentation Sync Check
 ========================
 
@@ -90,32 +95,27 @@ Updates Required:
 
 1. CLAUDE.md - JWT Operations section
    Current:
-```
-
-// Reserved claims (iss, sub, aud, exp, nbf, iat, jti) cannot be overridden
-
-```
-Add:
-```
-
-// Certificate-bound tokens include cnf claim with x5t#S256 thumbprint
-// See ADR-0007 for certificate binding requirements
-
-````
+   ```
+   // Reserved claims (iss, sub, aud, exp, nbf, iat, jti) cannot be overridden
+   ```
+   Add:
+   ```
+   // Certificate-bound tokens include cnf claim with x5t#S256 thumbprint
+   // See ADR-0007 for certificate binding requirements
+   ```
 
 2. packages/auth/README.md - API section
-Add new endpoint documentation:
-```markdown
-### bindCertificate(request)
-Binds a client certificate to an existing token for mTLS verification.
+   Add new endpoint documentation:
+   ```markdown
+   ### bindCertificate(request)
+   Binds a client certificate to an existing token for mTLS verification.
 
-Request: { token: string, certificatePem: string }
-Response: { success: true, boundToken: string } | { success: false, error: string }
-````
+   Request: { token: string, certificatePem: string }
+   Response: { success: true, boundToken: string } | { success: false, error: string }
+   ```
 
 3. SECURITY.md - Token Security section
    Add paragraph about certificate binding:
-
    ```markdown
    ## Certificate-Bound Tokens
 
@@ -130,18 +130,13 @@ ADR Status:
 No amendment needed
 
 No Changes Needed:
-
 - ARCHITECTURE.md (no structural changes)
 - CLAUDE_AGENTS.md (agents still applicable)
 - BGP_PROTOCOL.md (peering protocol unchanged)
 
 New Pattern for CLAUDE.md:
 Consider adding to AI Guidelines:
-
 ```
 13. **Certificate-bound tokens** - Include cnf claim with x5t#S256 for peering tokens per ADR-0007
 ```
-
-```
-
-```
+````

--- a/.claude/agents/documentation.md
+++ b/.claude/agents/documentation.md
@@ -1,3 +1,8 @@
+---
+name: Documentation
+description: Documentation synthesis and retrieval
+---
+
 # Documentation Agent
 
 ## Description

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -1,3 +1,8 @@
+---
+name: orchestrator
+description: Main entry point
+---
+
 # Orbi - Catalyst Development Orchestrator
 
 ## Description

--- a/.claude/agents/pre-work.md
+++ b/.claude/agents/pre-work.md
@@ -1,3 +1,8 @@
+---
+name: Pre-Work
+description: Run full pre-work phase
+---
+
 # Pre-Work Agent (Composite)
 
 ## Description

--- a/.claude/agents/stack-scope.md
+++ b/.claude/agents/stack-scope.md
@@ -1,3 +1,8 @@
+---
+name: Stack Scope
+description: Understand stack boundaries
+---
+
 # Stack Scope Agent
 
 ## Description

--- a/.claude/agents/verification.md
+++ b/.claude/agents/verification.md
@@ -1,3 +1,8 @@
+---
+name: Verification
+description: Run verification chain
+---
+
 # Verification Agent
 
 ## Description

--- a/.claude/agents/workflows/architecture.md
+++ b/.claude/agents/workflows/architecture.md
@@ -1,3 +1,8 @@
+---
+name: Architecture Workflow
+description: Workflow for design decisions
+---
+
 # Architecture Workflow
 
 ## Description

--- a/.claude/agents/workflows/cleanup.md
+++ b/.claude/agents/workflows/cleanup.md
@@ -1,3 +1,8 @@
+---
+name: Cleanup Workflow
+description: Workflow for removing dead code safely
+---
+
 # Cleanup Workflow
 
 ## Description

--- a/.claude/agents/workflows/documentation.md
+++ b/.claude/agents/workflows/documentation.md
@@ -1,3 +1,8 @@
+---
+name: Documentation Workflow
+description: Workflow for documentation updates
+---
+
 # Documentation Workflow
 
 ## Description
@@ -109,17 +114,17 @@ For README sections:
 ```typescript
 // Example code
 ```
-````
 
 ### Configuration
 
 | Option | Type | Default | Description |
 | ------ | ---- | ------- | ----------- |
 | [opt]  | [t]  | [def]   | [desc]      |
-
-```
+````
 
 For ADR updates:
+
+```
 [Draft following ADR template]
 ```
 
@@ -210,7 +215,7 @@ The auth service supports seamless key rotation with zero-downtime.
 
 ### Grace Period
 [explanation of overlap]
-````
+```
 
 2. Add to SECURITY.md:
 
@@ -235,18 +240,16 @@ The auth service supports seamless key rotation with zero-downtime.
 ```
 
 Want me to apply these documentation improvements?
-
-```
+````
 
 ## Documentation Types Reference
 
-| Type | Location | When to Use |
-|------|----------|-------------|
-| JSDoc | In code | Function/class documentation |
-| README | packages/*/README.md | Package overview and usage |
-| Architecture | ARCHITECTURE.md | System design |
-| Security | SECURITY.md | Security-related docs |
-| ADR | docs/adr/*.md | Decision records |
-| CLAUDE.md | CLAUDE.md | AI assistant patterns |
-| Inline | Code comments | Complex logic explanation |
-```
+| Type         | Location              | When to Use                  |
+| ------------ | --------------------- | ---------------------------- |
+| JSDoc        | In code               | Function/class documentation |
+| README       | packages/\*/README.md | Package overview and usage   |
+| Architecture | ARCHITECTURE.md       | System design                |
+| Security     | SECURITY.md           | Security-related docs        |
+| ADR          | docs/adr/\*.md        | Decision records             |
+| CLAUDE.md    | CLAUDE.md             | AI assistant patterns        |
+| Inline       | Code comments         | Complex logic explanation    |

--- a/.claude/agents/workflows/exploration.md
+++ b/.claude/agents/workflows/exploration.md
@@ -1,3 +1,8 @@
+---
+name: Exploration Workflow
+description: Read-only workflow for understanding code
+---
+
 # Exploration Workflow
 
 ## Description
@@ -192,7 +197,7 @@ export async function verifyToken(
 ): Promise<VerifyResult> {
   // ... [shows relevant code]
 }
-````
+```
 
 Patterns Used:
 
@@ -211,13 +216,11 @@ Open Questions:
 - Certificate binding only checked if cnf claim present
 
 Want me to dive deeper into any part of this?
-
-```
+````
 
 ## Output Format
 
 ```
-
 🔍 Exploration: [Topic]
 ═══════════════════════════════════════
 
@@ -228,15 +231,12 @@ Code Analysis:
 [What code does]
 
 Key Files:
-
 - [file]: [purpose]
 
 Patterns:
-
 - [patterns observed]
 
 Insights:
-
 - [key learnings]
 
 Questions Answered:
@@ -245,7 +245,4 @@ Questions Answered:
 
 Remaining Questions:
 ❓ [anything still unclear]
-
-```
-
 ```

--- a/.claude/agents/workflows/migration.md
+++ b/.claude/agents/workflows/migration.md
@@ -1,3 +1,8 @@
+---
+name: Migration Workflow
+description: Workflow for code migrations
+---
+
 # Migration Workflow
 
 ## Description

--- a/.claude/agents/workflows/new-feature.md
+++ b/.claude/agents/workflows/new-feature.md
@@ -1,3 +1,8 @@
+---
+name: New Feature Workflow
+description: Full workflow for new functionality
+---
+
 # New Feature Workflow
 
 ## Description

--- a/.claude/agents/workflows/pr-fix.md
+++ b/.claude/agents/workflows/pr-fix.md
@@ -1,3 +1,8 @@
+---
+name: PR Fix Workflow
+description: Streamlined workflow for PR comments
+---
+
 # PR Fix Workflow
 
 ## Description

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://claude.ai/schemas/claude-code-settings.json",
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "projectName": "catalyst-node",
   "description": "Distributed control and data plane system for secure service peering",
   "orchestrator": {
@@ -18,7 +18,8 @@
       "workflow": ".claude/agents/workflows/pr-fix.md",
       "triggers": ["PR comment", "fix feedback", "reviewer asked", "address comment", "PR review"],
       "preWork": ["stack-scope"],
-      "verification": "minimal"
+      "verification": "minimal",
+      "model": "sonnet"
     },
     {
       "id": "new-feature",
@@ -28,7 +29,8 @@
       "workflow": ".claude/agents/workflows/new-feature.md",
       "triggers": ["add", "implement", "create new", "build", "new feature"],
       "preWork": ["stack-scope", "documentation", "adr-compliance"],
-      "verification": "full"
+      "verification": "full",
+      "model": "opus"
     },
     {
       "id": "migration",
@@ -38,7 +40,8 @@
       "workflow": ".claude/agents/workflows/migration.md",
       "triggers": ["migrate", "refactor", "move", "rename across", "update pattern"],
       "preWork": ["cross-package-impact", "adr-compliance"],
-      "verification": "full"
+      "verification": "full",
+      "model": "opus"
     },
     {
       "id": "exploration",
@@ -48,7 +51,9 @@
       "workflow": ".claude/agents/workflows/exploration.md",
       "triggers": ["understand", "investigate", "how does", "find", "research", "explain"],
       "preWork": [],
-      "verification": "none"
+      "verification": "none",
+      "model": "sonnet",
+      "modelNote": "Use opus for deep architectural exploration"
     },
     {
       "id": "architecture",
@@ -58,7 +63,8 @@
       "workflow": ".claude/agents/workflows/architecture.md",
       "triggers": ["design", "should we", "trade-offs", "approach for", "RFC", "decide"],
       "preWork": ["documentation", "adr-compliance"],
-      "verification": "none"
+      "verification": "none",
+      "model": "opus"
     },
     {
       "id": "documentation",
@@ -68,7 +74,8 @@
       "workflow": ".claude/agents/workflows/documentation.md",
       "triggers": ["document", "clarify docs", "update readme", "explain in docs"],
       "preWork": ["doc-sync"],
-      "verification": "minimal"
+      "verification": "minimal",
+      "model": "sonnet"
     },
     {
       "id": "cleanup",
@@ -78,7 +85,8 @@
       "workflow": ".claude/agents/workflows/cleanup.md",
       "triggers": ["remove", "delete unused", "dead code", "simplify", "cruft", "clean up"],
       "preWork": ["cross-package-impact"],
-      "verification": "full"
+      "verification": "full",
+      "model": "sonnet"
     }
   ],
   "agents": {
@@ -88,49 +96,57 @@
         "name": "orchestrator",
         "description": "Main entry point - identifies task type and guides workflow",
         "type": "Explore",
-        "file": "orchestrator.md"
+        "file": "orchestrator.md",
+        "model": "sonnet"
       },
       {
         "name": "pre-work",
         "description": "Run full pre-work phase (stack scope + docs + ADR compliance)",
         "type": "Explore",
-        "file": "pre-work.md"
+        "file": "pre-work.md",
+        "model": "sonnet"
       },
       {
         "name": "stack-scope",
         "description": "Understand current Graphite stack boundaries",
         "type": "Explore",
-        "file": "stack-scope.md"
+        "file": "stack-scope.md",
+        "model": "haiku"
       },
       {
         "name": "documentation",
         "description": "Read and synthesize relevant documentation",
         "type": "Explore",
-        "file": "documentation.md"
+        "file": "documentation.md",
+        "model": "sonnet"
       },
       {
         "name": "adr-compliance",
         "description": "Check Architecture Decision Record compliance",
         "type": "Explore",
-        "file": "adr-compliance.md"
+        "file": "adr-compliance.md",
+        "model": "sonnet"
       },
       {
         "name": "verification",
         "description": "Run lint, format, typecheck, and tests",
         "type": "Bash",
-        "file": "verification.md"
+        "file": "verification.md",
+        "model": "haiku"
       },
       {
         "name": "cross-package-impact",
         "description": "Assess ripple effects of shared code changes",
         "type": "Explore",
-        "file": "cross-package-impact.md"
+        "file": "cross-package-impact.md",
+        "model": "opus"
       },
       {
         "name": "doc-sync",
         "description": "Check if documentation needs updates",
         "type": "Explore",
-        "file": "doc-sync.md"
+        "file": "doc-sync.md",
+        "model": "sonnet"
       }
     ]
   },


### PR DESCRIPTION
# Add Model Strategy and Agent Metadata

Added a Model Strategy section to the Claude README that documents which Claude models are used for different agent tasks:
- Haiku: For verification and stack-scope (fast, cheap tasks)
- Sonnet: For most workflows (orchestrator, documentation, etc.)
- Opus: For complex reasoning tasks (architecture, migrations, etc.)

Added YAML frontmatter to all agent files with standardized metadata:
- name: Human-readable agent name
- description: Brief description of agent purpose

Updated settings.json with model specifications for each agent and workflow, and fixed the schema URL to use the standard schemastore.org location.

Fixed markdown formatting issues in several agent files to ensure proper code fence nesting and consistent documentation style.