### PR TITLE
fix(tests): quirks on examples.Dockerfiles

### DIFF
--- a/apps/auth/tests/system-token.test.ts
+++ b/apps/auth/tests/system-token.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'bun:test'
+import { beforeAll, describe, expect, it } from 'bun:test'
 import * as jose from 'jose'
 
 describe('System Admin Token', () => {

--- a/apps/orchestrator/tests/orchestrator.gateway.container.test.ts
+++ b/apps/orchestrator/tests/orchestrator.gateway.container.test.ts
@@ -124,7 +124,7 @@ describe.skipIf(skipTests)('Orchestrator Gateway Container Tests', () => {
       gateway = await startContainer(
         'gateway',
         'gateway',
-        'GATEWAY_STARTED',
+        'Catalyst server [gateway] listening',
         {
           CATALYST_NODE_ID: 'gateway',
         },
@@ -299,7 +299,7 @@ describe.skipIf(skipTests)('Orchestrator Gateway Container Tests', () => {
       gateway = await startContainer(
         'gateway',
         'gateway',
-        'GATEWAY_STARTED',
+        'Catalyst server [gateway] listening',
         {
           CATALYST_NODE_ID: 'gateway',
         },

--- a/examples/movies-api/Dockerfile
+++ b/examples/movies-api/Dockerfile
@@ -18,6 +18,7 @@ COPY packages/routing/package.json packages/routing/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/telemetry/package.json packages/telemetry/package.json
 COPY packages/types/package.json packages/types/package.json
+COPY packages/service/package.json packages/service/package.json
 COPY examples/books-api/package.json examples/books-api/package.json
 COPY examples/movies-api/package.json examples/movies-api/package.json
 COPY examples/orders-api/package.json examples/orders-api/package.json
@@ -49,6 +50,7 @@ COPY packages/routing/package.json packages/routing/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/telemetry/package.json packages/telemetry/package.json
 COPY packages/types/package.json packages/types/package.json
+COPY packages/service/package.json packages/service/package.json
 COPY examples/books-api/package.json examples/books-api/package.json
 COPY examples/movies-api/package.json examples/movies-api/package.json
 COPY examples/orders-api/package.json examples/orders-api/package.json

--- a/examples/orders-api/Dockerfile
+++ b/examples/orders-api/Dockerfile
@@ -18,6 +18,7 @@ COPY packages/routing/package.json packages/routing/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/telemetry/package.json packages/telemetry/package.json
 COPY packages/types/package.json packages/types/package.json
+COPY packages/service/package.json packages/service/package.json
 COPY examples/books-api/package.json examples/books-api/package.json
 COPY examples/movies-api/package.json examples/movies-api/package.json
 COPY examples/orders-api/package.json examples/orders-api/package.json
@@ -49,6 +50,7 @@ COPY packages/routing/package.json packages/routing/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/telemetry/package.json packages/telemetry/package.json
 COPY packages/types/package.json packages/types/package.json
+COPY packages/service/package.json packages/service/package.json
 COPY examples/books-api/package.json examples/books-api/package.json
 COPY examples/movies-api/package.json examples/movies-api/package.json
 COPY examples/orders-api/package.json examples/orders-api/package.json

--- a/examples/product-api/Dockerfile
+++ b/examples/product-api/Dockerfile
@@ -18,6 +18,7 @@ COPY packages/routing/package.json packages/routing/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/telemetry/package.json packages/telemetry/package.json
 COPY packages/types/package.json packages/types/package.json
+COPY packages/service/package.json packages/service/package.json
 COPY examples/books-api/package.json examples/books-api/package.json
 COPY examples/movies-api/package.json examples/movies-api/package.json
 COPY examples/orders-api/package.json examples/orders-api/package.json
@@ -49,6 +50,7 @@ COPY packages/routing/package.json packages/routing/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/telemetry/package.json packages/telemetry/package.json
 COPY packages/types/package.json packages/types/package.json
+COPY packages/service/package.json packages/service/package.json
 COPY examples/books-api/package.json examples/books-api/package.json
 COPY examples/movies-api/package.json examples/movies-api/package.json
 COPY examples/orders-api/package.json examples/orders-api/package.json

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -94,7 +94,6 @@ type ConfigLoadOptions = {
  */
 export function loadDefaultConfig(options: ConfigLoadOptions = {}): CatalystConfig {
   const nodeName = process.env.CATALYST_NODE_ID
-  console.log('nodeName', nodeName)
   if (!nodeName) {
     throw new Error('CATALYST_NODE_ID environment variable is required')
   }


### PR DESCRIPTION
### TL;DR

Fixed Docker builds for example APIs and improved logging in the gateway container tests.

### What changed?

- Added missing `packages/service/package.json` to Dockerfiles for movies-api, orders-api, and product-api examples
- Updated the gateway container test to look for the correct startup message: `Catalyst server [gateway] listening` instead of `GATEWAY_STARTED`
- Removed a debug console.log statement from the config package
- Alphabetically sorted imports in the system-token test

### How to test?

1. Build the Docker images for the example APIs:
   ```
   docker build -t movies-api -f examples/movies-api/Dockerfile .
   docker build -t orders-api -f examples/orders-api/Dockerfile .
   docker build -t product-api -f examples/product-api/Dockerfile .
   ```

2. Run the orchestrator gateway container tests:
   ```
   bun test apps/orchestrator/tests/orchestrator.gateway.container.test.ts
   ```

### Why make this change?

The Docker builds for example APIs were failing because they were missing the service package. The gateway container tests were looking for an outdated startup message, causing tests to fail or time out. These changes ensure that builds complete successfully and tests correctly identify when services are ready.