### PR TITLE
refactor(cli): update token commands to use Principal instead of Role

### DIFF
--- a/apps/cli/src/commands/auth/token.ts
+++ b/apps/cli/src/commands/auth/token.ts
@@ -1,4 +1,4 @@
-import { Role } from '@catalyst/authorization'
+import { Principal } from '@catalyst/authorization'
 import { Command } from 'commander'
 import chalk from 'chalk'
 import { createAuthClient } from '../../clients/auth-client.js'
@@ -16,7 +16,11 @@ export function tokenCommands(): Command {
     .command('mint')
     .description('Mint a new token')
     .argument('<subject>', 'Token subject (user/service ID)')
-    .option('--role <role>', `Role (${Object.values(Role).join(', ')})`, 'USER')
+    .option(
+      '--principal <principal>',
+      `Principal (${Object.values(Principal).join(', ')})`,
+      Principal.USER
+    )
     .option('--name <name>', 'Entity name')
     .option('--type <type>', 'Entity type (user, service)', 'user')
     .option('--expires-in <duration>', 'Expiration (e.g., 1h, 7d, 30m)')
@@ -28,7 +32,7 @@ export function tokenCommands(): Command {
       const globals = cmd.optsWithGlobals()
       const validation = MintTokenInputSchema.safeParse({
         subject,
-        role: options.role,
+        principal: options.principal,
         name: options.name || subject,
         type: options.type,
         expiresIn: options.expiresIn,

--- a/apps/cli/src/handlers/auth-token-handlers.ts
+++ b/apps/cli/src/handlers/auth-token-handlers.ts
@@ -44,12 +44,11 @@ export async function mintTokenHandler(input: MintTokenInput): Promise<MintToken
         id: input.subject,
         name: input.name,
         type: input.type,
-        role: input.role,
         nodeId: input.nodeId,
         trustedDomains: input.trustedDomains,
         trustedNodes: input.trustedNodes,
       },
-      roles: [input.role],
+      principal: input.principal,
       expiresIn: input.expiresIn,
     })
 

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -1,4 +1,4 @@
-import { Role } from '@catalyst/authorization'
+import { Principal } from '@catalyst/authorization'
 import { DataChannelDefinitionSchema } from '@catalyst/routing'
 import { z } from 'zod'
 
@@ -70,7 +70,7 @@ export type ListRoutesInput = z.infer<typeof ListRoutesInputSchema>
 // Auth Token Schemas
 export const MintTokenInputSchema = z.object({
   subject: z.string().min(1),
-  role: z.enum(Role),
+  principal: z.enum(Principal),
   name: z.string().min(1),
   type: z.enum(['user', 'service']).default('user'),
   expiresIn: z.string().optional(),


### PR DESCRIPTION
CLI mint command now uses --principal flag (default: CATALYST::USER)
instead of --role. Handler passes principal directly to auth RPC API.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>