### PR TITLE
feat: add permissions API with Cedar authorization

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "catalyst-monorepo",
+      "dependencies": {
+        "@logtape/logtape": "^2.0.2",
+      },
       "devDependencies": {
         "@commitlint/cli": "^20.3.1",
         "@commitlint/config-conventional": "^20.3.1",
@@ -575,6 +578,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
+
+    "@logtape/logtape": ["@logtape/logtape@2.0.2", "", {}, "sha512-cveUBLbCMFkvkLycP/2vNWvywl47JcJbazHIju94/QNGboZ/jyYAgZIm0ZXezAOx3eIz8OG1EOZ5CuQP3+2FQg=="],
 
     "@phc/format": ["@phc/format@1.0.0", "", {}, "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ=="],
 

--- a/package.json
+++ b/package.json
@@ -80,5 +80,8 @@
     "lint-staged": "^16.2.7",
     "prettier": "^3.7.4",
     "typescript-eslint": "^8.52.0"
+  },
+  "dependencies": {
+    "@logtape/logtape": "^2.0.2"
   }
 }

--- a/packages/auth/src/logger.ts
+++ b/packages/auth/src/logger.ts
@@ -1,0 +1,33 @@
+import { configure, getConsoleSink, getLogger } from '@logtape/logtape'
+
+// Configure LogTape for auth service
+let configured = false
+
+export function configureLogging() {
+  if (configured) return
+
+  configure({
+    sinks: {
+      console: getConsoleSink(),
+    },
+    filters: {},
+    loggers: [
+      {
+        category: ['auth'],
+        level: 'debug',
+        sinks: ['console'],
+      },
+    ],
+  })
+
+  configured = true
+}
+
+/**
+ * Get a logger for the auth service
+ * @param subcategory Optional subcategory like 'permissions', 'tokens', etc.
+ */
+export function getAuthLogger(subcategory?: string) {
+  const category = subcategory ? ['auth', subcategory] : ['auth']
+  return getLogger(category)
+}

--- a/packages/auth/src/rpc/schema.ts
+++ b/packages/auth/src/rpc/schema.ts
@@ -378,3 +378,73 @@ export const CreateTokenRequestSchema = z.object({
 })
 
 export type CreateTokenRequest = z.infer<typeof CreateTokenRequestSchema>
+
+/**
+ * Permissions API schemas
+ */
+export const PermissionsApiRequestSchema = z.string() // token
+
+export const NodeContextSchema = z.object({
+  nodeId: z.string(),
+  domains: z.array(z.string()),
+})
+
+export type NodeContext = z.infer<typeof NodeContextSchema>
+
+export const AuthorizeActionRequestSchema = z.object({
+  action: z.string(),
+  nodeContext: NodeContextSchema,
+})
+
+export type AuthorizeActionRequest = z.infer<typeof AuthorizeActionRequestSchema>
+
+/**
+ * Authorization result with discriminated union for different error types
+ */
+export const AuthorizeActionResultSchema = z.discriminatedUnion('success', [
+  // Success case
+  z.object({
+    success: z.literal(true),
+    allowed: z.boolean(),
+  }),
+  // Token expired
+  z.object({
+    success: z.literal(false),
+    errorType: z.literal('token_expired'),
+    reason: z.string(),
+  }),
+  // Token malformed
+  z.object({
+    success: z.literal(false),
+    errorType: z.literal('token_malformed'),
+    reason: z.string(),
+  }),
+  // Token revoked
+  z.object({
+    success: z.literal(false),
+    errorType: z.literal('token_revoked'),
+    reason: z.string(),
+  }),
+  // Permission denied
+  z.object({
+    success: z.literal(false),
+    errorType: z.literal('permission_denied'),
+    reasons: z.array(z.string()),
+  }),
+  // System error
+  z.object({
+    success: z.literal(false),
+    errorType: z.literal('system_error'),
+    reason: z.string(),
+  }),
+])
+
+export type AuthorizeActionResult = z.infer<typeof AuthorizeActionResultSchema>
+
+/**
+ * Permissions handlers interface
+ */
+export interface PermissionsHandlers {
+  /** Authorize an action based on token and node context */
+  authorizeAction(request: AuthorizeActionRequest): Promise<AuthorizeActionResult>
+}


### PR DESCRIPTION
### TL;DR

Added Cedar-based permissions API to the auth service with structured logging support.

### What changed?

- Added `@logtape/logtape` as a dependency for structured logging
- Created a new logger module in the auth service with configuration for consistent logging
- Implemented a permissions API with Cedar-based authorization checks
- Added schemas for permission requests and responses with proper error handling
- Integrated logging throughout the auth service for better observability
- Converted existing console logs to structured logging

### How to test?

1. Call the new permissions API endpoint with a valid token:
   ```typescript
   const permissionsApi = await authClient.permissions(token)
   const result = await permissionsApi.authorizeAction({
     action: "VIEW_DASHBOARD",
     nodeContext: {
       nodeId: "node-123",
       domains: ["example.com"]
     }
   })
   ```

2. Verify different authorization scenarios:
   - Success case: `result.success === true && result.allowed === true`
   - Permission denied: `result.success === false && result.errorType === 'permission_denied'`
   - Token errors: Check for `token_expired`, `token_malformed`, or `token_revoked` error types

3. Check logs to verify structured logging is working correctly

### Why make this change?

This change adds a critical permissions API that enables Cedar-based authorization checks for admin panel actions. The implementation allows for fine-grained access control based on user roles and context. The addition of structured logging improves observability and debugging capabilities across the auth service.