### PR TITLE
feat(telemetry): add unified observability package

### DIFF
--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -45,12 +45,6 @@ export type { InstrumentUpgradeOptions } from './middleware/capnweb-transport.js
 // to avoid requiring hono for consumers that only need logs/metrics/tracing.
 
 // ---------------------------------------------------------------------------
-// Builder + DI
-// ---------------------------------------------------------------------------
-export { TelemetryBuilder } from './builder.js'
-export type { ServiceTelemetry, InstrumentRpcOptions } from './types.js'
-
-// ---------------------------------------------------------------------------
 // Unified init / shutdown
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# Traces (NodeTracerProvider), logs (LogTape), and metrics (MeterProvider)
behind a single initTelemetry() entry point. Includes Hono HTTP middleware,
Proxy-based capnweb RPC instrumentation, and W3C traceparent propagation
over WebSocket transport.