### PR TITLE
refactor(orchestrator): migrate console.log to structured logging

### DIFF
--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -15,6 +15,7 @@
     "@catalyst/config": "catalog:",
     "@catalyst/routing": "catalog:",
     "@catalyst/service": "catalog:",
+    "@catalyst/telemetry": "catalog:",
     "@hono/capnweb": "catalog:",
     "capnweb": "catalog:",
     "hono": "catalog:",

--- a/bun.lock
+++ b/bun.lock
@@ -127,6 +127,7 @@
         "@catalyst/config": "catalog:",
         "@catalyst/routing": "catalog:",
         "@catalyst/service": "catalog:",
+        "@catalyst/telemetry": "catalog:",
         "@hono/capnweb": "catalog:",
         "capnweb": "catalog:",
         "hono": "catalog:",


### PR DESCRIPTION
Replace 47 console.log/console.error calls across orchestrator.ts and
service.ts with LogTape structured logging via getLogger() and
this.telemetry.logger. Also removes duplicate error log statements and
downgrades verbose dispatch logging to debug level.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>