### PR TITLE
fix(gateway): rename reload counter to follow OTEL naming conventions

### DIFF
--- a/packages/gateway/src/graphql/server.ts
+++ b/packages/gateway/src/graphql/server.ts
@@ -30,7 +30,7 @@ export class GatewayGraphqlServer {
     this.telemetry = telemetry
     this.logger = telemetry.logger.getChild('graphql')
 
-    this.reloadCounter = telemetry.meter.createCounter('gateway.schema.reload.count', {
+    this.reloadCounter = telemetry.meter.createCounter('gateway.schema.reloads', {
       description: 'Number of schema reload attempts',
       unit: '{reload}',
     })

--- a/packages/gateway/tests/telemetry.unit.test.ts
+++ b/packages/gateway/tests/telemetry.unit.test.ts
@@ -95,7 +95,7 @@ describe('GatewayGraphqlServer telemetry DI', () => {
     new GatewayGraphqlServer(telemetry)
 
     expect(spies.createCounter).toHaveBeenCalledWith(
-      'gateway.schema.reload.count',
+      'gateway.schema.reloads',
       expect.objectContaining({ description: expect.any(String) })
     )
     expect(spies.createHistogram).toHaveBeenCalledWith(


### PR DESCRIPTION
gateway.schema.reload.count → gateway.schema.reloads
The .count suffix is redundant on Counter instruments; plural noun
matches OTEL semconv for discrete-event counters.