### PR TITLE
chore(docker): add health checks to all compose services

### DIFF
--- a/docker-compose/docker.compose.yaml
+++ b/docker-compose/docker.compose.yaml
@@ -10,6 +10,11 @@ services:
     ports:
       - '4317:4317' # OTLP gRPC
       - '4318:4318' # OTLP HTTP
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:13133']
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   # --- Catalyst services ---
 
@@ -23,8 +28,14 @@ services:
       - PORT=4020
       - OTEL_SERVICE_NAME=auth
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:4020/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
     depends_on:
-      - otel-collector
+      otel-collector:
+        condition: service_healthy
 
   orchestrator:
     build:
@@ -41,10 +52,16 @@ services:
       - CATALYST_GQL_GATEWAY_ENDPOINT=ws://gateway:4000/api
       - OTEL_SERVICE_NAME=orchestrator
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:3000/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
     depends_on:
-      - otel-collector
-      - auth
-      - gateway
+      auth:
+        condition: service_healthy
+      gateway:
+        condition: service_healthy
 
   gateway:
     build:
@@ -56,10 +73,18 @@ services:
       - PORT=4000
       - OTEL_SERVICE_NAME=gateway
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:4000/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
     depends_on:
-      - otel-collector
-      - books-service
-      - movies-service
+      otel-collector:
+        condition: service_healthy
+      books-service:
+        condition: service_healthy
+      movies-service:
+        condition: service_healthy
 
   books-service:
     build:
@@ -69,6 +94,11 @@ services:
       - '8081:8080'
     environment:
       - PORT=8080
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   movies-service:
     build:
@@ -78,3 +108,8 @@ services:
       - '8082:8080'
     environment:
       - PORT=8080
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/docker-compose/example.m0p2.compose.yaml
+++ b/docker-compose/example.m0p2.compose.yaml
@@ -13,7 +13,7 @@ services:
     volumes:
       - auth-data:/data
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:5000/health']
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:5000/health']
       interval: 5s
       timeout: 3s
       retries: 10
@@ -29,11 +29,16 @@ services:
       - CATALYST_AUTH_ENDPOINT=ws://auth:5000/rpc
       - CATALYST_SYSTEM_TOKEN=${CATALYST_SYSTEM_TOKEN}
       - PORT=3000
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:3000/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
     depends_on:
       auth:
         condition: service_healthy
       gateway:
-        condition: service_started
+        condition: service_healthy
 
   gateway:
     build:
@@ -43,9 +48,16 @@ services:
       - '4000:4000'
     environment:
       - PORT=4000
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:4000/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
     depends_on:
-      - books-service
-      - movies-service
+      books-service:
+        condition: service_healthy
+      movies-service:
+        condition: service_healthy
 
   books-service:
     build:
@@ -55,6 +67,11 @@ services:
       - '8081:8080'
     environment:
       - PORT=8080
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   movies-service:
     build:
@@ -64,6 +81,11 @@ services:
       - '8082:8080'
     environment:
       - PORT=8080
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   auth-data:

--- a/docker-compose/otel-collector-config.yaml
+++ b/docker-compose/otel-collector-config.yaml
@@ -1,3 +1,8 @@
+# Health check extension for Docker healthcheck probes
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
 # Ingestion endpoints for telemetry data from Catalyst services
 receivers:
   otlp:
@@ -25,6 +30,7 @@ exporters:
 
 # All three signal types use the same receiver -> processor -> exporter chain
 service:
+  extensions: [health_check]
   pipelines:
     traces:
       receivers: [otlp]

--- a/docker-compose/two-node.compose.yaml
+++ b/docker-compose/two-node.compose.yaml
@@ -10,6 +10,11 @@ services:
     ports:
       - '4317:4317' # OTLP gRPC
       - '4318:4318' # OTLP HTTP
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:13133']
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   # --- Shared auth ---
 
@@ -23,8 +28,14 @@ services:
       - PORT=4020
       - OTEL_SERVICE_NAME=auth
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:4020/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
     depends_on:
-      - otel-collector
+      otel-collector:
+        condition: service_healthy
 
   # --- Node A: gateway-a + books ---
 
@@ -38,9 +49,16 @@ services:
       - PORT=4000
       - OTEL_SERVICE_NAME=gateway-a
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:4000/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
     depends_on:
-      - otel-collector
-      - books-service
+      otel-collector:
+        condition: service_healthy
+      books-service:
+        condition: service_healthy
 
   books-service:
     build:
@@ -50,6 +68,11 @@ services:
       - '8081:8080'
     environment:
       - PORT=8080
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   node-a:
     build:
@@ -66,14 +89,20 @@ services:
       - CATALYST_GQL_GATEWAY_ENDPOINT=ws://gateway-a:4000/api
       - OTEL_SERVICE_NAME=orchestrator-node-a
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:3000/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       default:
         aliases:
           - node-a
     depends_on:
-      - otel-collector
-      - auth
-      - gateway-a
+      auth:
+        condition: service_healthy
+      gateway-a:
+        condition: service_healthy
 
   # --- Node B: gateway-b + movies ---
 
@@ -87,9 +116,16 @@ services:
       - PORT=4000
       - OTEL_SERVICE_NAME=gateway-b
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:4000/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
     depends_on:
-      - otel-collector
-      - movies-service
+      otel-collector:
+        condition: service_healthy
+      movies-service:
+        condition: service_healthy
 
   movies-service:
     build:
@@ -99,6 +135,11 @@ services:
       - '8082:8080'
     environment:
       - PORT=8080
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   node-b:
     build:
@@ -115,11 +156,17 @@ services:
       - CATALYST_GQL_GATEWAY_ENDPOINT=ws://gateway-b:4000/api
       - OTEL_SERVICE_NAME=orchestrator-node-b
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:3000/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       default:
         aliases:
           - node-b
     depends_on:
-      - otel-collector
-      - auth
-      - gateway-b
+      auth:
+        condition: service_healthy
+      gateway-b:
+        condition: service_healthy


### PR DESCRIPTION
Add healthcheck blocks to every service in all three compose files:
- docker.compose.yaml (single-node dev)
- two-node.compose.yaml (multi-node topology)
- example.m0p2.compose.yaml (M0P2 bootstrap example)

All Catalyst services check /health via wget. OTEL collector uses
the health_check extension on port 13133. Service startup ordering
now uses condition: service_healthy for proper dependency chains.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>