### PR TITLE
feat(cli): implement auth token commands (mint/verify/revoke/list)

### DIFF
--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -65,3 +65,46 @@ export const ListRoutesInputSchema = BaseCliConfigSchema.extend({
   token: z.string().optional(),
 })
 export type ListRoutesInput = z.infer<typeof ListRoutesInputSchema>
+
+// Auth Token Schemas
+export const MintTokenInputSchema = z.object({
+  subject: z.string().min(1),
+  role: z.enum(['ADMIN', 'NODE', 'NODE_CUSTODIAN', 'DATA_CUSTODIAN', 'USER']),
+  name: z.string().min(1),
+  type: z.enum(['user', 'service']).default('user'),
+  expiresIn: z.string().optional(),
+  nodeId: z.string().optional(),
+  trustedDomains: z.array(z.string()).optional(),
+  trustedNodes: z.array(z.string()).optional(),
+  authUrl: z.string().url().optional(),
+  token: z.string().optional(),
+})
+export type MintTokenInput = z.infer<typeof MintTokenInputSchema>
+
+export const VerifyTokenInputSchema = z.object({
+  tokenToVerify: z.string().min(1),
+  audience: z.string().optional(),
+  authUrl: z.string().url().optional(),
+  token: z.string().optional(),
+})
+export type VerifyTokenInput = z.infer<typeof VerifyTokenInputSchema>
+
+export const RevokeTokenInputSchema = z
+  .object({
+    jti: z.string().optional(),
+    san: z.string().optional(),
+    authUrl: z.string().url().optional(),
+    token: z.string().optional(),
+  })
+  .refine((data) => data.jti || data.san, {
+    message: 'Either jti or san must be provided',
+  })
+export type RevokeTokenInput = z.infer<typeof RevokeTokenInputSchema>
+
+export const ListTokensInputSchema = z.object({
+  certificateFingerprint: z.string().optional(),
+  san: z.string().optional(),
+  authUrl: z.string().url().optional(),
+  token: z.string().optional(),
+})
+export type ListTokensInput = z.infer<typeof ListTokensInputSchema>


### PR DESCRIPTION
Add hierarchical `cli auth token` commands with comprehensive testing
and direct auth service integration.

New commands:
- cli auth token mint <subject> --role <role> [options]
- cli auth token verify <token-to-verify> [--audience] [--token]
- cli auth token revoke --jti <jti> | --san <san> [--token]
- cli auth token list [--cert-fingerprint] [--san] [--token]

Mint options: --name, --type, --expires-in, --node-id,
--trusted-domains, --trusted-nodes, --token

Implementation:
- Create commands/auth/ directory structure
- Add token.ts with mint/verify/revoke/list subcommands
- Add auth/index.ts command group
- Update types.ts with token schemas (Zod validation)
- Use auth service RPC API directly (not orchestrator proxy)
- Support role-based minting: ADMIN, NODE, NODE_CUSTODIAN,
  DATA_CUSTODIAN, USER
- Require CATALYST_AUTH_URL env var or --auth-url flag

Tests:
- Unit tests: 13 tests for command structure and arguments
- Container tests: 2 integration tests with auth service
  - Token lifecycle: mint, verify, list, revoke
  - Invalid token handling
- All tests passing (48/48 unit, container skipped without flag)

Phase 4 of CLI restructure.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>