### PR TITLE
feat(cli): implement node route commands (create/list/delete)

### DIFF
--- a/packages/cli/src/commands/node/index.ts
+++ b/packages/cli/src/commands/node/index.ts
@@ -1,10 +1,12 @@
 import { Command } from 'commander'
 import { peerCommands } from './peer.js'
+import { routeCommands } from './route.js'
 
 export function nodeCommands(): Command {
   const node = new Command('node').description('Node management commands (peers, routes)')
 
   node.addCommand(peerCommands())
+  node.addCommand(routeCommands())
 
   return node
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -43,3 +43,25 @@ export const ListPeersInputSchema = BaseCliConfigSchema.extend({
   token: z.string().optional(),
 })
 export type ListPeersInput = z.infer<typeof ListPeersInputSchema>
+
+// Node Route Schemas
+export const CreateRouteInputSchema = BaseCliConfigSchema.extend({
+  name: z.string().min(1),
+  endpoint: z.string().url(),
+  protocol: z.enum(['http', 'http:graphql', 'http:gql', 'http:grpc']).default('http:graphql'),
+  region: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  token: z.string().optional(),
+})
+export type CreateRouteInput = z.infer<typeof CreateRouteInputSchema>
+
+export const DeleteRouteInputSchema = BaseCliConfigSchema.extend({
+  name: z.string().min(1),
+  token: z.string().optional(),
+})
+export type DeleteRouteInput = z.infer<typeof DeleteRouteInputSchema>
+
+export const ListRoutesInputSchema = BaseCliConfigSchema.extend({
+  token: z.string().optional(),
+})
+export type ListRoutesInput = z.infer<typeof ListRoutesInputSchema>


### PR DESCRIPTION
Add hierarchical `cli node route` commands with comprehensive testing.

New commands:
- cli node route create <name> <endpoint> [-p <protocol>] [--region] [--tags] [--token]
- cli node route list [--token]
- cli node route delete <name> [--token]

Implementation:
- Create commands/node/route.ts with create/list/delete subcommands
- Update node/index.ts to include route commands
- Update types.ts with route schemas (Zod validation)
- Use orchestrator ManagementScope RPC API (localRoute resource)
- Support protocol selection: http, http:graphql, http:gql, http:grpc
- Default protocol: http:graphql

Tests:
- Unit tests: 10 tests for command structure and arguments
- Container tests: Integration test with auth + orchestrator
- All tests passing (35/35 unit, container skipped without flag)

Phase 3 of CLI restructure.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>