### PR TITLE
refactor: remove instanceof checks from TokenManager

### DIFF
--- a/packages/auth/src/rpc/server.ts
+++ b/packages/auth/src/rpc/server.ts
@@ -8,7 +8,6 @@ import {
   type TokenManager,
   Role,
   Action,
-  LocalTokenManager,
   jwtToEntity,
 } from '@catalyst/authorization'
 import type { BootstrapService } from '../bootstrap.js'
@@ -201,10 +200,7 @@ export class AuthRpcServer extends RpcTarget {
         await this.tokenManager.revoke({ jti: request.jti, san: request.san })
       },
       list: async (request) => {
-        if (this.tokenManager instanceof LocalTokenManager) {
-          return this.tokenManager.getStore().listTokens(request)
-        }
-        return []
+        return this.tokenManager.listTokens(request)
       },
     }
   }
@@ -260,12 +256,9 @@ export class AuthRpcServer extends RpcTarget {
         }
       },
       getTokensByCert: async (request) => {
-        if (this.tokenManager instanceof LocalTokenManager) {
-          return this.tokenManager.getStore().listTokens({
-            certificateFingerprint: request.fingerprint,
-          })
-        }
-        return []
+        return this.tokenManager.listTokens({
+          certificateFingerprint: request.fingerprint,
+        })
       },
     }
   }
@@ -287,10 +280,7 @@ export class AuthRpcServer extends RpcTarget {
         return { valid: true, payload: result.payload }
       },
       getRevocationList: async () => {
-        if (this.tokenManager instanceof LocalTokenManager) {
-          return this.tokenManager.getStore().getRevocationList()
-        }
-        return []
+        return this.tokenManager.getRevocationList()
       },
       getJWKS: async () => {
         const jwks = await this.keyManager.getJwks()

--- a/packages/authorization/src/jwt/index.ts
+++ b/packages/authorization/src/jwt/index.ts
@@ -90,6 +90,10 @@ export interface TokenManager {
   revoke(options: { jti?: string; san?: string }): Promise<void>
   /** Verify a token and check its tracking status */
   verify(token: string, options?: { audience?: string | string[] }): Promise<VerifyResult>
+  /** List tokens, optionally filtered by certificate fingerprint or SAN */
+  listTokens(filter?: { certificateFingerprint?: string; san?: string }): Promise<TokenRecord[]>
+  /** Get all unexpired revoked tokens (for CRL/VRL) */
+  getRevocationList(): Promise<string[]>
 }
 
 /**

--- a/packages/authorization/src/jwt/local/index.ts
+++ b/packages/authorization/src/jwt/local/index.ts
@@ -86,4 +86,15 @@ export class LocalTokenManager implements TokenManager {
 
     return result
   }
+
+  async listTokens(filter?: {
+    certificateFingerprint?: string
+    san?: string
+  }): Promise<TokenRecord[]> {
+    return this.store.listTokens(filter)
+  }
+
+  async getRevocationList(): Promise<string[]> {
+    return this.store.getRevocationList()
+  }
 }


### PR DESCRIPTION
### TL;DR

Updated the TokenManager interface to include listTokens and getRevocationList methods, removing type checking in the RPC server.

### What changed?

- Added two new methods to the TokenManager interface: `listTokens` and `getRevocationList`
- Implemented these methods in the LocalTokenManager class
- Removed type checking and conditional logic in the AuthRpcServer that was checking if the tokenManager was an instance of LocalTokenManager
- Updated the RPC server to directly call these methods on the TokenManager interface

### How to test?

1. Verify that token listing functionality works correctly by calling the list method on the token manager
2. Verify that getting the revocation list works by calling the getRevocationList method
3. Ensure that any implementations of TokenManager now properly implement the new interface methods

### Why make this change?

This change improves the design by properly extending the TokenManager interface rather than relying on type checking. It removes the need for conditional logic in the RPC server that was checking for a specific implementation type (LocalTokenManager). This makes the code more maintainable and follows better interface design principles, allowing for different TokenManager implementations to provide their own logic for listing tokens and getting revocation lists.