### PR TITLE
refactor(cli): extract node peer handlers for testability

### DIFF
--- a/apps/cli/src/commands/auth/token.ts
+++ b/apps/cli/src/commands/auth/token.ts
@@ -62,7 +62,7 @@ export function tokenCommands(): Command {
         const tokensApi = await client.tokens(validation.data.token || '')
 
         if ('error' in tokensApi) {
-          console.error(chalk.red(`✗ Auth failed: ${tokensApi.error}`))
+          console.error(chalk.red(`[error] Auth failed: ${tokensApi.error}`))
           process.exit(1)
         }
 
@@ -81,11 +81,11 @@ export function tokenCommands(): Command {
           expiresIn: validation.data.expiresIn,
         })
 
-        console.log(chalk.green('✓ Token minted successfully:'))
+        console.log(chalk.green('[ok] Token minted successfully:'))
         console.log(newToken)
         process.exit(0)
       } catch (error) {
-        console.error(chalk.red(`✗ Error: ${error instanceof Error ? error.message : error}`))
+        console.error(chalk.red(`[error] Error: ${error instanceof Error ? error.message : error}`))
         process.exit(1)
       }
     })
@@ -124,7 +124,7 @@ export function tokenCommands(): Command {
         const validationApi = await client.validation(validation.data.token || '')
 
         if ('error' in validationApi) {
-          console.error(chalk.red(`✗ Auth failed: ${validationApi.error}`))
+          console.error(chalk.red(`[error] Auth failed: ${validationApi.error}`))
           process.exit(1)
         }
 
@@ -134,16 +134,16 @@ export function tokenCommands(): Command {
         })
 
         if (result.valid) {
-          console.log(chalk.green('✓ Token is valid'))
+          console.log(chalk.green('[ok] Token is valid'))
           console.log(chalk.cyan('Payload:'))
           console.log(JSON.stringify(result.payload, null, 2))
           process.exit(0)
         } else {
-          console.log(chalk.red(`✗ Token is invalid: ${result.error}`))
+          console.log(chalk.red(`[error] Token is invalid: ${result.error}`))
           process.exit(1)
         }
       } catch (error) {
-        console.error(chalk.red(`✗ Error: ${error instanceof Error ? error.message : error}`))
+        console.error(chalk.red(`[error] Error: ${error instanceof Error ? error.message : error}`))
         process.exit(1)
       }
     })
@@ -182,7 +182,7 @@ export function tokenCommands(): Command {
         const tokensApi = await client.tokens(validation.data.token || '')
 
         if ('error' in tokensApi) {
-          console.error(chalk.red(`✗ Auth failed: ${tokensApi.error}`))
+          console.error(chalk.red(`[error] Auth failed: ${tokensApi.error}`))
           process.exit(1)
         }
 
@@ -191,10 +191,10 @@ export function tokenCommands(): Command {
           san: validation.data.san,
         })
 
-        console.log(chalk.green('✓ Token revoked successfully.'))
+        console.log(chalk.green('[ok] Token revoked successfully.'))
         process.exit(0)
       } catch (error) {
-        console.error(chalk.red(`✗ Error: ${error instanceof Error ? error.message : error}`))
+        console.error(chalk.red(`[error] Error: ${error instanceof Error ? error.message : error}`))
         process.exit(1)
       }
     })
@@ -233,7 +233,7 @@ export function tokenCommands(): Command {
         const tokensApi = await client.tokens(validation.data.token || '')
 
         if ('error' in tokensApi) {
-          console.error(chalk.red(`✗ Auth failed: ${tokensApi.error}`))
+          console.error(chalk.red(`[error] Auth failed: ${tokensApi.error}`))
           process.exit(1)
         }
 
@@ -257,7 +257,7 @@ export function tokenCommands(): Command {
         }
         process.exit(0)
       } catch (error) {
-        console.error(chalk.red(`✗ Error: ${error instanceof Error ? error.message : error}`))
+        console.error(chalk.red(`[error] Error: ${error instanceof Error ? error.message : error}`))
         process.exit(1)
       }
     })

--- a/apps/cli/src/commands/node/peer.ts
+++ b/apps/cli/src/commands/node/peer.ts
@@ -40,10 +40,10 @@ export function peerCommands(): Command {
       const result = await createPeerHandler(validation.data)
 
       if (result.success) {
-        console.log(chalk.green(`✓ Peer '${result.data.name}' created successfully.`))
+        console.log(chalk.green(`[ok] Peer '${result.data.name}' created successfully.`))
         process.exit(0)
       } else {
-        console.error(chalk.red(`✗ Failed to create peer: ${result.error}`))
+        console.error(chalk.red(`[error] Failed to create peer: ${result.error}`))
         process.exit(1)
       }
     })
@@ -84,7 +84,7 @@ export function peerCommands(): Command {
         }
         process.exit(0)
       } else {
-        console.error(chalk.red(`✗ Error: ${result.error}`))
+        console.error(chalk.red(`[error] Error: ${result.error}`))
         process.exit(1)
       }
     })
@@ -113,10 +113,10 @@ export function peerCommands(): Command {
       const result = await deletePeerHandler(validation.data)
 
       if (result.success) {
-        console.log(chalk.green(`✓ Peer '${result.data.name}' deleted.`))
+        console.log(chalk.green(`[ok] Peer '${result.data.name}' deleted.`))
         process.exit(0)
       } else {
-        console.error(chalk.red(`✗ Failed to delete peer: ${result.error}`))
+        console.error(chalk.red(`[error] Failed to delete peer: ${result.error}`))
         process.exit(1)
       }
     })

--- a/apps/cli/src/commands/node/route.ts
+++ b/apps/cli/src/commands/node/route.ts
@@ -60,14 +60,14 @@ export function routeCommands(): Command {
         })
 
         if (result.success) {
-          console.log(chalk.green(`✓ Route '${name}' created successfully.`))
+          console.log(chalk.green(`[ok] Route '${name}' created successfully.`))
           process.exit(0)
         } else {
-          console.error(chalk.red(`✗ Failed to create route: ${result.error}`))
+          console.error(chalk.red(`[error] Failed to create route: ${result.error}`))
           process.exit(1)
         }
       } catch (error) {
-        console.error(chalk.red(`✗ Error: ${error instanceof Error ? error.message : error}`))
+        console.error(chalk.red(`[error] Error: ${error instanceof Error ? error.message : error}`))
         process.exit(1)
       }
     })
@@ -116,7 +116,7 @@ export function routeCommands(): Command {
         }
         process.exit(0)
       } catch (error) {
-        console.error(chalk.red(`✗ Error: ${error instanceof Error ? error.message : error}`))
+        console.error(chalk.red(`[error] Error: ${error instanceof Error ? error.message : error}`))
         process.exit(1)
       }
     })
@@ -155,14 +155,14 @@ export function routeCommands(): Command {
         })
 
         if (result.success) {
-          console.log(chalk.green(`✓ Route '${name}' deleted.`))
+          console.log(chalk.green(`[ok] Route '${name}' deleted.`))
           process.exit(0)
         } else {
-          console.error(chalk.red(`✗ Failed to delete route: ${result.error}`))
+          console.error(chalk.red(`[error] Failed to delete route: ${result.error}`))
           process.exit(1)
         }
       } catch (error) {
-        console.error(chalk.red(`✗ Error: ${error instanceof Error ? error.message : error}`))
+        console.error(chalk.red(`[error] Error: ${error instanceof Error ? error.message : error}`))
         process.exit(1)
       }
     })

--- a/apps/gateway/scripts/test-rpc.ts
+++ b/apps/gateway/scripts/test-rpc.ts
@@ -37,13 +37,13 @@ async function main() {
     console.log('Result:', result)
 
     if (result.success) {
-      console.log('✅ Configuration update successful!')
+      console.log('[ok] Configuration update successful!')
     } else {
-      console.error('❌ Configuration update failed:', result.error)
+      console.error('[error] Configuration update failed:', result.error)
       process.exit(1)
     }
   } catch (error) {
-    console.error('❌ RPC Call failed:', error)
+    console.error('[error] RPC Call failed:', error)
     process.exit(1)
   } finally {
     ws.close()

--- a/apps/orchestrator/src/service.ts
+++ b/apps/orchestrator/src/service.ts
@@ -1,4 +1,3 @@
-import { Role } from '@catalyst/authorization'
 import { newRpcResponse } from '@hono/capnweb'
 import { newWebSocketRpcSession } from 'capnweb'
 import { Principal } from '@catalyst/authorization'
@@ -113,7 +112,7 @@ export class OrchestratorService extends CatalystService {
 
   private async mintNodeToken(): Promise<void> {
     if (!this.config.orchestrator?.auth) {
-      this.telemetry.logger.info`No auth service configured — skipping node token mint`
+      this.telemetry.logger.info`No auth service configured -- skipping node token mint`
       return
     }
 

--- a/apps/orchestrator/tests/auth-test-helpers.ts
+++ b/apps/orchestrator/tests/auth-test-helpers.ts
@@ -155,6 +155,6 @@ export async function mintPeerToken(
     expiresIn: '1h',
   })
 
-  console.log(`✓ Peer token minted for ${peerName}: ${peerToken.substring(0, 20)}...`)
+  console.log(`[ok] Peer token minted for ${peerName}: ${peerToken.substring(0, 20)}...`)
   return peerToken
 }

--- a/apps/orchestrator/tests/peering.orchestrator.topology.container.test.ts
+++ b/apps/orchestrator/tests/peering.orchestrator.topology.container.test.ts
@@ -161,14 +161,14 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
 
         expect(invalidOnA.success).toBe(false)
         expect(invalidOnB.success).toBe(false)
-        console.log('✓ Invalid tokens correctly rejected')
+        console.log('[ok] Invalid tokens correctly rejected')
 
         // Valid shared token works on both nodes
         const validOnA = await clientA.getNetworkClient(auth.systemToken)
         const validOnB = await clientB.getNetworkClient(auth.systemToken)
         expect(validOnA.success).toBe(true)
         expect(validOnB.success).toBe(true)
-        console.log('✓ Shared auth token works on all nodes')
+        console.log('[ok] Shared auth token works on all nodes')
       },
       TIMEOUT
     )
@@ -221,7 +221,7 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
         if (!dataBBefore.success) throw new Error('Failed to get data client B')
         const routesBefore = await dataBBefore.client.listRoutes()
         expect(routesBefore.internal.some((r) => r.name === 'service-a')).toBe(false)
-        console.log('✓ Confirmed route not on B before propagation')
+        console.log('[ok] Confirmed route not on B before propagation')
 
         const routeResult = await dataAResult.client.addRoute({
           name: 'service-a',
@@ -233,7 +233,7 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
           console.error('Route create failed:', routeResult)
           throw new Error(`Route create failed: ${routeResult.error || 'Unknown error'}`)
         }
-        console.log('✓ Route added on A')
+        console.log('[ok] Route added on A')
 
         // Check B learned it
         let learnedOnB = false
@@ -250,12 +250,12 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
           await new Promise((r) => setTimeout(r, 500))
         }
         expect(learnedOnB).toBe(true)
-        console.log('✓ Route propagated to B')
+        console.log('[ok] Route propagated to B')
 
         // Verify route details match
         expect(matchingRoute.endpoint).toBe('http://a:8080')
         expect(matchingRoute.protocol).toBe('http')
-        console.log('✓ Route details match')
+        console.log('[ok] Route details match')
       },
       TIMEOUT
     )
@@ -362,11 +362,11 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
         // Each token works on its own node
         const netAResult = await clientA.getNetworkClient(authA.systemToken)
         expect(netAResult.success).toBe(true)
-        console.log('✓ Node A authenticated with auth-a token')
+        console.log('[ok] Node A authenticated with auth-a token')
 
         const netBResult = await clientB.getNetworkClient(authB.systemToken)
         expect(netBResult.success).toBe(true)
-        console.log('✓ Node B authenticated with auth-b token')
+        console.log('[ok] Node B authenticated with auth-b token')
 
         // SECURITY TEST: Verify cross-auth tokens are rejected (no SKIP_AUTH)
         console.log('Testing cross-auth token rejection...')
@@ -376,7 +376,7 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
         // Without SKIP_AUTH, cross-auth tokens should be rejected
         expect(crossAuthAtoB.success).toBe(false)
         expect(crossAuthBtoA.success).toBe(false)
-        console.log('✓ Cross-auth tokens correctly rejected')
+        console.log('[ok] Cross-auth tokens correctly rejected')
 
         // SECURITY TEST: Verify invalid tokens are rejected
         const invalidToken = 'completely-invalid-token'
@@ -384,7 +384,7 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
         const invalidOnB = await clientB.getNetworkClient(invalidToken)
         expect(invalidOnA.success).toBe(false)
         expect(invalidOnB.success).toBe(false)
-        console.log('✓ Invalid tokens correctly rejected')
+        console.log('[ok] Invalid tokens correctly rejected')
       },
       TIMEOUT
     )
@@ -471,7 +471,7 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
         if (!dataBBefore.success) throw new Error('Failed to get data client B')
         const routesBefore = await dataBBefore.client.listRoutes()
         expect(routesBefore.internal.some((r) => r.name === 'service-separate-auth')).toBe(false)
-        console.log('✓ Confirmed route not on B before propagation')
+        console.log('[ok] Confirmed route not on B before propagation')
 
         const routeResult = await dataAResult.client.addRoute({
           name: 'service-separate-auth',
@@ -482,7 +482,7 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
         if (!routeResult.success) {
           throw new Error(`Route create failed: ${routeResult.error || 'Unknown error'}`)
         }
-        console.log('✓ Route added on A with separate auth')
+        console.log('[ok] Route added on A with separate auth')
 
         // Check B learned it
         let learnedOnB = false
@@ -499,12 +499,12 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
           await new Promise((r) => setTimeout(r, 500))
         }
         expect(learnedOnB).toBe(true)
-        console.log('✓ Route propagated to B with separate auth')
+        console.log('[ok] Route propagated to B with separate auth')
 
         // Verify route details match
         expect(matchingRoute.endpoint).toBe('http://separate:9090')
         expect(matchingRoute.protocol).toBe('http')
-        console.log('✓ Route details match with separate auth')
+        console.log('[ok] Route details match with separate auth')
       },
       TIMEOUT
     )


### PR DESCRIPTION
Extract business logic from Commander actions into testable handler
functions. This enables unit testing without running the CLI.

Phase 1 of handler extraction.

Changes:
- Create handlers/node-peer-handlers.ts with extracted logic:
  - createPeerHandler(input): Promise<CreatePeerResult>
  - listPeersHandler(input): Promise<ListPeersResult>
  - deletePeerHandler(input): Promise<DeletePeerResult>
- Update commands/node/peer.ts to use handlers
- Add unit tests: handlers/node-peer-handlers.test.ts (9 tests)
- Handlers return discriminated unions { success, data/error }
- Handlers are pure functions (no process.exit, no console output)

Benefits:
- Handlers can be tested independently of Commander
- Business logic separated from CLI presentation
- Easier to mock RPC calls in tests
- Consistent error handling pattern

Tests: 47/47 passing (38 command tests + 9 new handler tests)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>