### PR TITLE
fix(cli): escape GraphiQL endpoint string to prevent JS injection

### DIFF
--- a/apps/cli/src/handlers/graphql-ide-handlers.ts
+++ b/apps/cli/src/handlers/graphql-ide-handlers.ts
@@ -10,6 +10,10 @@ export type GraphqlIdeResult =
  * Uses CDN resources from esm.sh
  */
 function generateGraphiQLHtml(graphqlEndpoint: string): string {
+  // Escape for safe insertion into inline JS: JSON.stringify handles quotes/backslashes,
+  // and replacing </ prevents </script> breakout at the HTML parser level.
+  const safeEndpoint = JSON.stringify(graphqlEndpoint).replace(/<\//g, '\\u003c/')
+
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -42,7 +46,7 @@ function generateGraphiQLHtml(graphqlEndpoint: string): string {
     import { GraphiQL } from 'graphiql';
     import { explorerPlugin } from '@graphiql/plugin-explorer';
 
-    const endpoint = ${JSON.stringify(graphqlEndpoint)};
+    const endpoint = ${safeEndpoint};
 
     const fetcher = async (graphQLParams) => {
       const response = await fetch(endpoint, {


### PR DESCRIPTION
JSON.stringify the endpoint URL and replace </ with \u003c/ to prevent
script tag breakout and quote-based string escaping attacks in the
inline JS template.