### PR TITLE
feat(gateway): integrate telemetry for structured observability

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -142,11 +142,13 @@
       "name": "@catalyst/gateway",
       "version": "0.0.0",
       "dependencies": {
+        "@catalyst/telemetry": "workspace:*",
         "@graphql-tools/delegate": "catalog:",
         "@graphql-tools/stitch": "catalog:",
         "@graphql-tools/utils": "catalog:",
         "@graphql-tools/wrap": "catalog:",
         "@hono/capnweb": "catalog:",
+        "@opentelemetry/api": "catalog:",
         "capnweb": "catalog:",
         "graphql": "catalog:",
         "graphql-yoga": "catalog:",
@@ -214,6 +216,35 @@
         "vitest": "catalog:testing",
       },
     },
+    "packages/telemetry": {
+      "name": "@catalyst/telemetry",
+      "version": "0.0.0",
+      "dependencies": {
+        "@logtape/logtape": "^0.12.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.200.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.200.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.200.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
+        "@opentelemetry/resources": "^2.0.0",
+        "@opentelemetry/sdk-logs": "^0.200.0",
+        "@opentelemetry/sdk-metrics": "^2.0.0",
+        "@opentelemetry/sdk-trace-node": "^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
+      },
+      "devDependencies": {
+        "@types/bun": "catalog:dev",
+        "hono": "^4.11.7",
+        "typescript": "catalog:dev",
+      },
+      "peerDependencies": {
+        "hono": ">=4.0.0",
+      },
+      "optionalPeers": [
+        "hono",
+      ],
+    },
     "packages/types": {
       "name": "@catalyst/types",
       "version": "0.0.0",
@@ -250,6 +281,7 @@
     "@graphql-tools/wrap": "^11.1.4",
     "@hono/capnweb": "^0.1.0",
     "@hono/node-server": "^1.19.7",
+    "@opentelemetry/api": "^1.9.0",
     "argon2": "^0.44.0",
     "capnweb": "^0.4.0",
     "chalk": "^5.3.0",
@@ -398,6 +430,8 @@
     "@catalyst/orchestrator": ["@catalyst/orchestrator@workspace:packages/orchestrator"],
 
     "@catalyst/sdk": ["@catalyst/sdk@workspace:packages/sdk"],
+
+    "@catalyst/telemetry": ["@catalyst/telemetry@workspace:packages/telemetry"],
 
     "@catalyst/types": ["@catalyst/types@workspace:packages/types"],
 
@@ -580,6 +614,36 @@
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
     "@logtape/logtape": ["@logtape/logtape@2.0.2", "", {}, "sha512-cveUBLbCMFkvkLycP/2vNWvywl47JcJbazHIju94/QNGboZ/jyYAgZIm0ZXezAOx3eIz8OG1EOZ5CuQP3+2FQg=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.200.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q=="],
+
+    "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.5.0", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-uOXpVX0ZjO7heSVjhheW2XEPrhQAWr2BScDPoZ9UDycl5iuHG+Usyc3AIfG6kZeC1GyLpMInpQ6X5+9n69yOFw=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.5.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ=="],
+
+    "@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.200.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.200.0", "@opentelemetry/core": "2.0.0", "@opentelemetry/otlp-exporter-base": "0.200.0", "@opentelemetry/otlp-transformer": "0.200.0", "@opentelemetry/sdk-logs": "0.200.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-KfWw49htbGGp9s8N4KI8EQ9XuqKJ0VG+yVYVYFiCYSjEV32qpQ5qZ9UZBzOZ6xRb+E16SXOSCT3RkqBVSABZ+g=="],
+
+    "@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.200.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/otlp-exporter-base": "0.200.0", "@opentelemetry/otlp-transformer": "0.200.0", "@opentelemetry/resources": "2.0.0", "@opentelemetry/sdk-metrics": "2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-5BiR6i8yHc9+qW7F6LqkuUnIzVNA7lt0qRxIKcKT+gq3eGUPHZ3DY29sfxI3tkvnwMgtnHDMNze5DdxW39HsAw=="],
+
+    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.200.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/otlp-exporter-base": "0.200.0", "@opentelemetry/otlp-transformer": "0.200.0", "@opentelemetry/resources": "2.0.0", "@opentelemetry/sdk-trace-base": "2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Goi//m/7ZHeUedxTGVmEzH19NgqJY+Bzr6zXo1Rni1+hwqaksEyJ44gdlEMREu6dzX1DlAaH/qSykSVzdrdafA=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.200.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/otlp-transformer": "0.200.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-IxJgA3FD7q4V6gGq4bnmQM5nTIyMDkoGFGrBrrDjB6onEiq1pafma55V+bHvGYLWvcqbBbRfezr1GED88lacEQ=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.200.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.200.0", "@opentelemetry/core": "2.0.0", "@opentelemetry/resources": "2.0.0", "@opentelemetry/sdk-logs": "0.200.0", "@opentelemetry/sdk-metrics": "2.0.0", "@opentelemetry/sdk-trace-base": "2.0.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-+9YDZbYybOnv7sWzebWOeK6gKyt2XE7iarSyBFkwwnP559pEevKOUD8NyDHhRjCSp13ybh9iVXlMfcj/DwF/yw=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.5.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.200.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.200.0", "@opentelemetry/core": "2.0.0", "@opentelemetry/resources": "2.0.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-VZG870063NLfObmQQNtCVcdXXLzI3vOjjrRENmU37HYiPFa0ZXpXVDsTD02Nh3AT3xYJzQaWKl2X2lQ2l7TWJA=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.5.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/resources": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.0.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/resources": "2.0.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw=="],
+
+    "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@2.5.0", "", { "dependencies": { "@opentelemetry/context-async-hooks": "2.5.0", "@opentelemetry/core": "2.5.0", "@opentelemetry/sdk-trace-base": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-O6N/ejzburFm2C84aKNrwJVPpt6HSTSq8T0ZUMq3xT2XmqT4cwxUItcL5UWGThYuq8RTcbH8u1sfj6dmRci0Ow=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.39.0", "", {}, "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg=="],
 
     "@phc/format": ["@phc/format@1.0.0", "", {}, "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ=="],
 
@@ -1585,25 +1649,39 @@
 
     "@catalyst/auth/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
+    "@catalyst/auth/hono": ["hono@4.11.7", "", {}, "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw=="],
+
     "@catalyst/authorization/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
     "@catalyst/cli/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
     "@catalyst/config/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
+    "@catalyst/examples/hono": ["hono@4.11.7", "", {}, "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw=="],
+
     "@catalyst/examples/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
 
     "@catalyst/gateway/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
+
+    "@catalyst/gateway/hono": ["hono@4.11.7", "", {}, "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw=="],
 
     "@catalyst/gateway/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
 
     "@catalyst/node/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
+    "@catalyst/node/hono": ["hono@4.11.7", "", {}, "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw=="],
+
     "@catalyst/node/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
+
+    "@catalyst/orchestrator/hono": ["hono@4.11.7", "", {}, "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw=="],
 
     "@catalyst/orchestrator/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
 
     "@catalyst/sdk/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
+
+    "@catalyst/telemetry/@logtape/logtape": ["@logtape/logtape@0.12.3", "", {}, "sha512-LNIYAQ3CbIBPDVlKz25g8ix47iYnJhkI93cPs8WWANLB1cBxdhNb2ibWg1gKZtenR72grDXFLM49Ci+7sYjUmQ=="],
+
+    "@catalyst/telemetry/hono": ["hono@4.11.7", "", {}, "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw=="],
 
     "@catalyst/types/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
@@ -1622,6 +1700,36 @@
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "@opentelemetry/exporter-logs-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
+
+    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
+
+    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/resources": ["@opentelemetry/resources@2.0.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg=="],
+
+    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.0.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/resources": "2.0.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA=="],
+
+    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
+
+    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/resources": ["@opentelemetry/resources@2.0.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg=="],
+
+    "@opentelemetry/otlp-exporter-base/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/resources": ["@opentelemetry/resources@2.0.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.0.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/resources": "2.0.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA=="],
+
+    "@opentelemetry/sdk-logs/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
+
+    "@opentelemetry/sdk-logs/@opentelemetry/resources": ["@opentelemetry/resources@2.0.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg=="],
+
+    "@opentelemetry/sdk-trace-base/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
+
+    "@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.0.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg=="],
+
+    "@opentelemetry/sdk-trace-node/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.5.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/resources": "2.5.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-VzRf8LzotASEyNDUxTdaJ9IRJ1/h692WyArDBInf5puLCjxbICD6XkHgpuudis56EndyS7LYFmtTMny6UABNdQ=="],
 
     "@types/chai/assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,6 +34,7 @@ export default tseslint.config(
       ],
       '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-expressions': ['error', { allowTaggedTemplates: true }],
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
       "jose": "^6.0.0",
       "argon2": "^0.44.0",
       "@cedar-policy/cedar-wasm": "^4.8.2",
+      "@opentelemetry/api": "^1.9.0",
       "chalk": "^5.3.0",
       "inquirer": "^9.2.14",
       "ws": "^8.19.0",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -19,7 +19,9 @@
     "graphql": "catalog:",
     "graphql-yoga": "catalog:",
     "hono": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "@catalyst/telemetry": "workspace:*",
+    "@opentelemetry/api": "catalog:"
   },
   "devDependencies": {
     "@types/bun": "catalog:dev",

--- a/packages/gateway/src/graphql/server.ts
+++ b/packages/gateway/src/graphql/server.ts
@@ -1,6 +1,10 @@
 import { Hono } from 'hono'
 import { createYoga, createSchema } from 'graphql-yoga'
 import { stitchSchemas } from '@graphql-tools/stitch'
+import { context, propagation, SpanKind, SpanStatusCode } from '@opentelemetry/api'
+import type { Counter, Histogram, UpDownCounter } from '@opentelemetry/api'
+import { TelemetryBuilder } from '@catalyst/telemetry'
+import type { ServiceTelemetry } from '@catalyst/telemetry'
 
 import type { AsyncExecutor, Executor } from '@graphql-tools/utils'
 import {
@@ -15,13 +19,37 @@ import type { GatewayConfig } from '../rpc/server.js'
 
 export class GatewayGraphqlServer {
   private yoga: ReturnType<typeof createYoga> | null = null
+  private readonly telemetry: ServiceTelemetry
+  private readonly logger: ServiceTelemetry['logger']
+  private readonly reloadCounter: Counter
+  private readonly reloadDuration: Histogram
+  private readonly activeSubgraphs: UpDownCounter
+  private currentSubgraphCount = 0
 
-  constructor() {
+  constructor(telemetry: ServiceTelemetry = TelemetryBuilder.noop('gateway')) {
+    this.telemetry = telemetry
+    this.logger = telemetry.logger.getChild('graphql')
+
+    this.reloadCounter = telemetry.meter.createCounter('gateway.schema.reload.count', {
+      description: 'Number of schema reload attempts',
+      unit: '{reload}',
+    })
+    this.reloadDuration = telemetry.meter.createHistogram('gateway.schema.reload.duration', {
+      description: 'Duration of schema reload operations',
+      unit: 's',
+    })
+    this.activeSubgraphs = telemetry.meter.createUpDownCounter('gateway.subgraph.active', {
+      description: 'Number of active subgraph services',
+      unit: '{subgraph}',
+    })
+
     // Initialize with a default health check schema
     this.createYogaInstance([
       {
         typeDefs: 'type Query { status: String }',
-        resolvers: { Query: { status: () => 'Waiting for configuration...' } },
+        resolvers: {
+          Query: { status: () => 'Waiting for configuration...' },
+        },
       },
     ])
   }
@@ -29,7 +57,8 @@ export class GatewayGraphqlServer {
   async reload(
     config: GatewayConfig
   ): Promise<{ success: true } | { success: false; error: string }> {
-    console.log('Reloading gateway with new config...', config)
+    this.logger.info`Reloading with ${config.services.length} services`
+    const startTime = performance.now()
 
     try {
       const subschemas = await Promise.all(
@@ -47,13 +76,21 @@ export class GatewayGraphqlServer {
       )
 
       if (subschemas.length === 0) {
-        console.warn('No services configured, reverting to default status schema.')
+        this.logger.warn`No services configured, using default schema`
         this.createYogaInstance([
           {
             typeDefs: 'type Query { status: String }',
-            resolvers: { Query: { status: () => 'No services configured.' } },
+            resolvers: {
+              Query: { status: () => 'No services configured.' },
+            },
           },
         ])
+        const durationS = (performance.now() - startTime) / 1000
+        this.reloadCounter.add(1, { result: 'success' })
+        this.reloadDuration.record(durationS)
+        const newCount = 0
+        this.activeSubgraphs.add(newCount - this.currentSubgraphCount)
+        this.currentSubgraphCount = newCount
         return { success: true }
       }
 
@@ -62,11 +99,24 @@ export class GatewayGraphqlServer {
       })
 
       this.createYogaInstance({ schema: stitchedSchema })
-      console.log('Gateway reloaded successfully.')
+
+      const durationS = (performance.now() - startTime) / 1000
+      this.reloadCounter.add(1, { result: 'success' })
+      this.reloadDuration.record(durationS)
+      const newCount = subschemas.length
+      this.activeSubgraphs.add(newCount - this.currentSubgraphCount)
+      this.currentSubgraphCount = newCount
+
+      const durationMs = Math.round(durationS * 1000)
+      this.logger.info`Reloaded successfully in ${durationMs}ms`
       return { success: true }
     } catch (error: unknown) {
-      console.error('Failed to reload gateway:', error)
+      const durationS = (performance.now() - startTime) / 1000
+      this.reloadCounter.add(1, { result: 'failure' })
+      this.reloadDuration.record(durationS)
+
       const message = error instanceof Error ? error.message : String(error)
+      this.logger.error`Reload failed: ${message}`
       // We do NOT update the yoga instance here, effectively keeping the last known good config.
       return { success: false, error: message }
     }
@@ -105,23 +155,54 @@ export class GatewayGraphqlServer {
   }
 
   private createRemoteExecutor(url: string, token?: string): AsyncExecutor {
+    const tracer = this.telemetry.tracer
+    const hostname = new URL(url).hostname
     return async ({ document, variables, operationName, extensions }) => {
       const query = print(document)
-      const fetchResult = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
-        body: JSON.stringify({ query, variables, operationName, extensions }),
-      })
-      return fetchResult.json()
+      return tracer.startActiveSpan(
+        `gateway subgraph ${hostname}`,
+        { kind: SpanKind.CLIENT, attributes: { 'url.full': url } },
+        async (span) => {
+          const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          }
+          // Inject W3C traceparent into outbound headers
+          propagation.inject(context.active(), headers)
+
+          try {
+            const res = await fetch(url, {
+              method: 'POST',
+              headers,
+              body: JSON.stringify({
+                query,
+                variables,
+                operationName,
+                extensions,
+              }),
+            })
+            const result = await res.json()
+            span.end()
+            return result
+          } catch (err) {
+            span.recordException(err as Error)
+            span.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: err instanceof Error ? err.message : String(err),
+            })
+            span.end()
+            throw err
+          }
+        }
+      )
     }
   }
 
   private async fetchRemoteSchema(executor: Executor) {
-    const result = (await executor({ document: parse(getIntrospectionQuery()) })) as {
+    const result = (await executor({
+      document: parse(getIntrospectionQuery()),
+    })) as {
       data?: unknown
       errors?: { message: string }[]
     }
@@ -132,37 +213,56 @@ export class GatewayGraphqlServer {
   }
 
   private async validateServiceSdl(url: string, token?: string) {
-    try {
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
-        body: JSON.stringify({ query: 'query { _sdl }' }),
-      })
+    const tracer = this.telemetry.tracer
+    const hostname = new URL(url).hostname
+    return tracer.startActiveSpan(
+      `gateway validate-sdl ${hostname}`,
+      { kind: SpanKind.CLIENT, attributes: { 'url.full': url } },
+      async (span) => {
+        try {
+          const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          }
+          propagation.inject(context.active(), headers)
 
-      if (!res.ok) {
-        throw new Error(`Service returned status ${res.status}`)
-      }
+          const res = await fetch(url, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({ query: 'query { _sdl }' }),
+          })
 
-      const result = (await res.json()) as {
-        data?: { _sdl?: string }
-        errors?: { message: string }[]
-      }
-      if (result.errors) {
-        throw new Error(result.errors.map((e) => e.message).join(', '))
-      }
+          if (!res.ok) {
+            throw new Error(`Service returned status ${res.status}`)
+          }
 
-      const sdl = result.data?._sdl
-      if (!sdl || typeof sdl !== 'string' || sdl.trim().length === 0) {
-        throw new Error('Service returned empty or invalid SDL')
+          const result = (await res.json()) as {
+            data?: { _sdl?: string }
+            errors?: { message: string }[]
+          }
+          if (result.errors) {
+            throw new Error(result.errors.map((e) => e.message).join(', '))
+          }
+
+          const sdl = result.data?._sdl
+          if (!sdl || typeof sdl !== 'string' || sdl.trim().length === 0) {
+            throw new Error('Service returned empty or invalid SDL')
+          }
+
+          span.end()
+        } catch (error: unknown) {
+          const message = error instanceof Error ? error.message : String(error)
+          span.recordException(error as Error)
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message,
+          })
+          span.end()
+          throw new Error(`Service validation failed for ${url}: ${message}`)
+        }
       }
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error)
-      throw new Error(`Service validation failed for ${url}: ${message}`)
-    }
+    )
   }
 }
 

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,32 +1,65 @@
 import { Hono } from 'hono'
 import { websocket } from 'hono/bun'
-import { createGatewayHandler } from './graphql/server.js'
+import { TelemetryBuilder, shutdownTelemetry } from '@catalyst/telemetry'
+import type { ServiceTelemetry } from '@catalyst/telemetry'
+import { telemetryMiddleware } from '@catalyst/telemetry/middleware/hono'
+import { GatewayGraphqlServer, createGatewayHandler } from './graphql/server.js'
 import { GatewayRpcServer, createRpcHandler } from './rpc/server.js'
 
-const app = new Hono()
-
-const { app: graphqlApp, server: gateway } = createGatewayHandler()
-
-// Initialize the RPC server logic
-const rpcServer = new GatewayRpcServer(async (config) => {
-  return gateway.reload(config)
-})
-const rpcApp = createRpcHandler(rpcServer)
-
-// Root endpoint
-app.get('/', (c) => c.text('Catalyst GraphQL Gateway is running.'))
-
-// Mount the sub-apps
-app.route('/graphql', graphqlApp)
-app.route('/api', rpcApp)
-
 const port = Number(process.env.PORT) || 4000
-console.log(`Starting server on port ${port}...`)
-console.log('GATEWAY_STARTED')
 
-export default {
-  fetch: app.fetch,
-  port,
-  hostname: '0.0.0.0',
-  websocket,
+async function main() {
+  // Initialize telemetry before server starts
+  let telemetry: ServiceTelemetry
+  try {
+    telemetry = await new TelemetryBuilder('gateway')
+      .withLogger({ category: ['catalyst', 'gateway'] })
+      .withMetrics()
+      .withTracing()
+      .withRpcInstrumentation()
+      .build()
+  } catch (err) {
+    // Non-fatal telemetry failure — stderr is acceptable here since
+    // the logger isn't available yet (bootstrap chicken-and-egg).
+    process.stderr.write(`[gateway] telemetry init failed, falling back to noop: ${err}\n`)
+    telemetry = TelemetryBuilder.noop('gateway')
+  }
+
+  const { logger } = telemetry
+
+  const app = new Hono()
+
+  // HTTP telemetry middleware (before routes)
+  // @ts-expect-error -- TODO: hono peer dep causes MiddlewareHandler generic mismatch across packages
+  app.use(telemetryMiddleware({ ignorePaths: ['/', '/health'] }))
+
+  // Construct with DI
+  const { app: graphqlApp, server: gateway } = createGatewayHandler(
+    new GatewayGraphqlServer(telemetry)
+  )
+
+  // Wrap RPC server with instrumentation
+  const rpcServer = new GatewayRpcServer(async (config) => gateway.reload(config), telemetry)
+  const instrumentedRpc = telemetry.instrumentRpc(rpcServer)
+  const rpcApp = createRpcHandler(instrumentedRpc)
+
+  // Mount routes
+  app.get('/', (c) => c.text('Catalyst GraphQL Gateway is running.'))
+  app.route('/graphql', graphqlApp)
+  app.route('/api', rpcApp)
+
+  // Graceful shutdown
+  const shutdown = async () => {
+    await shutdownTelemetry()
+    process.exit(0)
+  }
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+
+  logger.info`Gateway starting on port ${port}`
+  logger.info`Gateway started`
+
+  return { fetch: app.fetch, port, hostname: '0.0.0.0', websocket }
 }
+
+export default await main()

--- a/packages/gateway/tests/telemetry.unit.test.ts
+++ b/packages/gateway/tests/telemetry.unit.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, mock, afterEach } from 'bun:test'
+import { trace } from '@opentelemetry/api'
+import type { Logger } from '@logtape/logtape'
+import type { Meter } from '@opentelemetry/api'
+import type { ServiceTelemetry } from '@catalyst/telemetry'
+import { GatewayGraphqlServer } from '../src/graphql/server.js'
+
+// ---------------------------------------------------------------------------
+// Spy factory — builds a ServiceTelemetry with observable instruments
+// ---------------------------------------------------------------------------
+
+function createSpyTelemetry() {
+  const childLogger = {
+    debug: mock(() => {}),
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    fatal: mock(() => {}),
+    getChild: mock(() => childLogger),
+  }
+
+  const getChildSpy = mock(() => childLogger)
+
+  const logger = {
+    debug: mock(() => {}),
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    fatal: mock(() => {}),
+    getChild: getChildSpy,
+  }
+
+  const counterAddSpy = mock(() => {})
+  const histogramRecordSpy = mock(() => {})
+  const upDownCounterAddSpy = mock(() => {})
+
+  const createCounterSpy = mock(() => ({ add: counterAddSpy }))
+  const createHistogramSpy = mock(() => ({ record: histogramRecordSpy }))
+  const createUpDownCounterSpy = mock(() => ({ add: upDownCounterAddSpy }))
+
+  const meter = {
+    createCounter: createCounterSpy,
+    createHistogram: createHistogramSpy,
+    createUpDownCounter: createUpDownCounterSpy,
+    createObservableCounter: mock(() => ({})),
+    createObservableGauge: mock(() => ({})),
+    createObservableUpDownCounter: mock(() => ({})),
+    createGauge: mock(() => ({})),
+  }
+
+  const telemetry: ServiceTelemetry = {
+    serviceName: 'gateway',
+    logger: logger as unknown as Logger,
+    meter: meter as unknown as Meter,
+    tracer: trace.getTracer('test-noop'),
+    instrumentRpc: <T extends object>(t: T) => t,
+  }
+
+  return {
+    telemetry,
+    spies: {
+      getChild: getChildSpy,
+      childLogger,
+      counterAdd: counterAddSpy,
+      histogramRecord: histogramRecordSpy,
+      upDownCounterAdd: upDownCounterAddSpy,
+      createCounter: createCounterSpy,
+      createHistogram: createHistogramSpy,
+      createUpDownCounter: createUpDownCounterSpy,
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GatewayGraphqlServer telemetry DI', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('constructor calls telemetry.logger.getChild("graphql")', () => {
+    const { telemetry, spies } = createSpyTelemetry()
+    new GatewayGraphqlServer(telemetry)
+
+    expect(spies.getChild).toHaveBeenCalledTimes(1)
+    expect(spies.getChild).toHaveBeenCalledWith('graphql')
+  })
+
+  it('constructor creates metric instruments from the provided meter', () => {
+    const { telemetry, spies } = createSpyTelemetry()
+    new GatewayGraphqlServer(telemetry)
+
+    expect(spies.createCounter).toHaveBeenCalledWith(
+      'gateway.schema.reload.count',
+      expect.objectContaining({ description: expect.any(String) })
+    )
+    expect(spies.createHistogram).toHaveBeenCalledWith(
+      'gateway.schema.reload.duration',
+      expect.objectContaining({ description: expect.any(String) })
+    )
+    expect(spies.createUpDownCounter).toHaveBeenCalledWith(
+      'gateway.subgraph.active',
+      expect.objectContaining({ description: expect.any(String) })
+    )
+  })
+
+  it('reload() with empty services records success metrics', async () => {
+    const { telemetry, spies } = createSpyTelemetry()
+    const server = new GatewayGraphqlServer(telemetry)
+
+    const result = await server.reload({ services: [] })
+
+    expect(result).toEqual({ success: true })
+    expect(spies.counterAdd).toHaveBeenCalledWith(1, { result: 'success' })
+    expect(spies.histogramRecord).toHaveBeenCalledWith(expect.any(Number))
+  })
+
+  it('reload() with unreachable service records failure metrics', async () => {
+    const { telemetry, spies } = createSpyTelemetry()
+    const server = new GatewayGraphqlServer(telemetry)
+
+    // Mock fetch to reject — simulates unreachable service
+    globalThis.fetch = mock(() =>
+      Promise.reject(new Error('ECONNREFUSED'))
+    ) as unknown as typeof globalThis.fetch
+
+    const result = await server.reload({
+      services: [{ name: 'bad', url: 'http://fail.test/graphql' }],
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBeTypeOf('string')
+    }
+    expect(spies.counterAdd).toHaveBeenCalledWith(1, { result: 'failure' })
+    expect(spies.histogramRecord).toHaveBeenCalledWith(expect.any(Number))
+  })
+
+  it('reload() updates active subgraph gauge correctly', async () => {
+    const { telemetry, spies } = createSpyTelemetry()
+    const server = new GatewayGraphqlServer(telemetry)
+
+    // First reload with empty services → delta should be 0 (0 - 0)
+    await server.reload({ services: [] })
+    expect(spies.upDownCounterAdd).toHaveBeenCalledWith(0)
+
+    // Clear spies to isolate second call
+    spies.upDownCounterAdd.mockClear()
+
+    // Second reload still empty → delta should be 0 again (0 - 0)
+    await server.reload({ services: [] })
+    expect(spies.upDownCounterAdd).toHaveBeenCalledWith(0)
+  })
+})


### PR DESCRIPTION
Replace all console.log calls with LogTape structured logging,
add OTEL metrics (reload count, duration, active subgraphs),
trace subgraph calls with W3C traceparent propagation, and
wire up DI via ServiceTelemetry constructor injection.