### PR TITLE
refactor(authorization): add Principal enum and switch tokens to principal-based model

### DIFF
--- a/packages/authorization/src/jwt/jwt-token-factory.ts
+++ b/packages/authorization/src/jwt/jwt-token-factory.ts
@@ -54,7 +54,7 @@ export interface JWTTokenFactoryConfig {
  * })
  * await factory.initialize()
  *
- * const token = await factory.mint({ subject: 'alice', roles: [Role.USER], entity: { ... } })
+ * const token = await factory.mint({ subject: 'alice', principal: Principal.USER, entity: { ... } })
  * const result = await factory.verify(token)  // auto-checks revocation
  * await factory.revoke({ jti: '...' })
  *

--- a/packages/authorization/src/jwt/local/index.ts
+++ b/packages/authorization/src/jwt/local/index.ts
@@ -22,7 +22,7 @@ export class LocalTokenManager implements TokenManager {
     const claims: Record<string, unknown> = {
       ...options.claims,
       entity: options.entity,
-      roles: options.roles,
+      principal: options.principal,
     }
 
     // Support certificate binding (ADR 0007)

--- a/packages/authorization/src/policy/src/definitions/models.ts
+++ b/packages/authorization/src/policy/src/definitions/models.ts
@@ -43,6 +43,30 @@ export enum Role {
 }
 
 /**
+ * Cedar principal types for the Catalyst system.
+ * These are the actual entity type strings used in Cedar policies.
+ * Tokens store the principal directly — no role-to-principal mapping needed at verification time.
+ */
+export enum Principal {
+  ADMIN = 'CATALYST::ADMIN',
+  NODE = 'CATALYST::NODE',
+  NODE_CUSTODIAN = 'CATALYST::NODE_CUSTODIAN',
+  DATA_CUSTODIAN = 'CATALYST::DATA_CUSTODIAN',
+  USER = 'CATALYST::USER',
+}
+
+/**
+ * Maps Role enum values to their corresponding Cedar Principal types.
+ */
+export const ROLE_TO_PRINCIPAL: Record<Role, Principal> = {
+  [Role.ADMIN]: Principal.ADMIN,
+  [Role.NODE]: Principal.NODE,
+  [Role.NODE_CUSTODIAN]: Principal.NODE_CUSTODIAN,
+  [Role.DATA_CUSTODIAN]: Principal.DATA_CUSTODIAN,
+  [Role.USER]: Principal.USER,
+}
+
+/**
  * Standardized actions for the Catalyst system.
  */
 export enum Action {

--- a/packages/authorization/src/policy/src/definitions/schema.cedar
+++ b/packages/authorization/src/policy/src/definitions/schema.cedar
@@ -3,7 +3,6 @@ namespace CATALYST {
         id: String,
         name: String,
         type: String,
-        role: String,
         trustedNodes: Set<String>,
         trustedDomains: Set<String>
     };
@@ -11,7 +10,6 @@ namespace CATALYST {
         id: String,
         name: String,
         type: String,
-        role: String,
         trustedNodes: Set<String>,
         trustedDomains: Set<String>
     };
@@ -19,7 +17,6 @@ namespace CATALYST {
         id: String,
         name: String,
         type: String,
-        role: String,
         trustedNodes: Set<String>,
         trustedDomains: Set<String>
     };
@@ -27,7 +24,6 @@ namespace CATALYST {
         id: String,
         name: String,
         type: String,
-        role: String,
         trustedNodes: Set<String>,
         trustedDomains: Set<String>
     };
@@ -35,7 +31,6 @@ namespace CATALYST {
         id: String,
         name: String,
         type: String,
-        role: String,
         trustedNodes: Set<String>,
         trustedDomains: Set<String>
     };

--- a/packages/authorization/src/service/rpc/schema.ts
+++ b/packages/authorization/src/service/rpc/schema.ts
@@ -1,8 +1,8 @@
 import type { TokenRecord } from '../../jwt/index.js'
-import { Role } from '../../policy/src/definitions/models.js'
+import { Principal } from '../../policy/src/definitions/models.js'
 import { z } from 'zod'
 
-export const RoleSchema = z.enum(Role)
+export const PrincipalSchema = z.enum(Principal)
 
 /**
  * SignToken Request/Response schemas
@@ -155,10 +155,9 @@ export interface TokenHandlers {
       id: string
       name: string
       type: 'user' | 'service'
-      role: z.infer<typeof RoleSchema>
       nodeId?: string
     }
-    roles: z.infer<typeof RoleSchema>[]
+    principal: z.infer<typeof PrincipalSchema>
     sans?: string[]
     expiresIn?: string
   }): Promise<string>

--- a/packages/authorization/src/service/rpc/server.ts
+++ b/packages/authorization/src/service/rpc/server.ts
@@ -5,7 +5,7 @@ import { upgradeWebSocket } from 'hono/bun'
 
 import type { JWTTokenFactory } from '../../jwt/jwt-token-factory.js'
 import { jwtToEntity } from '../../jwt/index.js'
-import { Role, type CatalystPolicyEngine } from '../../policy/src/index.js'
+import { Principal, type CatalystPolicyEngine } from '../../policy/src/index.js'
 import type { ServiceTelemetry } from '@catalyst/telemetry'
 import {
   type AuthorizeActionRequest,
@@ -110,11 +110,8 @@ export class AuthRpcServer extends RpcTarget {
       create: async (request) => {
         return this.tokenFactory.mint({
           subject: request.subject,
-          entity: {
-            ...request.entity,
-            role: (request.roles as Role[])[0] || Role.USER, // Use primary role
-          },
-          roles: request.roles as Role[],
+          entity: request.entity,
+          principal: (request.principal as Principal) || Principal.USER,
           sans: request.sans,
           expiresAt: request.expiresIn ? Date.now() + parseDuration(request.expiresIn) : undefined,
           claims: {},

--- a/packages/authorization/src/service/service.ts
+++ b/packages/authorization/src/service/service.ts
@@ -4,7 +4,7 @@ import {
   AuthorizationEngine,
   CATALYST_SCHEMA,
   type CatalystPolicyDomain,
-  Role,
+  Principal,
 } from '../policy/src/index.js'
 import { CatalystService, type CatalystServiceOptions } from '@catalyst/service'
 import { Hono } from 'hono'
@@ -67,11 +67,10 @@ export class AuthService extends CatalystService {
         id: 'system',
         name: 'System Admin',
         type: 'service',
-        role: Role.ADMIN,
         trustedDomains: this.config.node.domains,
         trustedNodes: [],
       },
-      roles: [Role.ADMIN],
+      principal: Principal.ADMIN,
       expiresAt: Date.now() + 365 * 24 * 60 * 60 * 1000,
     })
 

--- a/packages/authorization/tests/jwt/jwt-token-factory.test.ts
+++ b/packages/authorization/tests/jwt/jwt-token-factory.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
 import * as jose from 'jose'
 import { JWTTokenFactory } from '../../src/jwt/jwt-token-factory.js'
-import { Role } from '../../src/policy/src/definitions/models.js'
+import { Principal } from '../../src/policy/src/definitions/models.js'
 
 describe('JWTTokenFactory', () => {
   let factory: JWTTokenFactory
@@ -18,12 +18,11 @@ describe('JWTTokenFactory', () => {
   const mintTestToken = (overrides?: Partial<Parameters<typeof factory.mint>[0]>) =>
     factory.mint({
       subject: 'user-1',
-      roles: [Role.USER],
+      principal: Principal.USER,
       entity: {
         id: 'user-1',
         name: 'alice',
         type: 'user',
-        role: Role.USER,
       },
       ...overrides,
     })
@@ -74,8 +73,8 @@ describe('JWTTokenFactory', () => {
 
       const token = await customFactory.mint({
         subject: 'user-1',
-        roles: [Role.USER],
-        entity: { id: 'u1', name: 'alice', type: 'user', role: Role.USER },
+        principal: Principal.USER,
+        entity: { id: 'u1', name: 'alice', type: 'user' },
       })
 
       const result = await customFactory.rotate({ gracePeriodMs: 1000 })
@@ -109,7 +108,6 @@ describe('JWTTokenFactory', () => {
           id: 'user-1',
           name: 'alice',
           type: 'user',
-          role: Role.USER,
           nodeId: 'explicit-node',
         },
       })
@@ -139,7 +137,7 @@ describe('JWTTokenFactory', () => {
       expect(result.valid).toBe(true)
       if (result.valid) {
         expect(result.payload.entity).toBeDefined()
-        expect(result.payload.roles).toEqual([Role.USER])
+        expect(result.payload.principal).toBe(Principal.USER)
       }
     })
 
@@ -189,7 +187,7 @@ describe('JWTTokenFactory', () => {
       await mintTestToken({
         subject: 'user-2',
         sans: ['api.internal'],
-        entity: { id: 'u2', name: 'bob', type: 'user', role: Role.USER },
+        entity: { id: 'u2', name: 'bob', type: 'user' },
       })
 
       await factory.revoke({ san: 'api.internal' })
@@ -288,7 +286,7 @@ describe('JWTTokenFactory', () => {
       await mintTestToken()
       await mintTestToken({
         subject: 'user-2',
-        entity: { id: 'u2', name: 'bob', type: 'user', role: Role.USER },
+        entity: { id: 'u2', name: 'bob', type: 'user' },
       })
 
       const tokens = await factory.listTokens()
@@ -299,7 +297,7 @@ describe('JWTTokenFactory', () => {
       await mintTestToken({ certificateFingerprint: 'sha256-abc' })
       await mintTestToken({
         subject: 'user-2',
-        entity: { id: 'u2', name: 'bob', type: 'user', role: Role.USER },
+        entity: { id: 'u2', name: 'bob', type: 'user' },
       })
 
       const filtered = await factory.listTokens({ certificateFingerprint: 'sha256-abc' })
@@ -312,7 +310,7 @@ describe('JWTTokenFactory', () => {
       await mintTestToken({
         subject: 'user-2',
         sans: ['web.example.com'],
-        entity: { id: 'u2', name: 'bob', type: 'user', role: Role.USER },
+        entity: { id: 'u2', name: 'bob', type: 'user' },
       })
 
       const filtered = await factory.listTokens({ san: 'api.example.com' })
@@ -354,8 +352,8 @@ describe('JWTTokenFactory', () => {
 
       const token = await f.mint({
         subject: 'test',
-        roles: [Role.USER],
-        entity: { id: 't1', name: 'test', type: 'user', role: Role.USER },
+        principal: Principal.USER,
+        entity: { id: 't1', name: 'test', type: 'user' },
       })
 
       const result = await f.verify(token)

--- a/packages/authorization/tests/jwt/local.test.ts
+++ b/packages/authorization/tests/jwt/local.test.ts
@@ -3,7 +3,7 @@ import * as jose from 'jose'
 import { type TokenStore } from '../../src/jwt/index.js'
 import { LocalTokenManager } from '../../src/jwt/local/index.js'
 import { type IKeyManager } from '../../src/key-manager/index.js'
-import { Role } from '../../src/policy/src/definitions/models.js'
+import { Principal } from '../../src/policy/src/definitions/models.js'
 
 describe('LocalTokenManager', () => {
   const mockKeyManager: IKeyManager = {
@@ -47,12 +47,11 @@ describe('LocalTokenManager', () => {
 
     const token = await manager.mint({
       subject: 'user-1',
-      roles: [Role.USER],
+      principal: Principal.USER,
       entity: {
         id: 'user-1',
         name: 'alice',
         type: 'user',
-        role: Role.USER,
       },
     })
 
@@ -66,12 +65,11 @@ describe('LocalTokenManager', () => {
 
     const token = await manager.mint({
       subject: 'user-1',
-      roles: [Role.USER],
+      principal: Principal.USER,
       entity: {
         id: 'user-1',
         name: 'alice',
         type: 'user',
-        role: Role.USER,
         nodeId: 'node-b', // Explicitly provided
       },
     })

--- a/packages/authorization/tests/policy/jwt-helper.test.ts
+++ b/packages/authorization/tests/policy/jwt-helper.test.ts
@@ -1,19 +1,18 @@
 import { describe, expect, it } from 'bun:test'
 import { jwtToEntity } from '../../src/jwt/index.js'
-import { Role } from '../../src/policy/src/definitions/models.js'
+import { Principal } from '../../src/policy/src/definitions/models.js'
 
 describe('jwtToEntity', () => {
-  it('should map a JWT payload to a Cedar Entity with primary role and name', () => {
+  it('should map a JWT payload to a Cedar Entity using principal directly', () => {
     const payload = {
       sub: 'user-123',
+      principal: Principal.ADMIN,
       entity: {
         id: 'user-123',
         name: 'alice',
         type: 'user',
-        role: Role.ADMIN,
         nodeId: 'node-a',
       },
-      roles: [Role.ADMIN, Role.USER],
       claims: {
         orgId: 'org-456',
       },
@@ -26,10 +25,9 @@ describe('jwtToEntity', () => {
     expect(entity.attrs.id).toBe('user-123')
     expect(entity.attrs.name).toBe('alice')
     expect(entity.attrs.orgId).toBe('org-456')
-    // nodeId is no longer mapped directly
   })
 
-  it('should fallback to first role if primaryRole is missing', () => {
+  it('should fallback to USER principal if principal is missing', () => {
     const payload = {
       sub: 'node-01',
       entity: {
@@ -37,19 +35,18 @@ describe('jwtToEntity', () => {
         name: 'catalyst-node-01',
         type: 'node',
       },
-      roles: [Role.NODE],
     }
 
     const entity = jwtToEntity(payload)
 
-    expect(entity.uid.type).toBe('CATALYST::NODE')
+    expect(entity.uid.type).toBe('CATALYST::USER')
     expect(entity.uid.id).toBe('catalyst-node-01')
   })
 
   it('should fallback to sub if entity.name is missing', () => {
     const payload = {
       sub: 'user-789',
-      roles: [Role.USER],
+      principal: Principal.USER,
     }
 
     const entity = jwtToEntity(payload)

--- a/packages/authorization/tests/service/rpc-progressive.test.ts
+++ b/packages/authorization/tests/service/rpc-progressive.test.ts
@@ -12,7 +12,7 @@ import {
   type CatalystPolicyDomain,
 } from '../../src/policy/src/index.js'
 import { JWTTokenFactory } from '../../src/jwt/jwt-token-factory.js'
-import { Role } from '../../src/policy/src/definitions/models.js'
+import { Principal } from '../../src/policy/src/definitions/models.js'
 import type { TokenRecord } from '../../src/jwt/index.js'
 import { TelemetryBuilder } from '@catalyst/telemetry'
 
@@ -35,10 +35,9 @@ describe('Auth Progressive API', () => {
         id: 'admin-user',
         name: 'Admin',
         type: 'user',
-        role: Role.ADMIN,
         trustedDomains: ['test-domain'],
       },
-      roles: [Role.ADMIN],
+      principal: Principal.ADMIN,
     })
 
     // User token: Trusted for 'test-domain'
@@ -48,10 +47,9 @@ describe('Auth Progressive API', () => {
         id: 'regular-user',
         name: 'User',
         type: 'user',
-        role: Role.USER,
         trustedDomains: ['test-domain'],
       },
-      roles: [Role.USER],
+      principal: Principal.USER,
     })
 
     policyService = new AuthorizationEngine<CatalystPolicyDomain>(CATALYST_SCHEMA, ALL_POLICIES)
@@ -87,8 +85,8 @@ describe('Auth Progressive API', () => {
       const handlers = (await rpcServer.tokens(adminToken)) as TokenHandlers
       const newToken = await handlers.create({
         subject: 'new-service',
-        entity: { id: 's1', name: 'Service', type: 'service', role: Role.NODE },
-        roles: [Role.NODE],
+        entity: { id: 's1', name: 'Service', type: 'service' },
+        principal: Principal.NODE,
       })
       expect(newToken).toBeString()
 
@@ -167,10 +165,9 @@ describe('Auth Progressive API', () => {
           id: 'admin-user',
           name: 'Admin',
           type: 'user',
-          role: Role.ADMIN,
           trustedDomains: ['other-domain'],
         },
-        roles: [Role.ADMIN],
+        principal: Principal.ADMIN,
       })
 
       const result = await rpcServer.tokens(otherDomainToken)
@@ -186,11 +183,10 @@ describe('Auth Progressive API', () => {
           id: 'admin-user',
           name: 'Admin',
           type: 'user',
-          role: Role.ADMIN,
           trustedDomains: ['test-domain'],
           trustedNodes: ['other-node'],
         },
-        roles: [Role.ADMIN],
+        principal: Principal.ADMIN,
       })
 
       const result = await rpcServer.tokens(otherNodeToken)
@@ -206,11 +202,10 @@ describe('Auth Progressive API', () => {
           id: 'admin-user',
           name: 'Admin',
           type: 'user',
-          role: Role.ADMIN,
           trustedDomains: ['test-domain'],
           trustedNodes: ['test-node'],
         },
-        roles: [Role.ADMIN],
+        principal: Principal.ADMIN,
       })
 
       const handlers = await rpcServer.tokens(matchedNodeToken)
@@ -225,10 +220,9 @@ describe('Auth Progressive API', () => {
           id: 'admin-user',
           name: 'Admin',
           type: 'user',
-          role: Role.ADMIN,
           trustedDomains: ['domain-A', 'test-domain'],
         },
-        roles: [Role.ADMIN],
+        principal: Principal.ADMIN,
       })
 
       const handlers = await rpcServer.tokens(multiDomainToken)


### PR DESCRIPTION
Tokens now store the Cedar principal type directly (e.g. CATALYST::ADMIN)
instead of roles. MintOptions accepts `principal: Principal` replacing
`roles: Role[]` and `entity.role`. jwtToEntity() reads the principal
as-is with no string interpolation mapping. Removed redundant `role`
attribute from Cedar schema entity types.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>