### PR TITLE
feat(cli): add client infrastructure for orchestrator and auth services

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,7 +17,8 @@
     "inquirer": "catalog:",
     "ws": "catalog:",
     "zod": "catalog:",
-    "@catalyst/orchestrator": "catalog:"
+    "@catalyst/orchestrator": "catalog:",
+    "@catalyst/authorization": "catalog:"
   },
   "devDependencies": {
     "@types/inquirer": "catalog:dev",

--- a/packages/cli/src/clients/auth-client.ts
+++ b/packages/cli/src/clients/auth-client.ts
@@ -1,0 +1,56 @@
+import { newWebSocketRpcSession } from 'capnweb'
+
+export interface CreateTokenRequest {
+  subject: string
+  entity: {
+    id: string
+    name: string
+    type: 'user' | 'service'
+    role: string
+    nodeId?: string
+    trustedNodes?: string[]
+    trustedDomains?: string[]
+  }
+  roles: string[]
+  sans?: string[]
+  expiresIn?: string
+}
+
+export interface TokenRecord {
+  jti: string
+  sub: string
+  iat: number
+  exp: number
+  revoked: boolean
+  san?: string
+  certificateFingerprint?: string
+}
+
+export interface ValidateTokenResponse {
+  valid: boolean
+  payload?: Record<string, unknown>
+  error?: string
+}
+
+export interface AuthPublicApi {
+  tokens(token: string): Promise<AuthTokenHandlers | { error: string }>
+  validation(token: string): Promise<AuthValidationHandlers | { error: string }>
+}
+
+export interface AuthTokenHandlers {
+  create(request: CreateTokenRequest): Promise<string>
+  revoke(request: { jti?: string; san?: string }): Promise<void>
+  list(request: { certificateFingerprint?: string; san?: string }): Promise<TokenRecord[]>
+}
+
+export interface AuthValidationHandlers {
+  validate(request: { token: string; audience?: string }): Promise<ValidateTokenResponse>
+  getRevocationList(): Promise<string[]>
+  getJWKS(): Promise<{ keys: unknown[] }>
+}
+
+export async function createAuthClient(
+  url: string = process.env.CATALYST_AUTH_URL || 'ws://localhost:4000/rpc'
+): Promise<AuthPublicApi> {
+  return newWebSocketRpcSession<AuthPublicApi>(url)
+}

--- a/packages/cli/src/clients/index.ts
+++ b/packages/cli/src/clients/index.ts
@@ -1,0 +1,2 @@
+export * from './orchestrator-client.js'
+export * from './auth-client.js'

--- a/packages/cli/src/clients/orchestrator-client.ts
+++ b/packages/cli/src/clients/orchestrator-client.ts
@@ -1,0 +1,31 @@
+import type { RpcStub } from 'capnweb'
+import { newWebSocketRpcSession } from 'capnweb'
+import type { PeerInfo } from '@catalyst/orchestrator'
+import type { DataChannelDefinition } from '@catalyst/orchestrator'
+import type { InternalRoute } from '@catalyst/orchestrator'
+
+// Polyfill Symbol.asyncDispose if necessary
+// @ts-expect-error - polyfilling Symbol.asyncDispose
+Symbol.asyncDispose ??= Symbol('Symbol.asyncDispose')
+
+export type ActionResult = { success: true } | { success: false; error: string }
+
+export interface OrchestratorPublicApi {
+  connectionFromManagementSDK(): RpcStub<ManagementScope>
+}
+
+export interface ManagementScope {
+  applyAction(action: unknown): Promise<ActionResult>
+  listLocalRoutes(): Promise<{
+    routes: { local: DataChannelDefinition[]; internal: InternalRoute[] }
+  }>
+  listMetrics(): Promise<unknown>
+  listPeers(): Promise<{ peers: PeerInfo[] }>
+  deletePeer(peerId: string): Promise<ActionResult>
+}
+
+export async function createOrchestratorClient(
+  url: string = process.env.CATALYST_ORCHESTRATOR_URL || 'ws://localhost:3000/rpc'
+): Promise<OrchestratorPublicApi> {
+  return newWebSocketRpcSession<OrchestratorPublicApi>(url)
+}

--- a/packages/cli/tests/clients/auth-client.unit.test.ts
+++ b/packages/cli/tests/clients/auth-client.unit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test'
+import { createAuthClient } from '../../src/clients/auth-client.js'
+
+describe('Auth Client', () => {
+  it('should create client with default URL', async () => {
+    const client = await createAuthClient()
+    expect(client).toBeDefined()
+    expect(typeof client.tokens).toBe('function')
+    expect(typeof client.validation).toBe('function')
+  })
+
+  it('should create client with custom URL', async () => {
+    const client = await createAuthClient('ws://custom:4000/rpc')
+    expect(client).toBeDefined()
+    expect(typeof client.tokens).toBe('function')
+    expect(typeof client.validation).toBe('function')
+  })
+
+  it('should use CATALYST_AUTH_URL env var if set', async () => {
+    const originalEnv = process.env.CATALYST_AUTH_URL
+    process.env.CATALYST_AUTH_URL = 'ws://env-test:4000/rpc'
+
+    const client = await createAuthClient()
+    expect(client).toBeDefined()
+
+    // Restore env
+    if (originalEnv) {
+      process.env.CATALYST_AUTH_URL = originalEnv
+    } else {
+      delete process.env.CATALYST_AUTH_URL
+    }
+  })
+})

--- a/packages/cli/tests/clients/orchestrator-client.unit.test.ts
+++ b/packages/cli/tests/clients/orchestrator-client.unit.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test'
+import { createOrchestratorClient } from '../../src/clients/orchestrator-client.js'
+
+describe('Orchestrator Client', () => {
+  it('should create client with default URL', async () => {
+    const client = await createOrchestratorClient()
+    expect(client).toBeDefined()
+    expect(typeof client.connectionFromManagementSDK).toBe('function')
+  })
+
+  it('should create client with custom URL', async () => {
+    const client = await createOrchestratorClient('ws://custom:3000/rpc')
+    expect(client).toBeDefined()
+    expect(typeof client.connectionFromManagementSDK).toBe('function')
+  })
+
+  it('should use CATALYST_ORCHESTRATOR_URL env var if set', async () => {
+    const originalEnv = process.env.CATALYST_ORCHESTRATOR_URL
+    process.env.CATALYST_ORCHESTRATOR_URL = 'ws://env-test:3000/rpc'
+
+    const client = await createOrchestratorClient()
+    expect(client).toBeDefined()
+
+    // Restore env
+    if (originalEnv) {
+      process.env.CATALYST_ORCHESTRATOR_URL = originalEnv
+    } else {
+      delete process.env.CATALYST_ORCHESTRATOR_URL
+    }
+  })
+})


### PR DESCRIPTION
Create separate client modules for orchestrator and auth service RPC
communication as foundation for hierarchical CLI restructure.

Changes:
- Create clients/ directory with orchestrator-client.ts and auth-client.ts
- Add @catalyst/authorization dependency for token types
- Refactor existing client.ts logic into orchestrator-client.ts
- Add auth-client.ts for direct auth service communication
- Create unit tests for both clients (6 tests passing)
- Update package.json dependencies

This is Phase 1 of CLI restructure to support:
  cli node peer create/list/delete
  cli node route create/list/delete
  cli auth token mint/verify/revoke/list

Tests: 6/6 passing

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>