### PR TITLE
fix(tests): extract URL resolution to eliminate WebSocket connections in unit tests

### DIFF
--- a/apps/cli/src/clients/auth-client.ts
+++ b/apps/cli/src/clients/auth-client.ts
@@ -48,8 +48,10 @@ export interface AuthValidationHandlers {
   getJWKS(): Promise<{ keys: unknown[] }>
 }
 
-export async function createAuthClient(
-  url: string = process.env.CATALYST_AUTH_URL || 'ws://localhost:4000/rpc'
-): Promise<AuthPublicApi> {
-  return newWebSocketRpcSession<AuthPublicApi>(url)
+export function resolveAuthUrl(url?: string): string {
+  return url ?? process.env.CATALYST_AUTH_URL ?? 'ws://localhost:4000/rpc'
+}
+
+export async function createAuthClient(url?: string): Promise<AuthPublicApi> {
+  return newWebSocketRpcSession<AuthPublicApi>(resolveAuthUrl(url))
 }

--- a/apps/cli/src/clients/orchestrator-client.ts
+++ b/apps/cli/src/clients/orchestrator-client.ts
@@ -22,8 +22,10 @@ export interface ManagementScope {
   deletePeer(peerId: string): Promise<ActionResult>
 }
 
-export async function createOrchestratorClient(
-  url: string = process.env.CATALYST_ORCHESTRATOR_URL || 'ws://localhost:3000/rpc'
-): Promise<OrchestratorPublicApi> {
-  return newWebSocketRpcSession<OrchestratorPublicApi>(url)
+export function resolveOrchestratorUrl(url?: string): string {
+  return url ?? process.env.CATALYST_ORCHESTRATOR_URL ?? 'ws://localhost:3000/rpc'
+}
+
+export async function createOrchestratorClient(url?: string): Promise<OrchestratorPublicApi> {
+  return newWebSocketRpcSession<OrchestratorPublicApi>(resolveOrchestratorUrl(url))
 }


### PR DESCRIPTION
# Refactor client URL resolution and tests

Extracted pure `resolveAuthUrl` and `resolveOrchestratorUrl` functions from the client creation logic and rewrote tests to verify URL precedence logic without opening actual WebSocket connections.

The refactored code now:
- Uses the nullish coalescing operator for cleaner URL resolution
- Properly tests the URL resolution priority (explicit URL > environment variable > default)
- Avoids unnecessary network connections during tests
- Includes proper environment variable cleanup in test setup/teardown