### PR TITLE
refactor: migrate remaining console.log to structured logging

### DIFF
--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -5,8 +5,6 @@ import { GatewayService } from './service.js'
 const config = loadDefaultConfig()
 const gateway = await GatewayService.create({ config })
 
-console.log('GATEWAY_STARTED')
-
 catalystHonoServer(gateway.handler, {
   services: [gateway],
   port: config.port,

--- a/apps/node/package.json
+++ b/apps/node/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@catalyst/config": "catalog:",
     "@catalyst/service": "catalog:",
+    "@catalyst/telemetry": "catalog:",
     "@hono/node-server": "catalog:",
     "capnweb": "catalog:",
     "commander": "catalog:",

--- a/apps/node/src/cli/client.ts
+++ b/apps/node/src/cli/client.ts
@@ -1,10 +1,13 @@
+import { getLogger } from '@catalyst/telemetry'
 import type { CatalystRpc } from '../server/rpc.js'
 
 export class CatalystClient {
+  private readonly logger = getLogger(['catalyst', 'node', 'client'])
+
   // Mock connect - in reality this would connect via HTTP/WebSocket/IPC to the server
   async connect(): Promise<CatalystRpc> {
     // Return a proxy or stub. For now, returning null to show structure.
-    console.log('Connecting to Catalyst Node RPC...')
+    this.logger.info`Connecting to Catalyst Node RPC...`
     throw new Error('Not implemented: Transport layer for Client')
   }
 }

--- a/apps/node/src/server/index.ts
+++ b/apps/node/src/server/index.ts
@@ -1,6 +1,6 @@
+import { getLogger } from '@catalyst/telemetry'
 import { CatalystRpcServer } from './rpc.js'
 
+const logger = getLogger(['catalyst', 'node'])
 const _rpcServer = new CatalystRpcServer()
-console.log('RPC Server initialized')
-
-// comment to check into github
+logger.info`RPC server initialized`

--- a/apps/node/src/server/rpc.ts
+++ b/apps/node/src/server/rpc.ts
@@ -1,5 +1,4 @@
-// Mocking capnweb usage for now as we set up the structure.
-// In a real implementation we would import { RpcServer } from 'capnweb';
+import { getLogger } from '@catalyst/telemetry'
 
 // Defining the Interface locally for now to avoid circular deps until we refactor
 export interface PeerState {
@@ -32,7 +31,8 @@ export class CatalystRpcServer implements CatalystRpc {
   }
 
   async shutdown(): Promise<void> {
-    console.log('Shutdown requested via RPC...')
+    const logger = getLogger(['catalyst', 'node'])
+    logger.info`Shutdown requested via RPC`
     process.exit(0)
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -102,6 +102,7 @@
       "dependencies": {
         "@catalyst/config": "catalog:",
         "@catalyst/service": "catalog:",
+        "@catalyst/telemetry": "catalog:",
         "@hono/node-server": "catalog:",
         "capnweb": "catalog:",
         "commander": "catalog:",
@@ -204,6 +205,7 @@
       "name": "@catalyst/authorization",
       "version": "0.0.0",
       "dependencies": {
+        "@catalyst/telemetry": "catalog:",
         "@catalyst/types": "workspace:*",
         "@cedar-policy/cedar-wasm": "catalog:",
         "jose": "catalog:",

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -9,10 +9,11 @@
   },
   "private": true,
   "dependencies": {
-    "jose": "catalog:",
-    "zod": "catalog:",
+    "@catalyst/telemetry": "catalog:",
+    "@catalyst/types": "workspace:*",
     "@cedar-policy/cedar-wasm": "catalog:",
-    "@catalyst/types": "workspace:*"
+    "jose": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/bun": "catalog:dev",

--- a/packages/service/src/catalyst-hono-server.ts
+++ b/packages/service/src/catalyst-hono-server.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import { getLogger } from '@catalyst/telemetry'
 import { telemetryMiddleware } from '@catalyst/telemetry/middleware/hono'
 
 import type { CatalystService } from './catalyst-service.js'
@@ -112,7 +113,8 @@ export class CatalystHonoServer {
     process.on('SIGINT', shutdownHandler)
 
     const names = serviceNames.length > 0 ? ` [${serviceNames.join(', ')}]` : ''
-    console.log(`Catalyst server${names} listening on ${hostname}:${port}`)
+    const logger = getLogger(['catalyst', 'server'])
+    logger.info`Catalyst server${names} listening on ${hostname}:${port}`
 
     return this
   }


### PR DESCRIPTION
Replace console.log/error/warn with LogTape structured logging across:
- gateway (remove GATEWAY_STARTED marker)
- auth RPC server (use getAuthLogger for policy errors)
- node server/cli stubs (use getLogger)
- CatalystHonoServer startup message (use getLogger)
- AuthorizationEngine validation output (use getLogger)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>