### PR TITLE
chore: updated comments on isRevoked due to feedback

### DIFF
--- a/packages/authorization/src/jwt/local/sqlite-store.ts
+++ b/packages/authorization/src/jwt/local/sqlite-store.ts
@@ -84,6 +84,14 @@ export class BunSqliteTokenStore implements TokenStore {
     ])
   }
 
+  /**
+   * Check if a token is revoked.
+   *
+   * Performance: Optimized for high-throughput (1000s req/sec).
+   * - Uses PRIMARY KEY lookup on jti (O(log n))
+   * - Selects only is_revoked field, not all columns
+   * - Single round-trip to SQLite
+   */
   async isRevoked(jti: string): Promise<boolean> {
     const stmt = this.db.prepare('SELECT is_revoked FROM token WHERE jti = $jti')
     const row = stmt.get({ $jti: jti }) as { is_revoked: number } | null


### PR DESCRIPTION
### TL;DR

Added documentation for the `isRevoked` method in the SQLite token store implementation.

### What changed?

Added JSDoc comments to the `isRevoked` method in the `BunSqliteTokenStore` class that explain the performance characteristics of the implementation. The comments highlight that the method is optimized for high throughput (1000s req/sec) and detail the specific optimizations:
- Uses PRIMARY KEY lookup on jti (O(log n))
- Selects only the is_revoked field, not all columns
- Requires only a single round-trip to SQLite

### How to test?

No functional changes were made, so no testing is required. The code behavior remains unchanged.

### Why make this change?

This documentation helps developers understand the performance characteristics of the token revocation check, which is critical for high-throughput applications. It provides transparency about the implementation's efficiency and the design decisions that enable it to handle thousands of requests per second.