### PR TITLE
fix: make orbi orchestrator properly spawn subagents

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -35,6 +35,20 @@ Use "Orbi" when you want guided workflow execution with subagents. For general c
 
 When invoked with "Orbi [task]", follow these steps EXACTLY:
 
+**MANDATORY CHECKLIST - You MUST complete ALL steps:**
+
+- [ ] STEP 1: Classify task type (output classification block)
+- [ ] STEP 2: Ask clarifying questions (use AskUserQuestion if needed)
+- [ ] STEP 3: Spawn pre-work agents IN PARALLEL (use Task tool, NOT Grep/Read/Edit)
+- [ ] STEP 4: Wait for agent results, then implement
+- [ ] STEP 5: Run verification
+- [ ] STEP 6: Check doc sync (if behavior changed)
+- [ ] STEP 7: Provide commit guidance
+
+**If you skip STEP 3 (spawning agents), you are NOT following the protocol.**
+
+---
+
 ### STEP 1: Classify Task Type
 
 Analyze the user's request and classify using this decision tree:
@@ -147,7 +161,22 @@ Based on task type, gather context using AskUserQuestion. Each task type has spe
 
 ### STEP 3: Run Pre-Work (Parallel)
 
+**CRITICAL: You MUST spawn agents using the Task tool. Do NOT use Grep, Read, or Edit directly.**
+
 Based on task type, spawn appropriate agents IN PARALLEL using a SINGLE message with MULTIPLE Task tool calls.
+
+**Example: PR Fix spawns Stack Scope agent only**
+
+You must call Task tool with:
+
+- subagent_type: "Explore" (for Stack Scope) or "general-purpose" (for Documentation/ADR)
+- description: Short 3-5 word description
+- model: "haiku", "sonnet", or "opus" (see matrix below)
+- prompt: Copy the exact prompt from "Pre-Work Agent Prompts" section below
+
+**Example: New Feature spawns 3 agents in parallel (Stack Scope + Documentation + ADR Compliance)**
+
+Send ONE message with THREE Task tool calls - one for each agent.
 
 #### Task-Specific Pre-Work Matrix
 

--- a/.claude/skills/orbi/SKILL.md
+++ b/.claude/skills/orbi/SKILL.md
@@ -17,15 +17,44 @@ This skill is triggered by:
 
 ## Your Role
 
-When invoked, you:
+When invoked, you MUST execute this workflow:
 
-1. **Classify the task type** based on keywords and intent
-2. **Ask clarifying questions** specific to that task type
-3. **Run pre-work agents** in parallel to gather context
-4. **Guide implementation** or delegate to workflow agents
-5. **Run verification** at the appropriate level
-6. **Check documentation sync** if behavior changed
-7. **Provide commit guidance** with Graphite commands
+**STEP 0: Read the Protocol (MANDATORY)**
+
+- Read `.claude/agents/orchestrator.md` FIRST before doing anything else
+- This contains the exact prompts and agent definitions you must use
+
+**STEP 1: Classify the task type**
+
+- Use keywords and intent from orchestrator.md
+- Output: `🎯 Task Classification` with type, confidence, rationale
+
+**STEP 2: Ask clarifying questions**
+
+- Use AskUserQuestion with task-specific prompts from orchestrator.md
+- Skip only if context is crystal clear
+
+**STEP 3: Spawn pre-work agents IN PARALLEL**
+
+- Use SINGLE message with MULTIPLE Task tool calls
+- Follow the pre-work matrix in orchestrator.md (e.g., PR Fix = Stack Scope only)
+- Do NOT use Grep/Read/Edit yourself - spawn agents to do this
+
+**STEP 4: Guide implementation**
+
+- Use agent findings to implement or delegate to workflow agents
+
+**STEP 5: Run verification**
+
+- Spawn verification agents or run tests directly
+
+**STEP 6: Check documentation sync**
+
+- Spawn doc-sync agent if behavior changed
+
+**STEP 7: Provide commit guidance**
+
+- Give Graphite commands (gt c -am, gt submit)
 
 ## Task Types
 
@@ -41,16 +70,22 @@ When invoked, you:
 
 ## Detailed Protocol
 
-Load and follow the complete orchestration protocol from:
-`.claude/agents/orchestrator.md`
+**CRITICAL: Before responding to ANY task, you MUST:**
 
-This file contains:
+1. **Read `.claude/agents/orchestrator.md` in full** - This is MANDATORY, not optional
+2. **Follow EVERY step in the protocol EXACTLY** - No shortcuts, no skipping pre-work
+3. **Spawn agents as defined** - Use Task tool with proper subagent_type and model
+4. **Do NOT use tools directly** - Grep, Read, Edit are for agents, not orchestrator
 
-- Step-by-step orchestration instructions
-- Pre-work agent prompts and model assignments
+The orchestration protocol contains:
+
+- Step-by-step orchestration instructions (FOLLOW THESE)
+- Pre-work agent prompts and model assignments (SPAWN THESE)
 - State management patterns
 - Complete example sessions
 - Error handling and blocker resolution
+
+**If you skip reading the protocol or skip spawning agents, you are NOT following instructions.**
 
 ## Quick Start Response
 

--- a/packages/auth/src/rpc/server.ts
+++ b/packages/auth/src/rpc/server.ts
@@ -3,8 +3,8 @@ import { RpcTarget } from 'capnweb'
 import { Hono } from 'hono'
 import { upgradeWebSocket } from 'hono/bun'
 
-import type { IKeyManager } from '../key-manager/types.js'
 import {
+  type IKeyManager,
   type TokenManager,
   Role,
   Action,


### PR DESCRIPTION
### TL;DR

Enhance Orbi skill with clearer workflow steps and enforce proper agent spawning protocol.

### What changed?

- Added a mandatory checklist to the orchestrator agent to ensure all steps are followed
- Added explicit warnings about using the Task tool for spawning agents instead of direct tool usage
- Included detailed examples of how to properly spawn agents with the Task tool
- Restructured the Orbi skill documentation to emphasize the importance of following the protocol
- Added clear step-by-step instructions with highlighting of critical requirements
- Moved IKeyManager import to be inline with other imports in auth server.ts

### How to test?

1. Invoke the Orbi skill with "Orbi [task]" and verify it follows all steps in the checklist
2. Confirm the orchestrator spawns agents using the Task tool rather than using Grep/Read/Edit directly
3. Verify that for different task types (PR Fix, New Feature, etc.), the correct agents are spawned according to the matrix

### Why make this change?

The Orbi skill was not consistently following the proper workflow, particularly skipping the critical step of spawning agents. This change enforces the protocol by adding explicit checklists, warnings, and examples to ensure the orchestrator properly delegates work to specialized agents rather than attempting to do everything itself.