### PR TITLE
fix(test): orquestrator and auth

### DIFF
--- a/packages/auth/src/rpc/server.ts
+++ b/packages/auth/src/rpc/server.ts
@@ -4,7 +4,6 @@ import { Hono } from 'hono'
 import { upgradeWebSocket } from 'hono/bun'
 
 import {
-  Action,
   jwtToEntity,
   Role,
   type CatalystPolicyEngine,
@@ -231,7 +230,7 @@ export class AuthRpcServer extends RpcTarget {
     const entities = builder.build()
     const autorizedResult = this.policyService?.isAuthorized({
       principal: principal.uid,
-      action: { type: 'CATALYST::Action', id: Action.MANAGE },
+      action: 'CATALYST::Action::MANAGE',
       resource: { type: 'CATALYST::AdminPanel', id: 'admin-panel' },
       entities: entities.getAll(),
       context: {},

--- a/packages/auth/tests/rpc-progressive.test.ts
+++ b/packages/auth/tests/rpc-progressive.test.ts
@@ -1,19 +1,22 @@
-import { describe, it, expect, beforeAll } from 'bun:test'
-import { AuthRpcServer } from '../src/rpc/server.js'
+import type { CatalystPolicyDomain } from '@catalyst/authorization'
 import {
-  type TokenHandlers,
-  type CertHandlers,
-  type ValidationHandlers,
-} from '../src/rpc/schema.js'
-import {
-  LocalTokenManager,
-  BunSqliteTokenStore,
+  ALL_POLICIES,
+  AuthorizationEngine,
   BunSqliteKeyStore,
+  BunSqliteTokenStore,
+  CATALYST_SCHEMA,
+  LocalTokenManager,
   PersistentLocalKeyManager,
+  Role,
   type TokenRecord,
 } from '@catalyst/authorization'
-import { AuthorizationEngine, CATALYST_SCHEMA, ALL_POLICIES, Role } from '@catalyst/authorization'
-import { type CatalystPolicyDomain } from '../src/policies/types.js'
+import { beforeAll, describe, expect, it } from 'bun:test'
+import {
+  type CertHandlers,
+  type TokenHandlers,
+  type ValidationHandlers,
+} from '../src/rpc/schema.js'
+import { AuthRpcServer } from '../src/rpc/server.js'
 
 describe('Auth Progressive API', () => {
   let keyManager: PersistentLocalKeyManager

--- a/packages/gateway/Dockerfile
+++ b/packages/gateway/Dockerfile
@@ -6,7 +6,15 @@ WORKDIR /app
 # Copy root config
 COPY package.json bun.lock ./
 
-# Copy gateway package dependencies
+# Copy Gateway Dependencies package.json files (types and telemetry)
+COPY packages/types/package.json packages/types/package.json
+COPY packages/telemetry/package.json packages/telemetry/package.json
+
+# Copy Gateway Dependencies Code (types and telemetry)
+COPY packages/types packages/types
+COPY packages/telemetry packages/telemetry
+
+# Copy Gateway package dependencies
 COPY packages/gateway/package.json packages/gateway/package.json
 
 # Install production dependencies

--- a/packages/orchestrator/tests/orchestrator.gateway.container.test.ts
+++ b/packages/orchestrator/tests/orchestrator.gateway.container.test.ts
@@ -1,16 +1,16 @@
-import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { newWebSocketRpcSession } from 'capnweb'
+import type { Readable } from 'node:stream'
+import path from 'path'
 import {
   GenericContainer,
-  Wait,
   Network,
-  type StartedTestContainer,
+  Wait,
   type StartedNetwork,
+  type StartedTestContainer,
 } from 'testcontainers'
-import path from 'path'
-import type { Readable } from 'node:stream'
-import { newWebSocketRpcSession } from 'capnweb'
 import type { PublicApi } from '../src/orchestrator.js'
-import { startAuthService, mintPeerToken, type AuthServiceContext } from './auth-test-helpers.js'
+import { mintPeerToken, startAuthService, type AuthServiceContext } from './auth-test-helpers.js'
 
 const isDockerRunning = () => {
   try {
@@ -121,7 +121,7 @@ describe.skipIf(skipTests)('Orchestrator Gateway Container Tests', () => {
         return await container.start()
       }
 
-      gateway = await startContainer('gateway', 'gateway', 'GATEWAY_STARTED', {}, [4000])
+      gateway = await startContainer('gateway', 'gateway', 'Gateway started', {}, [4000])
 
       const nodeEnv = (name: string, alias: string, gq: string = '') => ({
         PORT: '3000',
@@ -288,7 +288,7 @@ describe.skipIf(skipTests)('Orchestrator Gateway Container Tests', () => {
         return await container.start()
       }
 
-      gateway = await startContainer('gateway', 'gateway', 'GATEWAY_STARTED', {}, [4000])
+      gateway = await startContainer('gateway', 'gateway', 'Gateway started', {}, [4000])
 
       const nodeEnv = (
         name: string,


### PR DESCRIPTION
### TL;DR

Updated the authorization action format, fixed imports, and improved Docker configuration for the Gateway service.

### What changed?

- Changed the authorization action format from object notation `{ type: 'CATALYST::Action', id: Action.MANAGE }` to string format `'CATALYST::Action::MANAGE'`
- Fixed import paths in auth tests to use the correct package imports
- Enhanced the Gateway Dockerfile to properly include and copy dependencies from the types and telemetry packages
- Updated log message detection in container tests from `'GATEWAY_STARTED'` to `'Gateway started'`
- Organized imports across multiple files for better readability

### How to test?

1. Run the auth service tests to verify the new authorization action format works correctly
2. Build the Gateway Docker image and verify it starts properly
3. Run the orchestrator container tests to confirm the Gateway integration works with the updated log message detection

### Why make this change?

The authorization action format change simplifies the API and makes it more consistent. The Docker configuration improvements ensure that the Gateway service has all necessary dependencies properly included, fixing potential build issues. The import organization and path corrections improve code maintainability and prevent import-related errors.