### PR TITLE
refactor(auth): remove deprecated RBAC module and relocate isSecretValid

### DIFF
--- a/apps/orchestrator/src/types.ts
+++ b/apps/orchestrator/src/types.ts
@@ -8,11 +8,6 @@ export const OrchestratorConfigSchema = z.object({
   node: NodeConfigSchema.extend({
     endpoint: z.string(), // Orchestrator requires an endpoint for its own node
   }),
-  ibgp: z
-    .object({
-      secret: z.string().optional(),
-    })
-    .optional(),
   gqlGatewayConfig: z
     .object({
       endpoint: z.string(),

--- a/apps/orchestrator/tests/orchestrator.gateway.test.ts
+++ b/apps/orchestrator/tests/orchestrator.gateway.test.ts
@@ -54,7 +54,6 @@ describe('CatalystNodeBus > GraphQL Gateway Sync', () => {
     bus = new CatalystNodeBus({
       config: {
         node: MOCK_NODE,
-        ibgp: { secret: 'secret' },
         gqlGatewayConfig: { endpoint: GATEWAY_ENDPOINT },
       },
       connectionPool: { pool },

--- a/apps/orchestrator/tests/orchestrator.test.ts
+++ b/apps/orchestrator/tests/orchestrator.test.ts
@@ -309,7 +309,6 @@ describe('CatalystNodeBus > GraphQL Gateway Sync', () => {
     bus = new CatalystNodeBus({
       config: {
         node: MOCK_NODE,
-        ibgp: { secret: 'secret' },
         gqlGatewayConfig: { endpoint: GATEWAY_ENDPOINT },
       },
       connectionPool: { pool },

--- a/apps/orchestrator/tests/orchestrator.topology.test.ts
+++ b/apps/orchestrator/tests/orchestrator.topology.test.ts
@@ -31,7 +31,7 @@ describe('Orchestrator Topology Tests', () => {
 
     const createNode = (info: PeerInfo) => {
       const bus = new CatalystNodeBus({
-        config: { node: info, ibgp: { secret: 'secret' } },
+        config: { node: info },
         connectionPool: { pool },
         state: newRouteTable(),
       })

--- a/apps/orchestrator/tests/peering.orchestrator.topology.test.ts
+++ b/apps/orchestrator/tests/peering.orchestrator.topology.test.ts
@@ -24,7 +24,7 @@ describe('Orchestrator Peering Tests (Mocked Container Logic)', () => {
 
     const createNode = (info: PeerInfo) => {
       const bus = new CatalystNodeBus({
-        config: { node: info, ibgp: { secret: 'secret' } },
+        config: { node: info },
         connectionPool: { pool },
         state: newRouteTable(),
       })

--- a/apps/orchestrator/tests/transit.orchestrator.topology.test.ts
+++ b/apps/orchestrator/tests/transit.orchestrator.topology.test.ts
@@ -30,7 +30,7 @@ describe('Orchestrator Transit Tests (Mocked Container Logic)', () => {
 
     const createNode = (info: PeerInfo) => {
       const bus = new CatalystNodeBus({
-        config: { node: info, ibgp: { secret: 'secret' } },
+        config: { node: info },
         connectionPool: { pool },
         state: newRouteTable(),
       })

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -17,11 +17,6 @@ export type NodeConfig = z.infer<typeof NodeConfigSchema>
  * Orchestrator Specific Configuration
  */
 export const OrchestratorConfigSchema = z.object({
-  ibgp: z
-    .object({
-      secret: z.string().optional(),
-    })
-    .optional(),
   gqlGatewayConfig: z
     .object({
       endpoint: z.string(),
@@ -122,9 +117,6 @@ export function loadDefaultConfig(options: ConfigLoadOptions = {}): CatalystConf
       domains: domains,
     },
     orchestrator: {
-      ibgp: {
-        secret: process.env.CATALYST_PEERING_SECRET || 'valid-secret',
-      },
       gqlGatewayConfig: process.env.CATALYST_GQL_GATEWAY_ENDPOINT
         ? { endpoint: process.env.CATALYST_GQL_GATEWAY_ENDPOINT }
         : undefined,


### PR DESCRIPTION
Delete permissions.ts which contained the legacy role-based permission
system now fully replaced by Cedar policy engine. Move isSecretValid
to password.ts where it belongs alongside other crypto utilities.
Remove unused ibgp secret config from config and orchestrator packages.