### PR TITLE
fix(docker and gateway): missing deps and websocket in catalyst service creation

### DIFF
--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -18,6 +18,7 @@ COPY packages/routing/package.json packages/routing/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/telemetry/package.json packages/telemetry/package.json
 COPY packages/types/package.json packages/types/package.json
+COPY packages/service/package.json packages/service/package.json
 COPY examples/books-api/package.json examples/books-api/package.json
 COPY examples/movies-api/package.json examples/movies-api/package.json
 COPY examples/orders-api/package.json examples/orders-api/package.json
@@ -49,6 +50,7 @@ COPY packages/routing/package.json packages/routing/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/telemetry/package.json packages/telemetry/package.json
 COPY packages/types/package.json packages/types/package.json
+COPY packages/service/package.json packages/service/package.json
 COPY examples/books-api/package.json examples/books-api/package.json
 COPY examples/movies-api/package.json examples/movies-api/package.json
 COPY examples/orders-api/package.json examples/orders-api/package.json
@@ -59,6 +61,8 @@ COPY apps/auth apps/auth
 COPY packages/authorization packages/authorization
 COPY packages/config packages/config
 COPY packages/types packages/types
+COPY packages/service packages/service
+COPY packages/telemetry packages/telemetry
 
 # Recreate workspace symlinks (fast — external deps already cached)
 RUN bun install --omit=dev --ignore-scripts

--- a/apps/cli/tests/auth/token.container.test.ts
+++ b/apps/cli/tests/auth/token.container.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import path from 'path'
 import {
   GenericContainer,
-  Wait,
   Network,
-  type StartedTestContainer,
+  Wait,
   type StartedNetwork,
+  type StartedTestContainer,
 } from 'testcontainers'
-import path from 'path'
 import { createAuthClient } from '../../src/clients/auth-client.js'
 
 const isDockerRunning = () => {
@@ -58,6 +58,7 @@ describe.skipIf(skipTests)('Token Commands Container Tests', () => {
         CATALYST_AUTH_KEYS_DB: ':memory:',
         CATALYST_AUTH_TOKENS_DB: ':memory:',
         CATALYST_BOOTSTRAP_TTL: '3600000',
+        CATALYST_NODE_ID: 'auth-node',
       })
       .withWaitStrategy(Wait.forLogMessage('Auth service started'))
       .start()

--- a/apps/cli/tests/node/peer.container.test.ts
+++ b/apps/cli/tests/node/peer.container.test.ts
@@ -70,6 +70,7 @@ describe.skipIf(skipTests)('Peer Commands Container Tests', () => {
         CATALYST_AUTH_KEYS_DB: ':memory:',
         CATALYST_AUTH_TOKENS_DB: ':memory:',
         CATALYST_BOOTSTRAP_TTL: '3600000',
+        CATALYST_NODE_ID: 'test-node',
       })
       .withWaitStrategy(Wait.forLogMessage('Auth service started'))
       .start()

--- a/apps/cli/tests/node/route.container.test.ts
+++ b/apps/cli/tests/node/route.container.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import path from 'path'
 import {
   GenericContainer,
-  Wait,
   Network,
-  type StartedTestContainer,
+  Wait,
   type StartedNetwork,
+  type StartedTestContainer,
 } from 'testcontainers'
-import path from 'path'
 import { createOrchestratorClient } from '../../src/clients/orchestrator-client.js'
 
 const isDockerRunning = () => {
@@ -70,6 +70,7 @@ describe.skipIf(skipTests)('Route Commands Container Tests', () => {
         CATALYST_AUTH_KEYS_DB: ':memory:',
         CATALYST_AUTH_TOKENS_DB: ':memory:',
         CATALYST_BOOTSTRAP_TTL: '3600000',
+        CATALYST_NODE_ID: 'test-node',
       })
       .withWaitStrategy(Wait.forLogMessage('Auth service started'))
       .start()

--- a/apps/gateway/Dockerfile
+++ b/apps/gateway/Dockerfile
@@ -18,6 +18,7 @@ COPY packages/routing/package.json packages/routing/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/telemetry/package.json packages/telemetry/package.json
 COPY packages/types/package.json packages/types/package.json
+COPY packages/service/package.json packages/service/package.json
 COPY examples/books-api/package.json examples/books-api/package.json
 COPY examples/movies-api/package.json examples/movies-api/package.json
 COPY examples/orders-api/package.json examples/orders-api/package.json
@@ -49,6 +50,7 @@ COPY packages/routing/package.json packages/routing/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/telemetry/package.json packages/telemetry/package.json
 COPY packages/types/package.json packages/types/package.json
+COPY packages/service/package.json packages/service/package.json
 COPY examples/books-api/package.json examples/books-api/package.json
 COPY examples/movies-api/package.json examples/movies-api/package.json
 COPY examples/orders-api/package.json examples/orders-api/package.json
@@ -57,6 +59,8 @@ COPY examples/product-api/package.json examples/product-api/package.json
 # Copy app source and workspace dependencies
 COPY apps/gateway apps/gateway
 COPY packages/telemetry packages/telemetry
+COPY packages/service packages/service
+COPY packages/config packages/config
 
 # Recreate workspace symlinks (fast — external deps already cached)
 RUN bun install --omit=dev --ignore-scripts

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -1,11 +1,13 @@
 import { loadDefaultConfig } from '@catalyst/config'
 import { catalystHonoServer } from '@catalyst/service'
+import { websocket } from 'hono/bun'
 import { GatewayService } from './service.js'
 
-const config = loadDefaultConfig()
+const config = loadDefaultConfig({ serviceType: 'gateway' })
 const gateway = await GatewayService.create({ config })
 
 catalystHonoServer(gateway.handler, {
   services: [gateway],
   port: config.port,
+  websocket,
 }).start()

--- a/apps/orchestrator/Dockerfile
+++ b/apps/orchestrator/Dockerfile
@@ -18,6 +18,7 @@ COPY packages/routing/package.json packages/routing/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/telemetry/package.json packages/telemetry/package.json
 COPY packages/types/package.json packages/types/package.json
+COPY packages/service/package.json packages/service/package.json
 COPY examples/books-api/package.json examples/books-api/package.json
 COPY examples/movies-api/package.json examples/movies-api/package.json
 COPY examples/orders-api/package.json examples/orders-api/package.json
@@ -49,6 +50,7 @@ COPY packages/routing/package.json packages/routing/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/telemetry/package.json packages/telemetry/package.json
 COPY packages/types/package.json packages/types/package.json
+COPY packages/service/package.json packages/service/package.json
 COPY examples/books-api/package.json examples/books-api/package.json
 COPY examples/movies-api/package.json examples/movies-api/package.json
 COPY examples/orders-api/package.json examples/orders-api/package.json
@@ -61,6 +63,8 @@ COPY packages/authorization packages/authorization
 COPY packages/config packages/config
 COPY packages/routing packages/routing
 COPY packages/types packages/types
+COPY packages/service packages/service
+COPY packages/telemetry packages/telemetry
 
 # Recreate workspace symlinks (fast — external deps already cached)
 RUN bun install --omit=dev --ignore-scripts

--- a/apps/orchestrator/src/server.ts
+++ b/apps/orchestrator/src/server.ts
@@ -6,6 +6,9 @@ import { OrchestratorService } from './service.js'
 const config = loadDefaultConfig()
 const orchestrator = await OrchestratorService.create({ config })
 
+if (!websocket) {
+  throw new Error('WebSocket handler is required')
+}
 catalystHonoServer(orchestrator.handler, {
   services: [orchestrator],
   port: config.port,

--- a/apps/orchestrator/src/types.ts
+++ b/apps/orchestrator/src/types.ts
@@ -1,6 +1,6 @@
+import { Role } from '@catalyst/authorization'
 import type { Action, RouteTable } from '@catalyst/routing'
 import { z } from 'zod'
-import { Role } from '@catalyst/authorization'
 
 import { NodeConfigSchema } from '@catalyst/config'
 

--- a/apps/orchestrator/tests/orchestrator.gateway.container.test.ts
+++ b/apps/orchestrator/tests/orchestrator.gateway.container.test.ts
@@ -121,7 +121,15 @@ describe.skipIf(skipTests)('Orchestrator Gateway Container Tests', () => {
         return await container.start()
       }
 
-      gateway = await startContainer('gateway', 'gateway', 'Gateway started', {}, [4000])
+      gateway = await startContainer(
+        'gateway',
+        'gateway',
+        'GATEWAY_STARTED',
+        {
+          CATALYST_NODE_ID: 'gateway',
+        },
+        [4000]
+      )
 
       const nodeEnv = (name: string, alias: string, gq: string = '') => ({
         PORT: '3000',
@@ -136,14 +144,14 @@ describe.skipIf(skipTests)('Orchestrator Gateway Container Tests', () => {
       peerA = await startContainer(
         'peer-a.somebiz.local.io',
         'peer-a',
-        'NEXT_ORCHESTRATOR_STARTED',
+        'Catalyst server [orchestrator]',
         nodeEnv('peer-a.somebiz.local.io', 'peer-a'),
         [3000]
       )
       peerB = await startContainer(
         'peer-b.somebiz.local.io',
         'peer-b',
-        'NEXT_ORCHESTRATOR_STARTED',
+        'Catalyst server [orchestrator]',
         nodeEnv('peer-b.somebiz.local.io', 'peer-b', 'ws://gateway:4000/api'),
         [3000]
       )
@@ -288,7 +296,15 @@ describe.skipIf(skipTests)('Orchestrator Gateway Container Tests', () => {
         return await container.start()
       }
 
-      gateway = await startContainer('gateway', 'gateway', 'Gateway started', {}, [4000])
+      gateway = await startContainer(
+        'gateway',
+        'gateway',
+        'GATEWAY_STARTED',
+        {
+          CATALYST_NODE_ID: 'gateway',
+        },
+        [4000]
+      )
 
       const nodeEnv = (
         name: string,
@@ -309,14 +325,14 @@ describe.skipIf(skipTests)('Orchestrator Gateway Container Tests', () => {
       peerA = await startContainer(
         'peer-a.somebiz.local.io',
         'peer-a',
-        'NEXT_ORCHESTRATOR_STARTED',
+        'Catalyst server [orchestrator]',
         nodeEnv('peer-a.somebiz.local.io', 'peer-a', authA.endpoint, authA.systemToken),
         [3000]
       )
       peerB = await startContainer(
         'peer-b.somebiz.local.io',
         'peer-b',
-        'NEXT_ORCHESTRATOR_STARTED',
+        'Catalyst server [orchestrator]',
         nodeEnv(
           'peer-b.somebiz.local.io',
           'peer-b',

--- a/apps/orchestrator/tests/orchestrator.test.ts
+++ b/apps/orchestrator/tests/orchestrator.test.ts
@@ -1,17 +1,17 @@
-import { describe, it, expect, beforeEach, mock, beforeAll, afterAll } from 'bun:test'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
 import {
   GenericContainer,
-  Wait,
   Network,
-  type StartedTestContainer,
+  Wait,
   type StartedNetwork,
+  type StartedTestContainer,
 } from 'testcontainers'
 
-import path from 'path'
-import type { Readable } from 'node:stream'
-import { newWebSocketRpcSession, type RpcStub } from 'capnweb'
-import type { PublicApi, PeerInfo } from '../src/orchestrator'
 import { Actions } from '@catalyst/routing'
+import { newWebSocketRpcSession, type RpcStub } from 'capnweb'
+import type { Readable } from 'node:stream'
+import path from 'path'
+import type { PeerInfo, PublicApi } from '../src/orchestrator'
 import { CatalystNodeBus, ConnectionPool } from '../src/orchestrator'
 import type { AuthContext } from '../src/types'
 
@@ -112,7 +112,7 @@ describe.skipIf(skipTests)('Orchestrator Container Tests (Next)', () => {
           CATALYST_AUTH_ENDPOINT: 'ws://auth:5000/rpc',
           CATALYST_SYSTEM_TOKEN: systemToken,
         })
-        .withWaitStrategy(Wait.forLogMessage('NEXT_ORCHESTRATOR_STARTED'))
+        .withWaitStrategy(Wait.forLogMessage('Catalyst server [orchestrator]'))
         .withLogConsumer((stream: Readable) => {
           stream.pipe(process.stdout)
         })

--- a/apps/orchestrator/tests/peering.orchestrator.topology.container.test.ts
+++ b/apps/orchestrator/tests/peering.orchestrator.topology.container.test.ts
@@ -1,16 +1,16 @@
-import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { newWebSocketRpcSession, type RpcStub } from 'capnweb'
+import { spawnSync } from 'node:child_process'
+import path from 'path'
 import {
   GenericContainer,
-  Wait,
   Network,
-  type StartedTestContainer,
+  Wait,
   type StartedNetwork,
+  type StartedTestContainer,
 } from 'testcontainers'
-import path from 'path'
-import { spawnSync } from 'node:child_process'
-import { newWebSocketRpcSession, type RpcStub } from 'capnweb'
-import type { PublicApi, NetworkClient } from '../src/orchestrator.js'
-import { startAuthService, mintPeerToken, type AuthServiceContext } from './auth-test-helpers.js'
+import type { NetworkClient, PublicApi } from '../src/orchestrator.js'
+import { mintPeerToken, startAuthService, type AuthServiceContext } from './auth-test-helpers.js'
 
 const isDockerRunning = () => {
   try {
@@ -88,7 +88,7 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
             CATALYST_AUTH_ENDPOINT: auth.endpoint,
             CATALYST_SYSTEM_TOKEN: auth.systemToken,
           })
-          .withWaitStrategy(Wait.forLogMessage('NEXT_ORCHESTRATOR_STARTED'))
+          .withWaitStrategy(Wait.forLogMessage('Catalyst server [orchestrator]'))
           .withLogConsumer(
             (stream: {
               on(event: string, listener: (line: string) => void): void
@@ -295,7 +295,7 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
             CATALYST_AUTH_ENDPOINT: authEndpoint,
             CATALYST_SYSTEM_TOKEN: systemToken,
           })
-          .withWaitStrategy(Wait.forLogMessage('NEXT_ORCHESTRATOR_STARTED'))
+          .withWaitStrategy(Wait.forLogMessage('Catalyst server [orchestrator]'))
           .withLogConsumer(
             (stream: {
               on(event: string, listener: (line: string) => void): void

--- a/apps/orchestrator/tests/transit.orchestrator.topology.container.test.ts
+++ b/apps/orchestrator/tests/transit.orchestrator.topology.container.test.ts
@@ -1,16 +1,16 @@
-import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { newWebSocketRpcSession, type RpcStub } from 'capnweb'
+import { spawnSync } from 'node:child_process'
+import path from 'path'
 import {
   GenericContainer,
-  Wait,
   Network,
-  type StartedTestContainer,
+  Wait,
   type StartedNetwork,
+  type StartedTestContainer,
 } from 'testcontainers'
-import path from 'path'
-import { spawnSync } from 'node:child_process'
-import { newWebSocketRpcSession, type RpcStub } from 'capnweb'
-import type { PublicApi, NetworkClient, DataChannel } from '../src/orchestrator.js'
-import { startAuthService, mintPeerToken, type AuthServiceContext } from './auth-test-helpers.js'
+import type { DataChannel, NetworkClient, PublicApi } from '../src/orchestrator.js'
+import { mintPeerToken, startAuthService, type AuthServiceContext } from './auth-test-helpers.js'
 
 const isDockerRunning = () => {
   try {
@@ -89,7 +89,7 @@ describe.skipIf(skipTests)('Orchestrator Transit Container Tests', () => {
             CATALYST_AUTH_ENDPOINT: auth.endpoint,
             CATALYST_SYSTEM_TOKEN: auth.systemToken,
           })
-          .withWaitStrategy(Wait.forLogMessage('NEXT_ORCHESTRATOR_STARTED'))
+          .withWaitStrategy(Wait.forLogMessage('Catalyst server [orchestrator]'))
           .withLogConsumer(
             (stream: {
               on(event: string, listener: (line: string) => void): void
@@ -353,7 +353,7 @@ describe.skipIf(skipTests)('Orchestrator Transit Container Tests', () => {
             CATALYST_AUTH_ENDPOINT: authEndpoint,
             CATALYST_SYSTEM_TOKEN: systemToken,
           })
-          .withWaitStrategy(Wait.forLogMessage('NEXT_ORCHESTRATOR_STARTED'))
+          .withWaitStrategy(Wait.forLogMessage('Catalyst server [orchestrator]'))
           .withLogConsumer(
             (stream: {
               on(event: string, listener: (line: string) => void): void

--- a/examples/books-api/Dockerfile
+++ b/examples/books-api/Dockerfile
@@ -18,6 +18,7 @@ COPY packages/routing/package.json packages/routing/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/telemetry/package.json packages/telemetry/package.json
 COPY packages/types/package.json packages/types/package.json
+COPY packages/service/package.json packages/service/package.json
 COPY examples/books-api/package.json examples/books-api/package.json
 COPY examples/movies-api/package.json examples/movies-api/package.json
 COPY examples/orders-api/package.json examples/orders-api/package.json
@@ -49,6 +50,7 @@ COPY packages/routing/package.json packages/routing/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/telemetry/package.json packages/telemetry/package.json
 COPY packages/types/package.json packages/types/package.json
+COPY packages/service/package.json packages/service/package.json
 COPY examples/books-api/package.json examples/books-api/package.json
 COPY examples/movies-api/package.json examples/movies-api/package.json
 COPY examples/orders-api/package.json examples/orders-api/package.json

--- a/packages/service/src/catalyst-hono-server.ts
+++ b/packages/service/src/catalyst-hono-server.ts
@@ -1,6 +1,6 @@
-import { Hono } from 'hono'
 import { getLogger } from '@catalyst/telemetry'
 import { telemetryMiddleware } from '@catalyst/telemetry/middleware/hono'
+import { Hono } from 'hono'
 
 import type { CatalystService } from './catalyst-service.js'
 
@@ -51,6 +51,7 @@ export class CatalystHonoServer {
   private readonly _options: CatalystHonoServerOptions
   private _server: ReturnType<typeof Bun.serve> | undefined
   private _shutdownHandlers: (() => Promise<void>)[] = []
+  private readonly _logger = getLogger(['catalyst', 'hono-server'])
 
   constructor(handler: Hono, options?: CatalystHonoServerOptions) {
     this._handler = handler
@@ -92,6 +93,8 @@ export class CatalystHonoServer {
     if (this._options.websocket) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ;(serveOptions as any).websocket = this._options.websocket
+    } else {
+      this._logger.warn`'No websocket handler provided, RPC-over-WebSocket will not be available'`
     }
     this._server = Bun.serve(serveOptions)
 

--- a/packages/service/src/catalyst-service.ts
+++ b/packages/service/src/catalyst-service.ts
@@ -1,13 +1,13 @@
 import type { CatalystConfig } from '@catalyst/config'
-import { TelemetryBuilder, shutdownTelemetry } from '@catalyst/telemetry'
 import type { ServiceTelemetry } from '@catalyst/telemetry'
+import { TelemetryBuilder, shutdownTelemetry } from '@catalyst/telemetry'
+import type { Hono } from 'hono'
 import type {
   CatalystServiceOptions,
   ICatalystService,
   ServiceInfo,
   ServiceState,
 } from './types.js'
-import type { Hono } from 'hono'
 
 /**
  * Abstract base class for all Catalyst services.

--- a/packages/telemetry/src/instrumentation.ts
+++ b/packages/telemetry/src/instrumentation.ts
@@ -9,18 +9,18 @@
  */
 
 import {
-  trace,
-  TraceFlags,
   diag,
   DiagConsoleLogger,
   DiagLogLevel,
-  type Tracer,
+  trace,
+  TraceFlags,
   type Context,
+  type Tracer,
 } from '@opentelemetry/api'
-import { NodeTracerProvider, BatchSpanProcessor } from '@opentelemetry/sdk-trace-node'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
-import { buildResource } from './resource.js'
+import { BatchSpanProcessor, NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 import { EXPORT_TIMEOUT_MS } from './constants.js'
+import { buildResource } from './resource.js'
 
 let tracerProvider: NodeTracerProvider | null = null
 
@@ -93,7 +93,9 @@ export function initTracer(config: TracerConfig): void {
   const otlpEndpoint = config.otlpEndpoint ?? process.env.OTEL_EXPORTER_OTLP_ENDPOINT
 
   if (!otlpEndpoint) {
-    console.warn('[telemetry] tracing disabled: OTEL_EXPORTER_OTLP_ENDPOINT not set')
+    console.warn(
+      `[${config.serviceName}] [telemetry] tracing disabled: OTEL_EXPORTER_OTLP_ENDPOINT not set`
+    )
     return
   }
 


### PR DESCRIPTION
### TL;DR

Added node ID configuration to services and improved Docker container builds with proper package dependencies.

### What changed?

- Added `CATALYST_NODE_ID` environment variable to container tests and made it a required configuration
- Added `packages/service` to Docker build files for auth, gateway, orchestrator, and books-api
- Added missing package copies in Dockerfiles (telemetry, config, service)
- Updated the gateway service to use proper service type configuration
- Improved error handling for WebSocket requirements in the orchestrator
- Updated wait messages in container tests to match actual log output
- Fixed imports ordering across multiple files
- Enhanced configuration loading with service type awareness
- Added better logging for WebSocket handler availability

### How to test?

1. Build and run the Docker containers for auth, gateway, and orchestrator services
2. Verify that the services start correctly with the required `CATALYST_NODE_ID` environment variable
3. Run the container tests to ensure they pass with the updated wait messages
4. Test WebSocket functionality in the gateway service

### Why make this change?

These changes improve the reliability and consistency of the service configuration, particularly for containerized deployments. The node ID is now properly required across all services, ensuring proper identification in the network. The Docker builds have been updated to include all necessary package dependencies, preventing runtime errors. The configuration loading has been enhanced to be service-type aware, providing better error messages and validation specific to each service type.