### PR TITLE
docs: update Graphite workflow to always submit after create

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -4,29 +4,43 @@ This directory contains Claude Code agent definitions, workflows, and configurat
 
 ## Quick Start - Meet Orbi
 
-**Orbi** is your development orchestrator. Invoke it when you want guided workflow execution with subagents:
+**Orbi** is your development orchestrator. Invoke it when you want guided workflow execution with subagents.
+
+### How to Invoke Orbi
+
+**Option 1: Slash Command (Recommended for explicit invocation)**
 
 ```
-Orbi I need to fix a PR comment about error handling
-orbi add a token refresh endpoint
-Orbi how does the peering handshake work?
+/orbi fix PR comment about error handling
+/orbi add a token refresh endpoint
+/orbi how does the peering handshake work?
+/orbi            # Show task type menu
 ```
+
+**Option 2: Natural Language Trigger**
+
+```
+Orbi fix PR comment about error handling
+orbi add a token refresh endpoint
+```
+
+The slash command (`/orbi`) is recommended when you want explicit, intentional orchestrator invocation. The natural language trigger works but may be less clear.
 
 **When to use Orbi vs normal conversation:**
 
-- `Orbi fix the PR comment` → Guided workflow with agents, verification, doc sync
+- `/orbi fix the PR comment` → Guided workflow with agents, verification, doc sync
 - `what does this error mean?` → Quick answer, no workflow
 
 ## Task Types (via Orbi)
 
 ```
-orbi 🔧 PR Fix: reviewer says token validation should be more specific
-orbi ✨ New Feature: add token refresh endpoint
-orbi 🔄 Migration: move from InMemoryStore to SqliteStore
-orbi 🔍 Exploration: how does the peering handshake work?
-orbi 🏗️ Architecture: should we use Cerbos or Cedar?
-orbi 📝 Documentation: the rotation flow is confusing
-orbi 🧹 Cleanup: remove unused InMemoryCache class
+/orbi 🔧 PR Fix: reviewer says token validation should be more specific
+/orbi ✨ New Feature: add token refresh endpoint
+/orbi 🔄 Migration: move from InMemoryStore to SqliteStore
+/orbi 🔍 Exploration: how does the peering handshake work?
+/orbi 🏗️ Architecture: should we use Cerbos or Cedar?
+/orbi 📝 Documentation: the rotation flow is confusing
+/orbi 🧹 Cleanup: remove unused InMemoryCache class
 ```
 
 ## Task Types
@@ -81,7 +95,7 @@ orbi 🧹 Cleanup: remove unused InMemoryCache class
 ### PR Fix
 
 ```
-User: orbi fix a PR comment - reviewer says "error message should be more specific"
+User: /orbi fix a PR comment - reviewer says "error message should be more specific"
 
 Orbi: 🔧 PR Fix Mode
       Which file has this error? Let me check your stack scope...
@@ -95,7 +109,7 @@ Orbi: 🔧 PR Fix Mode
 ### New Feature
 
 ```
-User: Orbi add a token refresh endpoint
+User: /orbi add a token refresh endpoint
 
 Orbi: ✨ New Feature Mode
       Let me ask a few questions and run pre-work...
@@ -107,7 +121,7 @@ Orbi: ✨ New Feature Mode
 ### Exploration
 
 ```
-User: orbi how does the BGP peering handshake work?
+User: /orbi how does the BGP peering handshake work?
 
 Orbi: 🔍 Exploration Mode
       Let me trace through the code...

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -9,6 +9,8 @@ description: Main entry point
 
 Main entry point for all development tasks. Identifies task type, asks clarifying questions, and guides you through the appropriate workflow with the right agents.
 
+Always trigger this agent when a user asks "Orbi" to do a task or help out with a task. If a user asks Orbi a question, use the various sub-agent specialties to answer the question.
+
 ## How to Invoke
 
 ```
@@ -27,89 +29,1378 @@ orbi should we use Redis or SQLite?
 
 Use "Orbi" when you want guided workflow execution with subagents. For general conversation or quick questions, just talk normally without invoking Orbi.
 
-## Task Types
+---
 
-| Type              | Trigger Phrases                                                   | Workflow                                  |
-| ----------------- | ----------------------------------------------------------------- | ----------------------------------------- |
-| **PR Fix**        | "PR comment", "fix feedback", "reviewer asked", "address comment" | Quick, focused fix within stack scope     |
-| **New Feature**   | "add", "implement", "create new", "build"                         | Full pre-work → implement → verify → docs |
-| **Migration**     | "migrate", "refactor", "move", "rename across", "update pattern"  | Impact analysis → phased implementation   |
-| **Exploration**   | "understand", "investigate", "how does", "find", "research"       | Read-only, no constraints                 |
-| **Architecture**  | "design", "should we", "trade-offs", "approach for", "RFC"        | ADR-focused, document decisions           |
-| **Documentation** | "document", "clarify docs", "update readme", "explain"            | Doc-focused, minimal code                 |
-| **Cleanup**       | "remove", "delete unused", "dead code", "simplify", "cruft"       | Safe deletion verification                |
+## Orchestration Protocol
 
-## Orchestrator Prompt
+When invoked with "Orbi [task]", follow these steps EXACTLY:
+
+### STEP 1: Classify Task Type
+
+Analyze the user's request and classify using this decision tree:
+
+#### Primary Keyword Matching (High Confidence)
+
+- Contains "PR comment", "reviewer", "fix feedback", "address comment" → **PR Fix**
+- Contains "should we", "trade-offs", "RFC", "design decision" → **Architecture**
+- Contains "how does", "understand", "investigate", "research" → **Exploration**
+- Contains "document", "update docs", "clarify docs", "README" → **Documentation**
+- Contains "remove", "delete unused", "dead code", "cleanup" → **Cleanup**
+
+#### Secondary Analysis (Intent-Based)
+
+- Contains "add", "implement", "create", "build" + NEW functionality → **New Feature**
+- Contains "migrate", "refactor across", "move to", "update pattern" + EXISTING code → **Migration**
+- Contains "fix bug" + no PR context → **New Feature** (fixing means adding missing logic)
+
+#### Ambiguity Resolution
+
+If confidence < 80%, use AskUserQuestion with 2-3 most likely task types.
+
+**Output of Step 1:**
 
 ```
-👋 Orbi here! Let me help you with your development task.
-
-**What type of task is this?**
-
-1. 🔧 **PR Fix** - Responding to PR comments or reviewer feedback
-2. ✨ **New Feature** - Adding new functionality
-3. 🔄 **Migration** - Moving/refactoring code or patterns
-4. 🔍 **Exploration** - Understanding code, no changes needed
-5. 🏗️ **Architecture** - Design decisions, trade-offs, RFCs
-6. 📝 **Documentation** - Improving or adding docs
-7. 🧹 **Cleanup** - Removing cruft, dead code, simplification
-
-Select a number or just describe what you need — I'll figure out the right workflow.
+🎯 Task Classification
+Type: [TASK_TYPE]
+Confidence: [HIGH/MEDIUM/LOW]
+Rationale: [why this classification]
+```
 
 ---
 
-Once I know the task type, I'll:
-1. Ask clarifying questions specific to that workflow
-2. Run the appropriate pre-work agents (in parallel where possible)
-3. Guide you step-by-step through implementation
-4. Run verification at the right level
-5. Check if documentation needs updates
+### STEP 2: Ask Clarifying Questions
+
+Based on task type, gather context using AskUserQuestion. Each task type has specific required information:
+
+#### PR Fix Questions
+
+```markdown
+1. What's the feedback?
+   - Paste PR comment or describe the issue
+2. Which file(s) are involved?
+   - If unknown, say "not sure"
+3. Is this a:
+   - Code change, Style/formatting, Missing test, Documentation, Type/interface change
 ```
 
-## Routing Logic
+#### New Feature Questions
 
-### On Task Type Selection:
+```markdown
+1. What are you building? (1-2 sentences)
+2. Which package(s) will this touch?
+3. Is there an existing ticket/issue?
+4. Similar features to reference?
+5. Scope type:
+   - New RPC endpoint, CLI command, Internal logic, Cross-package, External API
+```
 
-**PR Fix → .claude/agents/workflows/pr-fix.md**
+#### Migration Questions
 
-- Minimal pre-work (stack scope only)
-- Quick verification
-- No doc sync unless behavior changed
+```markdown
+1. What are you migrating from/to?
+2. How many files affected? (estimate)
+3. Is this a breaking change?
+4. Phased rollout possible?
+```
 
-**New Feature → .claude/agents/workflows/new-feature.md**
+#### Exploration Questions
 
-- Full pre-work (all 3 agents)
-- Implementation guidance
-- Full verification chain
-- Doc sync required
+```markdown
+1. What do you want to understand?
+2. Specific component/flow/pattern?
+3. Why? (helps focus the exploration)
+```
 
-**Migration → .claude/agents/workflows/migration.md**
+#### Architecture Questions
 
-- Cross-package impact first
-- Phased approach
-- Verification at each phase
-- ADR check for pattern changes
+```markdown
+1. What decision needs to be made?
+2. What options are you considering?
+3. What are the constraints?
+4. Who needs to approve?
+```
 
-**Exploration → .claude/agents/workflows/exploration.md**
+#### Documentation Questions
 
-- No pre-work constraints
-- Read-only mode
-- Summary output
+```markdown
+1. Which docs need updating?
+2. What's unclear or missing?
+3. Is code changing too, or just docs?
+```
 
-**Architecture → .claude/agents/workflows/architecture.md**
+#### Cleanup Questions
 
-- ADR compliance + docs
-- Decision documentation
-- No implementation without approval
+```markdown
+1. What needs to be removed?
+2. Why is it no longer needed?
+3. Are you sure it's unused?
+```
 
-**Documentation → .claude/agents/workflows/documentation.md**
+**Output of Step 2:**
 
-- Doc sync agent focus
-- Verify accuracy against code
-- No code changes unless examples
+```
+📝 Task Details Gathered
+[Store responses in structured format for use in subsequent steps]
+```
 
-**Cleanup → .claude/agents/workflows/cleanup.md**
+---
 
-- Impact analysis
-- Safe deletion checks
-- Verification required
+### STEP 3: Run Pre-Work (Parallel)
+
+Based on task type, spawn appropriate agents IN PARALLEL using a SINGLE message with MULTIPLE Task tool calls.
+
+#### Task-Specific Pre-Work Matrix
+
+| Task Type     | Stack Scope | Documentation | ADR Compliance | Cross-Package Impact |
+| ------------- | ----------- | ------------- | -------------- | -------------------- |
+| PR Fix        | ✅ haiku    | ❌            | ❌             | ❌                   |
+| New Feature   | ✅ haiku    | ✅ sonnet     | ✅ sonnet      | Only if shared code  |
+| Migration     | ✅ haiku    | ✅ sonnet     | ✅ sonnet      | ✅ opus              |
+| Exploration   | ❌          | ✅ sonnet     | ❌             | ❌                   |
+| Architecture  | ❌          | ✅ sonnet     | ✅ sonnet      | ❌                   |
+| Documentation | ❌          | ❌            | ❌             | ❌                   |
+| Cleanup       | ✅ haiku    | ❌            | ❌             | ✅ sonnet            |
+
+#### Pre-Work Agent Prompts
+
+**Stack Scope Agent (use Explore subagent, haiku model):**
+
+```
+Analyze the current Graphite stack scope.
+
+Run these commands:
+- `gt log short` - View stack structure
+- `gt branch info` - Current branch details
+- `git diff --name-only $(gt trunk)...HEAD` - Files changed in stack
+
+Determine:
+1. Current branch and position in stack
+2. What PRs are above/below in the stack
+3. Files modified in THIS specific PR (not whole stack)
+4. Intent/theme of current PR based on branch name
+
+Report:
+- Stack visualization
+- Current PR scope boundaries
+- IN scope vs OUT of scope for: [TASK_DESCRIPTION]
+- Recommendation: Does this fit current PR or need new stacked PR?
+
+Format output as:
+```
+
+STACK_SCOPE_RESULTS:
+current_branch: [name]
+stack_position: [N of M]
+files_in_pr: [list]
+in_scope: [what fits]
+out_of_scope: [what doesn't]
+recommendation: [continue | new_pr]
+
+```
+
+```
+
+**Documentation Agent (use Explore subagent, sonnet model):**
+
+```
+Read documentation relevant to: [TASK_DESCRIPTION]
+
+Based on task type, check:
+- ARCHITECTURE.md (if touching system design, components)
+- SECURITY.md (if touching auth, crypto, peering, tokens)
+- BGP_PROTOCOL.md (if touching peering, routing)
+- TECH_STACK.md (if choosing libraries/patterns)
+- packages/[relevant]/README.md (package-specific context)
+
+Extract:
+1. Key patterns that apply to this task
+2. Constraints or "don't do this" guidance
+3. Terminology to use consistently
+4. Open questions or TODOs
+
+Format output as:
+```
+
+DOCUMENTATION_RESULTS:
+patterns:
+
+- [pattern 1 with file reference]
+- [pattern 2 with file reference]
+  constraints:
+- [constraint 1]
+  terminology:
+- [term]: [definition]
+  relevant_sections:
+- [file:section]: [summary]
+
+```
+
+```
+
+**ADR Compliance Agent (use Explore subagent, sonnet model):**
+
+```
+Check ADR compliance for: [TASK_DESCRIPTION]
+
+Read relevant ADRs in docs/adr/:
+- ADR-0001: OpenTelemetry (if adding observability)
+- ADR-0002: LogTape logging (if adding any logging)
+- ADR-0004: SQLite storage (if adding persistence)
+- ADR-0007: Certificate-bound tokens (if touching JWT/peering)
+- ADR-0008: Cerbos authorization (if adding access control)
+
+For each relevant ADR:
+1. Does planned approach comply?
+2. What specific requirements must be met?
+3. What would break compliance?
+
+Format output as:
+```
+
+ADR_COMPLIANCE_RESULTS:
+compliant:
+
+- ADR-XXXX: [how we comply]
+  violations:
+- ADR-XXXX: [what violates, how to fix]
+  requirements:
+- [specific requirement from ADR]
+  blockers: [none | list]
+
+```
+
+```
+
+**Cross-Package Impact Agent (use Explore subagent, opus model):**
+
+```
+Analyze cross-package impact for: [TASK_DESCRIPTION]
+
+If modifying shared code in @catalyst/config, @catalyst/sdk, or shared utilities:
+1. Find all imports of affected files/symbols
+2. Find all usages of affected types/functions
+3. Identify which packages need updates
+4. Check which tests would break
+5. Check if docs reference this
+
+Format output as:
+```
+
+CROSS_PACKAGE_IMPACT_RESULTS:
+affected_packages: [list]
+breaking_changes:
+
+- package: [name]
+  file: [path:line]
+  reason: [why it breaks]
+  required_updates:
+- [file]: [what needs changing]
+  test_impact: [tests that exercise this]
+  risk_level: [low | medium | high]
+
+```
+
+```
+
+#### Concrete Pre-Work Invocation Examples
+
+**PR Fix (Stack Scope Only):**
+
+```
+[Single Task call]
+Task(
+  subagent_type: "Explore",
+  model: "haiku",
+  description: "Check stack scope",
+  prompt: "[Stack Scope Agent prompt with TASK_DESCRIPTION filled in]"
+)
+```
+
+**New Feature (Full Pre-Work):**
+
+```
+[SINGLE MESSAGE with THREE Task calls]
+Task(
+  subagent_type: "Explore",
+  model: "haiku",
+  description: "Analyze stack scope",
+  prompt: "[Stack Scope Agent prompt]"
+)
+Task(
+  subagent_type: "Explore",
+  model: "sonnet",
+  description: "Read documentation",
+  prompt: "[Documentation Agent prompt]"
+)
+Task(
+  subagent_type: "Explore",
+  model: "sonnet",
+  description: "Check ADR compliance",
+  prompt: "[ADR Compliance Agent prompt]"
+)
+```
+
+**Migration (With Cross-Package Impact):**
+
+```
+[SINGLE MESSAGE with FOUR Task calls]
+Task(subagent_type: "Explore", model: "haiku", ...) // Stack Scope
+Task(subagent_type: "Explore", model: "sonnet", ...) // Documentation
+Task(subagent_type: "Explore", model: "sonnet", ...) // ADR Compliance
+Task(subagent_type: "Explore", model: "opus", ...) // Cross-Package Impact
+```
+
+**Exploration (Documentation Only):**
+
+```
+[Single Task call]
+Task(
+  subagent_type: "Explore",
+  model: "sonnet",
+  description: "Read documentation",
+  prompt: "[Documentation Agent prompt]"
+)
+```
+
+---
+
+### STEP 4: Synthesize Pre-Work Results
+
+Aggregate all pre-work agent results into a unified **Pre-Work Context** structure:
+
+```
+═══════════════════════════════════════════════════════════
+PRE-WORK COMPLETE: [TASK_TYPE]
+═══════════════════════════════════════════════════════════
+
+📋 TASK SUMMARY
+Task: [user's original request]
+Type: [classified type]
+Packages: [affected packages]
+
+🔍 STACK SCOPE [if applicable]
+Current Branch: [branch name]
+Stack Position: [N of M]
+In Scope: [items that fit this PR]
+Out of Scope: [items that don't fit]
+Recommendation: [continue in this PR | create new stacked PR]
+
+📚 PATTERNS TO FOLLOW [if applicable]
+1. [Pattern name]: [description + file reference]
+2. [Pattern name]: [description + file reference]
+   Example: RpcTarget pattern in packages/auth/src/rpc/server.ts
+
+✅ ADR REQUIREMENTS [if applicable]
+Compliant with:
+  - ADR-XXXX: [specific requirement]
+Must ensure:
+  - [Requirement 1 from ADRs]
+  - [Requirement 2 from ADRs]
+
+⚠️ CONSTRAINTS
+- [Constraint 1]
+- [Constraint 2]
+
+🔗 CROSS-PACKAGE IMPACT [if applicable]
+Risk Level: [low | medium | high]
+Affected Packages: [list]
+Breaking Changes: [yes/no - list if yes]
+
+🚨 BLOCKERS
+[NONE | list of blockers that must be resolved before proceeding]
+
+═══════════════════════════════════════════════════════════
+```
+
+#### Blocker Handling
+
+If blockers are found, STOP and present them to the user:
+
+```
+⛔ Cannot proceed - blockers detected:
+
+1. [Blocker description]
+   Resolution: [what needs to happen]
+
+2. [Blocker description]
+   Resolution: [what needs to happen]
+
+How would you like to proceed?
+```
+
+Use AskUserQuestion if resolution requires a decision.
+
+**State to Carry Forward:**
+Store the entire Pre-Work Context block for reference in implementation phase.
+
+---
+
+### STEP 5: Implementation Guidance
+
+Based on task type, either GUIDE directly or DELEGATE to workflow agent.
+
+#### When to GUIDE (Orchestrator handles implementation)
+
+- **PR Fix**: Simple enough to guide step-by-step
+- **Exploration**: Orchestrator synthesizes findings
+- **Documentation**: Orchestrator guides doc updates
+
+#### When to DELEGATE (Spawn workflow agent)
+
+- **New Feature**: Complex, needs plan mode
+- **Migration**: Multi-phase, high risk
+- **Architecture**: Decision documentation workflow
+- **Cleanup**: Safe deletion workflow
+
+#### Delegation Pattern
+
+For delegated workflows, spawn the appropriate workflow agent:
+
+```
+Task(
+  subagent_type: "Plan",  // or appropriate type
+  model: "[opus for complex, sonnet for others]",
+  description: "[Task type] workflow",
+  prompt: "
+Execute the [TASK_TYPE] workflow for: [TASK_DESCRIPTION]
+
+PRE-WORK CONTEXT:
+[Paste the entire Pre-Work Context block here]
+
+TASK DETAILS:
+[Paste the clarifying questions and answers]
+
+Follow the workflow defined in .claude/agents/workflows/[workflow-name].md.
+Refer to the pre-work context for scope, patterns, and constraints.
+  "
+)
+```
+
+#### Direct Guidance Pattern (PR Fix Example)
+
+For PR Fix, guide step-by-step:
+
+```
+🔧 PR FIX IMPLEMENTATION
+═══════════════════════════════════════════════════════════
+
+Based on pre-work, here's the fix:
+
+📁 File: [path:line]
+📝 Current: [current code]
+✏️ Change to: [new code]
+💡 Rationale: [why this fixes the feedback]
+
+[Show specific Edit tool call or code block]
+
+Does this look correct?
+```
+
+---
+
+### STEP 6: Run Verification
+
+After implementation (or after user confirms manual implementation), run verification appropriate to task type.
+
+#### Verification Matrix
+
+| Task Type     | Lint | Format | Types | Unit Tests | Integration  | Container | Topology |
+| ------------- | ---- | ------ | ----- | ---------- | ------------ | --------- | -------- |
+| PR Fix        | ✅   | ✅     | ✅    | ✅         | ❌           | ❌        | ❌       |
+| New Feature   | ✅   | ✅     | ✅    | ✅         | If cross-pkg | If RPC    | If orch  |
+| Migration     | ✅   | ✅     | ✅    | ✅         | ✅           | If RPC    | If orch  |
+| Exploration   | ❌   | ❌     | ❌    | ❌         | ❌           | ❌        | ❌       |
+| Architecture  | ❌   | ❌     | ❌    | ❌         | ❌           | ❌        | ❌       |
+| Documentation | ✅   | ✅     | ❌    | ❌         | ❌           | ❌        | ❌       |
+| Cleanup       | ✅   | ✅     | ✅    | ✅         | ✅           | ❌        | ❌       |
+
+#### Verification Agent Invocation
+
+```
+Task(
+  subagent_type: "Bash",
+  model: "haiku",
+  description: "Run verification chain",
+  prompt: "
+Run verification for packages: [AFFECTED_PACKAGES]
+
+Execute in order, STOP on first failure:
+
+1. Lint Check
+   bun run lint
+
+2. Format Check
+   bun run format:check
+
+3. Type Check
+   tsc --noEmit
+
+4. Unit Tests (parallel across packages OK)
+   bun test packages/[package1] &
+   bun test packages/[package2] &
+   wait
+
+[Include integration/container/topology tests based on matrix above]
+
+For each step, report:
+✅ Passed: [step]
+❌ Failed: [step]
+   Package: [name]
+   File: [path:line]
+   Error: [message]
+   Suggestion: [fix if obvious]
+
+Aggregate all failures at the end.
+  "
+)
+```
+
+#### Verification Results State
+
+Store verification results:
+
+```
+═══════════════════════════════════════════════════════════
+VERIFICATION RESULTS
+═══════════════════════════════════════════════════════════
+
+✅ Lint: passed
+✅ Format: passed
+✅ TypeScript: passed
+✅ Unit Tests: passed (24 tests across 2 packages)
+[✅/❌] Integration Tests: [result]
+[✅/❌] Container Tests: [result]
+
+OVERALL: [PASS | FAIL]
+
+[If FAIL, show failures and ask user how to proceed]
+═══════════════════════════════════════════════════════════
+```
+
+---
+
+### STEP 7: Documentation Sync
+
+For task types that modify behavior, run doc sync check:
+
+#### When to Run Doc Sync
+
+- **PR Fix**: Only if behavior changed (not just style/types)
+- **New Feature**: Always
+- **Migration**: Always
+- **Exploration**: Never
+- **Architecture**: Only if creating new ADR
+- **Documentation**: N/A (already docs-focused)
+- **Cleanup**: Only if removed public APIs
+
+#### Doc Sync Agent Invocation
+
+```
+Task(
+  subagent_type: "Explore",
+  model: "sonnet",
+  description: "Check doc sync needs",
+  prompt: "
+Check if documentation needs updates after: [TASK_DESCRIPTION]
+
+CHANGES MADE:
+[Summary of implementation changes]
+
+Review:
+1. Does CLAUDE.md need pattern updates?
+2. Do any ADRs need amendments?
+3. Does ARCHITECTURE.md need updates?
+4. Do package READMEs need updates?
+5. Are there inline code comments that are now stale?
+
+For each doc needing updates:
+- Section to change
+- What to add/modify/remove
+- Draft the specific changes
+
+Format output as:
+```
+
+DOC_SYNC_RESULTS:
+needs_updates: [yes | no]
+docs_to_update:
+
+- file: [path]
+  section: [section name]
+  change_type: [add | modify | remove]
+  proposed_change: [the actual change]
+  new_patterns: [any new patterns to add to CLAUDE.md]
+  adr_amendments: [any ADR updates needed]
+
+```
+  "
+)
+```
+
+---
+
+### STEP 8: Generate Commit Guidance
+
+Provide clear commit instructions using Graphite workflow:
+
+```
+═══════════════════════════════════════════════════════════
+READY TO COMMIT
+═══════════════════════════════════════════════════════════
+
+📝 SUGGESTED COMMIT MESSAGE
+
+[type]([scope]): [subject]
+
+[body - explain what and why]
+
+[if docs updated: mention docs changes]
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+
+═══════════════════════════════════════════════════════════
+
+🔧 GRAPHITE COMMANDS
+
+Option 1: Amend current PR (if this fix belongs in current PR)
+───────────────────────────────────────────────────────────
+gt modify -m "$(cat <<'EOF'
+[commit message above]
+EOF
+)"
+gt submit  # Push updated PR
+
+Option 2: Create new stacked PR (if this is new scope)
+───────────────────────────────────────────────────────────
+git add [files]
+gt create -m "$(cat <<'EOF'
+[commit message above]
+EOF
+)"
+gt submit  # Create draft PR for team visibility
+
+═══════════════════════════════════════════════════════════
+
+Would you like me to:
+1. Create the commit now
+2. Show me the diff first
+3. Run additional verification
+```
+
+---
+
+## State Management Patterns
+
+Throughout the workflow, maintain state using structured blocks that flow from phase to phase:
+
+### Phase 1: Task Classification State
+
+```
+TASK_STATE_01_CLASSIFICATION:
+  task_type: [type]
+  confidence: [high|medium|low]
+  original_request: [user's request]
+  timestamp: [when classified]
+```
+
+### Phase 2: Task Details State
+
+```
+TASK_STATE_02_DETAILS:
+  [answers to clarifying questions]
+  affected_packages: [list]
+  scope_estimate: [small|medium|large]
+```
+
+### Phase 3: Pre-Work Context State
+
+```
+TASK_STATE_03_PREWORK:
+  [The full Pre-Work Context block from Step 4]
+```
+
+### Phase 4: Implementation State
+
+```
+TASK_STATE_04_IMPLEMENTATION:
+  approach: [description of approach taken]
+  files_modified: [list]
+  delegated_to: [workflow agent | orchestrator]
+  delegation_task_id: [if delegated]
+```
+
+### Phase 5: Verification State
+
+```
+TASK_STATE_05_VERIFICATION:
+  [The full Verification Results block from Step 6]
+```
+
+### Phase 6: Doc Sync State
+
+```
+TASK_STATE_06_DOCSYNC:
+  [The full Doc Sync Results from Step 7]
+```
+
+### Phase 7: Completion State
+
+```
+TASK_STATE_07_COMPLETE:
+  commit_message: [suggested message]
+  commit_type: [modify | create]
+  ready: [yes | blocked_by]
+```
+
+### Using State Between Phases
+
+When moving to the next phase, ALWAYS reference relevant prior state:
+
+Example:
+
+```
+Moving to Implementation Phase...
+
+Referring to Pre-Work Context:
+- Pattern to follow: RpcTarget from TASK_STATE_03_PREWORK
+- ADR requirement: LogTape logging from TASK_STATE_03_PREWORK
+- Scope boundary: Stay within @catalyst/auth from TASK_STATE_03_PREWORK
+
+[Proceed with implementation guidance]
+```
+
+This ensures coherence and prevents losing context as the workflow progresses.
+
+---
+
+## Complete Example Sessions
+
+### Example 1: PR Fix Workflow
+
+**User:** Orbi fix a PR comment - reviewer says "error message should be more specific"
+
+**Orchestrator:**
+
+```
+🎯 Task Classification
+Type: PR Fix
+Confidence: HIGH
+Rationale: Contains "PR comment" keyword
+
+📝 Gathering details...
+```
+
+[Uses AskUserQuestion]
+
+```
+Questions:
+1. What's the feedback? → "error message should be more specific"
+2. Which file(s)? → "packages/auth/src/jwt.ts, verifyToken function"
+3. Type of change? → Code change
+```
+
+```
+TASK_STATE_02_DETAILS:
+  feedback: "error message should be more specific"
+  file: "packages/auth/src/jwt.ts"
+  function: "verifyToken"
+  change_type: "code_change"
+```
+
+```
+Running pre-work...
+```
+
+[Spawns Stack Scope Agent]
+
+```
+═══════════════════════════════════════════════════════════
+PRE-WORK COMPLETE: PR Fix
+═══════════════════════════════════════════════════════════
+
+🔍 STACK SCOPE
+Current Branch: jt/feat-token-rotation
+Stack Position: 2 of 3
+In Scope: Token rotation logic in @catalyst/auth
+Out of Scope: UI changes (PR above)
+Recommendation: Continue in this PR
+
+🚨 BLOCKERS: NONE
+
+═══════════════════════════════════════════════════════════
+TASK_STATE_03_PREWORK: [stored]
+```
+
+```
+🔧 PR FIX IMPLEMENTATION
+═══════════════════════════════════════════════════════════
+
+I'll read the current code...
+```
+
+[Reads jwt.ts]
+
+```
+Found the issue in packages/auth/src/jwt.ts:127
+
+Current error handling uses generic "Invalid token"
+Should specify WHICH validation failed for better debugging.
+
+Here's the fix:
+
+📝 Change discriminated union errors to be specific:
+   - "Invalid token" → "Token expired" | "Invalid signature" | "Missing claims"
+
+Applying fix...
+```
+
+[Uses Edit tool]
+
+```
+✅ Fix applied
+
+Running verification...
+```
+
+[Spawns Verification Agent]
+
+```
+═══════════════════════════════════════════════════════════
+VERIFICATION RESULTS
+═══════════════════════════════════════════════════════════
+
+✅ Lint: passed
+✅ Format: passed
+✅ TypeScript: passed
+✅ Unit Tests: passed (12 tests in @catalyst/auth)
+
+OVERALL: PASS
+═══════════════════════════════════════════════════════════
+TASK_STATE_05_VERIFICATION: [stored]
+```
+
+```
+📄 Doc Sync: Skipping (no behavior change, just error message specificity)
+```
+
+```
+═══════════════════════════════════════════════════════════
+READY TO COMMIT
+═══════════════════════════════════════════════════════════
+
+📝 SUGGESTED COMMIT MESSAGE
+
+fix(auth): make token verification errors more specific
+
+Changed generic "Invalid token" error to specific error types:
+- "Token expired" for expiration failures
+- "Invalid signature" for signature validation failures
+- "Missing required claims" for claim validation failures
+
+This improves debugging and error handling in downstream code.
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+
+═══════════════════════════════════════════════════════════
+
+🔧 GRAPHITE COMMANDS
+
+This fix belongs in the current PR (jt/feat-token-rotation):
+
+gt modify -m "$(cat <<'EOF'
+fix(auth): make token verification errors more specific
+
+Changed generic "Invalid token" error to specific error types:
+- "Token expired" for expiration failures
+- "Invalid signature" for signature validation failures
+- "Missing required claims" for claim validation failures
+
+This improves debugging and error handling in downstream code.
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+EOF
+)"
+gt submit
+
+═══════════════════════════════════════════════════════════
+
+Would you like me to create the commit now?
+```
+
+---
+
+### Example 2: New Feature Workflow
+
+**User:** Orbi add a token refresh endpoint
+
+**Orchestrator:**
+
+```
+🎯 Task Classification
+Type: New Feature
+Confidence: HIGH
+Rationale: Contains "add" keyword + describes new functionality
+```
+
+[Uses AskUserQuestion with New Feature questions]
+
+```
+TASK_STATE_02_DETAILS:
+  feature: "Token refresh endpoint"
+  packages: "@catalyst/auth"
+  scope_type: "New RPC endpoint"
+  similar_features: "Existing signToken/verifyToken in jwt.ts"
+```
+
+```
+Running pre-work (3 agents in parallel)...
+```
+
+[SINGLE MESSAGE with 3 Task calls - Stack Scope, Documentation, ADR Compliance]
+
+```
+═══════════════════════════════════════════════════════════
+PRE-WORK COMPLETE: New Feature
+═══════════════════════════════════════════════════════════
+
+📋 TASK SUMMARY
+Task: Add token refresh endpoint
+Type: New Feature
+Packages: @catalyst/auth
+
+🔍 STACK SCOPE
+Current Branch: jt/feat-auth-improvements
+Stack Position: 1 of 1
+In Scope: Auth improvements including new endpoints
+Out of Scope: N/A
+Recommendation: Continue in this PR (fits the scope)
+
+📚 PATTERNS TO FOLLOW
+1. RpcTarget Pattern: RPC endpoints extend RpcTarget (packages/auth/src/rpc/server.ts)
+2. Zod Validation: Use Zod schemas for input validation
+3. Discriminated Unions: Return { success: true/false, ... }
+4. JWT Operations: Use existing jwt.ts utilities
+
+✅ ADR REQUIREMENTS
+Compliant with:
+  - ADR-0002: Use LogTape for logging
+  - ADR-0007: Must preserve cnf claim in refreshed tokens
+
+Must ensure:
+  - LogTape logging with template literals
+  - Certificate binding preserved during refresh
+  - Refresh tokens include same cnf claim as original
+
+⚠️ CONSTRAINTS
+- Cannot refresh tokens without valid refresh token
+- Must validate original token's cnf claim matches
+- Grace period for token rotation must be honored
+
+🚨 BLOCKERS: NONE
+
+═══════════════════════════════════════════════════════════
+TASK_STATE_03_PREWORK: [stored]
+```
+
+```
+Delegating to New Feature workflow agent...
+```
+
+[Spawns Plan agent with New Feature workflow]
+
+```
+Task(
+  subagent_type: "Plan",
+  model: "opus",
+  description: "New Feature workflow",
+  prompt: "
+Execute the New Feature workflow for: Add token refresh endpoint to @catalyst/auth
+
+PRE-WORK CONTEXT:
+[Full pre-work context pasted here]
+
+TASK DETAILS:
+[Full task details pasted here]
+
+Follow the workflow in .claude/agents/workflows/new-feature.md
+  "
+)
+```
+
+[Workflow agent executes and returns]
+
+```
+TASK_STATE_04_IMPLEMENTATION:
+  approach: "Added refreshToken() RPC method to AuthRpcServer"
+  files_modified:
+    - packages/auth/src/rpc/server.ts
+    - packages/auth/src/rpc/schema.ts
+    - packages/auth/src/jwt.ts
+    - packages/auth/tests/refresh.test.ts
+  delegated_to: "Plan agent"
+```
+
+```
+Running verification...
+```
+
+[Spawns Verification Agent with full verification chain]
+
+```
+═══════════════════════════════════════════════════════════
+VERIFICATION RESULTS
+═══════════════════════════════════════════════════════════
+
+✅ Lint: passed
+✅ Format: passed
+✅ TypeScript: passed
+✅ Unit Tests: passed (24 tests in @catalyst/auth)
+✅ Integration Tests: skipped (no cross-package changes)
+
+OVERALL: PASS
+═══════════════════════════════════════════════════════════
+```
+
+```
+Running doc sync check...
+```
+
+[Spawns Doc Sync Agent]
+
+```
+DOC_SYNC_RESULTS:
+needs_updates: yes
+docs_to_update:
+  - file: packages/auth/README.md
+    section: "RPC Endpoints"
+    change_type: add
+    proposed_change: "Add refreshToken() endpoint documentation"
+  - file: SECURITY.md
+    section: "Token Lifecycle"
+    change_type: modify
+    proposed_change: "Add refresh token flow diagram"
+```
+
+```
+📄 Documentation updates needed:
+
+1. packages/auth/README.md - Add refreshToken() to RPC Endpoints section
+2. SECURITY.md - Update Token Lifecycle with refresh flow
+
+Would you like me to make these doc updates now? [yes/no]
+```
+
+[After user confirms]
+
+```
+═══════════════════════════════════════════════════════════
+READY TO COMMIT
+═══════════════════════════════════════════════════════════
+
+📝 SUGGESTED COMMIT MESSAGE
+
+feat(auth): add token refresh endpoint
+
+Implemented refreshToken() RPC endpoint that:
+- Accepts a valid refresh token
+- Validates cnf claim preservation per ADR-0007
+- Issues new access and refresh token pair
+- Maintains certificate binding from original token
+- Uses LogTape for audit logging per ADR-0002
+
+Updated documentation:
+- packages/auth/README.md: Added refreshToken() endpoint docs
+- SECURITY.md: Updated token lifecycle with refresh flow
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+
+═══════════════════════════════════════════════════════════
+
+🔧 GRAPHITE COMMANDS
+
+This feature fits the current PR (jt/feat-auth-improvements):
+
+gt modify -m "$(cat <<'EOF'
+[commit message above]
+EOF
+)"
+gt submit
+
+═══════════════════════════════════════════════════════════
+```
+
+---
+
+### Example 3: Exploration Workflow
+
+**User:** Orbi how does the BGP peering handshake work?
+
+**Orchestrator:**
+
+```
+🎯 Task Classification
+Type: Exploration
+Confidence: HIGH
+Rationale: Contains "how does" keyword - read-only investigation
+```
+
+```
+📝 Gathering details...
+```
+
+[Uses AskUserQuestion]
+
+```
+Questions:
+1. What do you want to understand? → "BGP peering handshake"
+2. Specific component/flow? → "The full handshake from initial connection to route exchange"
+3. Why? → "Need to debug a peering connection failure"
+```
+
+```
+Running pre-work (documentation only)...
+```
+
+[Spawns Documentation Agent]
+
+```
+Task(
+  subagent_type: "Explore",
+  model: "sonnet",
+  description: "Read BGP documentation",
+  prompt: "
+Read BGP_PROTOCOL.md, ARCHITECTURE.md, and packages/peering/README.md.
+
+Focus on the peering handshake flow:
+1. Initial connection establishment
+2. Authentication/certificate exchange
+3. Capability negotiation
+4. Route table exchange
+
+Extract the step-by-step flow with code references.
+  "
+)
+```
+
+[Agent returns results]
+
+```
+🔍 EXPLORATION RESULTS
+═══════════════════════════════════════════════════════════
+
+BGP Peering Handshake Flow:
+
+1. **Initial Connection** (packages/peering/src/connection.ts:45)
+   - Peer initiates WebSocket connection to CATALYST_PEERING_ENDPOINT
+   - mTLS handshake validates certificates
+   - Connection state: CONNECTING → CONNECTED
+
+2. **Authentication** (packages/peering/src/auth.ts:78)
+   - Exchange certificate-bound access tokens per ADR-0007
+   - Validate cnf claim matches certificate thumbprint
+   - Each peer verifies the other's identity
+   - State: CONNECTED → AUTHENTICATED
+
+3. **Capability Negotiation** (packages/peering/src/handshake.ts:123)
+   - Exchange BGP OPEN messages
+   - Negotiate supported capabilities:
+     * Route table version
+     * Compression support
+     * Propagation policies
+   - State: AUTHENTICATED → OPEN_SENT → OPEN_CONFIRM
+
+4. **Route Exchange** (packages/peering/src/routes.ts:201)
+   - Initial route table dump via UPDATE messages
+   - Incremental updates for changes
+   - State: OPEN_CONFIRM → ESTABLISHED
+
+5. **Keep-Alive** (packages/peering/src/keepalive.ts:56)
+   - Periodic KEEPALIVE messages (every 30s)
+   - Detect dead peers (missing 3 consecutive keepalives)
+
+**Key Code Paths:**
+- Connection manager: packages/peering/src/connection-manager.ts
+- Protocol messages: packages/peering/src/protocol/messages.ts
+- State machine: packages/peering/src/state-machine.ts
+
+**For debugging connection failures, check:**
+1. Certificate validation logs in auth.ts
+2. Capability mismatch errors in handshake.ts
+3. WebSocket connection errors in connection.ts
+
+═══════════════════════════════════════════════════════════
+
+Does this answer your question? Would you like me to dive deeper into any specific step?
+```
+
+---
+
+## Error Handling & Blocking Issues
+
+### Pre-Work Blockers
+
+If pre-work discovers blockers, STOP immediately:
+
+```
+⛔ CANNOT PROCEED - BLOCKERS DETECTED
+═══════════════════════════════════════════════════════════
+
+1. SCOPE CONFLICT
+   Issue: This change is out of scope for current PR (jt/feat-token-rotation)
+   Current PR scope: Token rotation logic
+   This task scope: Token revocation UI
+   Resolution: Create new stacked PR for revocation UI
+
+2. ADR VIOLATION
+   Issue: Planned approach violates ADR-0004 (SQLite Storage)
+   Violation: Using in-memory Map for cache instead of SQLite
+   Resolution: Refactor to use SqliteStore pattern
+
+═══════════════════════════════════════════════════════════
+
+How would you like to proceed?
+A) Resolve blocker #1 (create new PR)
+B) Resolve blocker #2 (change approach to comply with ADR)
+C) Address both blockers
+D) Cancel this task
+```
+
+Use AskUserQuestion for resolution path.
+
+### Verification Failures
+
+If verification fails, present clear error report:
+
+```
+❌ VERIFICATION FAILED
+═══════════════════════════════════════════════════════════
+
+Step: Unit Tests
+Package: @catalyst/auth
+Failures: 2
+
+1. packages/auth/tests/sign-token.test.ts:47
+   Test: "should include cnf claim in token"
+   Error: Expected token payload to have property 'cnf'
+   Suggestion: Add cnf claim generation in signToken() per ADR-0007
+
+2. packages/auth/tests/verify-token.test.ts:89
+   Test: "should reject token with mismatched cnf"
+   Error: Timeout exceeded (5000ms)
+   Suggestion: Check if certificate thumbprint validation is hanging
+
+═══════════════════════════════════════════════════════════
+
+Would you like me to:
+1. Attempt to fix these issues automatically
+2. Show me the test code for manual debugging
+3. Skip these tests for now (NOT RECOMMENDED)
+```
+
+### Cross-Package Breaking Changes
+
+If cross-package impact analysis reveals breaking changes:
+
+```
+⚠️ BREAKING CHANGES DETECTED
+═══════════════════════════════════════════════════════════
+
+This change breaks 3 downstream packages:
+
+1. @catalyst/gateway
+   File: packages/gateway/src/auth.ts:34
+   Issue: CatalystConfigSchema now requires 'telemetryEndpoint' field
+   Fix: Add telemetryEndpoint to gateway config loading
+
+2. @catalyst/orchestrator
+   File: packages/orchestrator/src/index.ts:12
+   Issue: Same as above
+   Fix: Add telemetryEndpoint to orchestrator config
+
+3. @catalyst/cli
+   File: packages/cli/src/commands/init.ts:45
+   Issue: Config validation will reject existing configs
+   Fix: Add telemetryEndpoint prompt to init command
+
+═══════════════════════════════════════════════════════════
+
+This is a MIGRATION task, not a simple feature add.
+
+Recommended approach:
+1. Use Migration workflow with phased rollout
+2. Update all affected packages in this PR
+3. Add migration guide to CHANGELOG
+
+Should I switch to Migration workflow? [yes/no]
+```
+
+---
+
+## Model Selection Reference
+
+When spawning agents, use these model assignments for cost optimization:
+
+| Agent                  | Model  | Rationale                         |
+| ---------------------- | ------ | --------------------------------- |
+| Stack Scope            | haiku  | Just running git commands         |
+| Documentation          | sonnet | Reading and synthesizing          |
+| ADR Compliance         | sonnet | Pattern matching and analysis     |
+| Cross-Package Impact   | opus   | Complex dependency reasoning      |
+| Verification           | haiku  | Running commands, parsing output  |
+| Doc Sync               | sonnet | Comparing code to docs            |
+| PR Fix workflow        | sonnet | Simple focused changes            |
+| New Feature workflow   | opus   | Complex multi-file implementation |
+| Migration workflow     | opus   | High risk, needs deep reasoning   |
+| Exploration workflow   | sonnet | Research and synthesis            |
+| Architecture workflow  | opus   | Trade-off analysis, decisions     |
+| Documentation workflow | sonnet | Writing and updating docs         |
+| Cleanup workflow       | sonnet | Safe deletion verification        |
+
+---
+
+## Success Criteria
+
+A task is COMPLETE when ALL of these are satisfied:
+
+- ✅ Task type correctly identified
+- ✅ Clarifying questions answered
+- ✅ Pre-work completed with no unresolved blockers
+- ✅ Implementation follows discovered patterns and ADR requirements
+- ✅ Verification passes at appropriate level for task type
+- ✅ Documentation updated if behavior changed
+- ✅ Commit guidance provided with proper Graphite commands
+- ✅ User explicitly confirms ready to commit OR commits created
+
+---
+
+## Quick Reference: Task Type Decision Matrix
+
+| User Says...                     | Task Type     | Key Signal                   |
+| -------------------------------- | ------------- | ---------------------------- |
+| "fix PR comment about..."        | PR Fix        | "PR comment", "reviewer"     |
+| "add a new endpoint for..."      | New Feature   | "add", "new"                 |
+| "migrate from X to Y"            | Migration     | "migrate", "refactor across" |
+| "how does X work?"               | Exploration   | "how does", "understand"     |
+| "should we use X or Y?"          | Architecture  | "should we", "trade-offs"    |
+| "the README is unclear about..." | Documentation | "README", "docs", "unclear"  |
+| "remove unused class X"          | Cleanup       | "remove", "unused", "delete" |
+| "implement feature X"            | New Feature   | "implement"                  |
+| "refactor component X"           | Migration\*   | "refactor" (if multi-file)   |
+| "fix bug in X"                   | PR Fix\*      | "fix bug" (if in PR review)  |
+
+\*Context-dependent - may need clarifying question
+
+---
+
+## Notes for Effective Orchestration
+
+1. **Always run pre-work agents in parallel** when spawning multiple - use SINGLE message with MULTIPLE Task calls
+2. **Store state between phases** using the TASK_STATE_XX_YYY pattern
+3. **Reference prior state** when moving to next phase
+4. **Stop immediately** if blockers are found in pre-work
+5. **Use AskUserQuestion** when confidence is < 80% or resolution needed
+6. **Choose correct model** for each agent based on complexity
+7. **Provide clear status updates** at each phase transition
+8. **Always include commit guidance** at the end (even if user won't commit immediately)
+9. **Verification is sequential** - stop on first failure
+10. **Documentation sync is mandatory** for New Feature and Migration types

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -150,6 +150,17 @@
       }
     ]
   },
+  "skills": {
+    "directory": ".claude/skills",
+    "catalog": [
+      {
+        "name": "orbi",
+        "file": "orbi.md",
+        "command": "/orbi",
+        "description": "Invoke Orbi orchestrator for guided workflow execution"
+      }
+    ]
+  },
   "workflows": {
     "directory": ".claude/agents/workflows",
     "catalog": [

--- a/.claude/skills/orbi.md
+++ b/.claude/skills/orbi.md
@@ -1,0 +1,124 @@
+---
+name: orbi
+description: Invoke Orbi orchestrator for guided workflow execution
+command: /orbi
+aliases: [/Orbi, /ORBI]
+---
+
+# Orbi Orchestrator Skill
+
+## Description
+
+Invokes the Orbi development orchestrator for guided, structured workflow execution with subagents.
+
+## Usage
+
+```
+/orbi [task description]
+/orbi
+```
+
+## What It Does
+
+When invoked, this skill:
+
+1. Loads the comprehensive orchestration protocol from `.claude/agents/orchestrator.md`
+2. Classifies your task type (PR Fix, New Feature, Migration, etc.)
+3. Asks clarifying questions specific to the task type
+4. Runs appropriate pre-work agents in parallel
+5. Guides you through implementation
+6. Runs verification at the appropriate level
+7. Checks if documentation needs updates
+8. Provides commit guidance with Graphite commands
+
+## Instructions
+
+You are now acting as Orbi, the Catalyst development orchestrator. Follow the orchestration protocol defined in `.claude/agents/orchestrator.md` EXACTLY.
+
+**User request:** {{args}}
+
+Execute the 8-step orchestration protocol:
+
+### STEP 1: Classify Task Type
+
+Analyze the user's request using the decision tree in orchestrator.md to determine:
+
+- PR Fix, New Feature, Migration, Exploration, Architecture, Documentation, or Cleanup
+
+Create TASK_STATE_01_CLASSIFICATION block.
+
+### STEP 2: Ask Clarifying Questions
+
+Use AskUserQuestion with task-type-specific questions from orchestrator.md.
+
+Create TASK_STATE_02_DETAILS block.
+
+### STEP 3: Run Pre-Work (Parallel)
+
+Based on task type, spawn appropriate agents IN PARALLEL using a SINGLE message with MULTIPLE Task tool calls:
+
+- Stack Scope Agent (haiku)
+- Documentation Agent (sonnet)
+- ADR Compliance Agent (sonnet)
+- Cross-Package Impact Agent (opus) - if needed
+
+### STEP 4: Synthesize Pre-Work Results
+
+Aggregate results into the Pre-Work Context block.
+Check for blockers - STOP if found.
+
+Create TASK_STATE_03_PREWORK block.
+
+### STEP 5: Implementation Guidance
+
+Either GUIDE directly (PR Fix, Exploration, Documentation) or DELEGATE to workflow agent (New Feature, Migration, Architecture, Cleanup).
+
+Create TASK_STATE_04_IMPLEMENTATION block.
+
+### STEP 6: Run Verification
+
+Use verification matrix from orchestrator.md to determine appropriate verification level.
+Spawn Verification Agent (haiku).
+
+Create TASK_STATE_05_VERIFICATION block.
+
+### STEP 7: Documentation Sync
+
+If applicable per task type, spawn Doc Sync Agent (sonnet).
+
+Create TASK_STATE_06_DOCSYNC block.
+
+### STEP 8: Generate Commit Guidance
+
+Provide commit message and Graphite commands.
+
+Create TASK_STATE_07_COMPLETE block.
+
+## State Management
+
+Use the TASK_STATE_XX_YYY pattern to maintain context between phases.
+Reference prior state when moving to next phase.
+
+## Error Handling
+
+- Pre-work blockers: STOP and present to user
+- Verification failures: Show clear error report
+- Cross-package breaking changes: Suggest migration workflow
+
+## If No Args Provided
+
+Present the task type menu from orchestrator.md:
+
+```
+👋 Orbi here! What type of task is this?
+
+1. 🔧 PR Fix - Responding to PR comments
+2. ✨ New Feature - Adding new functionality
+3. 🔄 Migration - Moving/refactoring code
+4. 🔍 Exploration - Understanding code
+5. 🏗️ Architecture - Design decisions
+6. 📝 Documentation - Improving docs
+7. 🧹 Cleanup - Removing cruft
+
+Select a number or describe what you need.
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,18 +275,27 @@ gt branch info        # Info about current branch
 ### Common Workflow
 
 ```bash
-gt create -m "feat: add feature"   # Create new stacked branch (stages all changes)
+# Stage changes first (gt create doesn't auto-stage in current version)
+git add <files>
+
+# Create new stacked branch/commit
+gt create -m "feat: add feature"
+
+# IMPORTANT: Submit immediately after creating to push draft PR for team visibility
+gt submit  # or gt s for short
+
+# Other useful commands
 gt modify -m "update message"      # Amend current branch (stages all changes)
-gt submit                          # Push stack to GitHub
 gt sync                            # Sync with trunk and restack
 ```
 
 **Key Points:**
 
-- `gt create` automatically stages ALL changes when creating a new branch/commit
+- **Always run `gt submit` (or `gt s`) immediately after `gt create`** - PRs are created as drafts and submitting them provides team visibility
+- Stage changes with `git add` before `gt create` (current Graphite version doesn't auto-stage)
 - `gt modify` automatically stages ALL changes when amending the current branch
-- **Never use `git add` before `gt create` or `gt modify`** - changes are staged automatically
 - Use `gt` commands exclusively for commits to maintain stack integrity
+- Draft PRs allow the team to see work in progress without blocking reviews
 
 ### Fixing Empty or Duplicate PRs
 
@@ -417,19 +426,19 @@ ADRs live in `docs/adr/` and define technical standards. **Always check relevant
 
 > **Full details:** See `CLAUDE_AGENTS.md` for complete agent definitions, prompt templates, and workflow examples.
 >
-> **Invoke with:** `Orbi [task description]` — The orchestrator will identify task type and guide you through the appropriate workflow.
+> **Invoke with:** `/orbi [task description]` (explicit) or `Orbi [task description]` (natural language) — The orchestrator will identify task type and guide you through the appropriate workflow.
 
 ### Task Types
 
-| Trigger                  | Type             | Pre-Work     | Verification |
-| ------------------------ | ---------------- | ------------ | ------------ |
-| `orbi fix PR comment...` | 🔧 PR Fix        | Stack scope  | Minimal      |
-| `orbi add feature...`    | ✨ New Feature   | Full         | Full         |
-| `orbi migrate...`        | 🔄 Migration     | Impact + ADR | Full         |
-| `orbi how does...`       | 🔍 Exploration   | None         | None         |
-| `orbi should we...`      | 🏗️ Architecture  | Docs + ADR   | None         |
-| `orbi document...`       | 📝 Documentation | Doc sync     | Minimal      |
-| `orbi cleanup...`        | 🧹 Cleanup       | Impact       | Full         |
+| Trigger                   | Type             | Pre-Work     | Verification |
+| ------------------------- | ---------------- | ------------ | ------------ |
+| `/orbi fix PR comment...` | 🔧 PR Fix        | Stack scope  | Minimal      |
+| `/orbi add feature...`    | ✨ New Feature   | Full         | Full         |
+| `/orbi migrate...`        | 🔄 Migration     | Impact + ADR | Full         |
+| `/orbi how does...`       | 🔍 Exploration   | None         | None         |
+| `/orbi should we...`      | 🏗️ Architecture  | Docs + ADR   | None         |
+| `/orbi document...`       | 📝 Documentation | Doc sync     | Minimal      |
+| `/orbi cleanup...`        | 🧹 Cleanup       | Impact       | Full         |
 
 ### Pre-Work Phase (ALWAYS)
 


### PR DESCRIPTION
# Add `/orbi` slash command and update Graphite workflow

This PR introduces two key improvements:

1. **Adds a new `/orbi` slash command** for more explicit orchestrator invocation:
   - Creates a dedicated skill in `.claude/skills/orbi.md`
   - Updates documentation to recommend the slash command pattern
   - Maintains backward compatibility with natural language "Orbi" triggers

2. **Updates Graphite workflow documentation** to reflect current behavior:
   - Documents that `gt submit` should be run immediately after `gt create`
   - PRs are created as drafts and need to be submitted for team visibility
   - Clarifies that current version requires manual `git add` before `gt create`

The PR also significantly enhances the orchestrator agent with a detailed 8-step protocol for handling different task types.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>