### PR TITLE
feat(envoy): implement port allocator

### DIFF
--- a/apps/envoy/package.json
+++ b/apps/envoy/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@catalyst/envoy-service",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@catalyst/config": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/bun": "catalog:dev",
+    "typescript": "catalog:dev"
+  }
+}

--- a/apps/envoy/src/port-allocator.ts
+++ b/apps/envoy/src/port-allocator.ts
@@ -1,0 +1,103 @@
+import type { PortEntry } from '@catalyst/config'
+
+export interface PortAllocator {
+  /** Allocate a port for a data channel. Idempotent -- returns existing allocation. */
+  allocate(channelName: string): { success: true; port: number } | { success: false; error: string }
+
+  /** Release a previously allocated port. */
+  release(channelName: string): void
+
+  /** Get the port for a channel, if allocated. */
+  getPort(channelName: string): number | undefined
+
+  /** Get all current allocations. */
+  getAllocations(): ReadonlyMap<string, number>
+
+  /** Number of ports remaining in the pool. */
+  availableCount(): number
+}
+
+/**
+ * Expand a PortEntry array into a flat list of individual port numbers.
+ *
+ * Single ports pass through unchanged. Tuple ranges [start, end] expand
+ * into every integer from start to end inclusive.
+ */
+export function expandPortRange(entries: PortEntry[]): number[] {
+  const ports: number[] = []
+  for (const entry of entries) {
+    if (typeof entry === 'number') {
+      ports.push(entry)
+    } else {
+      const [start, end] = entry
+      for (let port = start; port <= end; port++) {
+        ports.push(port)
+      }
+    }
+  }
+  return ports
+}
+
+/**
+ * Create a port allocator from a PortEntry array.
+ *
+ * Optionally accepts existing allocations (Map<string, number>) for restart
+ * recovery. Re-hydrated ports are reserved in the pool before any new
+ * allocations are made.
+ */
+export function createPortAllocator(
+  portRange: PortEntry[],
+  existing?: Map<string, number>
+): PortAllocator {
+  const pool = expandPortRange(portRange)
+  const available = new Set<number>(pool)
+  const allocations = new Map<string, number>()
+
+  // Re-hydrate existing allocations
+  if (existing) {
+    for (const [name, port] of existing) {
+      allocations.set(name, port)
+      available.delete(port)
+    }
+  }
+
+  return {
+    allocate(channelName: string) {
+      // Idempotent: return existing allocation
+      const existing = allocations.get(channelName)
+      if (existing !== undefined) {
+        return { success: true, port: existing }
+      }
+
+      // Find next available port
+      const next = available.values().next()
+      if (next.done) {
+        return { success: false, error: 'No ports available' }
+      }
+
+      const port = next.value
+      available.delete(port)
+      allocations.set(channelName, port)
+      return { success: true, port }
+    },
+
+    release(channelName: string) {
+      const port = allocations.get(channelName)
+      if (port === undefined) return
+      allocations.delete(channelName)
+      available.add(port)
+    },
+
+    getPort(channelName: string) {
+      return allocations.get(channelName)
+    },
+
+    getAllocations() {
+      return allocations as ReadonlyMap<string, number>
+    },
+
+    availableCount() {
+      return available.size
+    },
+  }
+}

--- a/apps/envoy/tests/port-allocator.test.ts
+++ b/apps/envoy/tests/port-allocator.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from 'bun:test'
+import { expandPortRange, createPortAllocator } from '../src/port-allocator.js'
+
+describe('expandPortRange', () => {
+  it('expands single ports', () => {
+    const result = expandPortRange([8000])
+    expect(result).toEqual([8000])
+  })
+
+  it('expands tuple ranges', () => {
+    const result = expandPortRange([[9000, 9003]])
+    expect(result).toEqual([9000, 9001, 9002, 9003])
+  })
+
+  it('expands mixed single ports and ranges', () => {
+    const result = expandPortRange([8000, [9000, 9002], 10000])
+    expect(result).toEqual([8000, 9000, 9001, 9002, 10000])
+  })
+
+  it('handles single-element tuple (start equals end)', () => {
+    const result = expandPortRange([[5000, 5000]])
+    expect(result).toEqual([5000])
+  })
+
+  it('expands multiple ranges', () => {
+    const result = expandPortRange([
+      [100, 102],
+      [200, 201],
+    ])
+    expect(result).toEqual([100, 101, 102, 200, 201])
+  })
+
+  it('returns empty array for empty input', () => {
+    const result = expandPortRange([])
+    expect(result).toEqual([])
+  })
+})
+
+describe('createPortAllocator', () => {
+  describe('creation', () => {
+    it('creates allocator from PortEntry array', () => {
+      const allocator = createPortAllocator([8000, [9000, 9002]])
+      expect(allocator).toBeDefined()
+    })
+
+    it('starts with correct availableCount', () => {
+      const allocator = createPortAllocator([8000, [9000, 9002]])
+      // 8000 + 9000, 9001, 9002 = 4 ports
+      expect(allocator.availableCount()).toBe(4)
+    })
+
+    it('initially has empty allocations', () => {
+      const allocator = createPortAllocator([8000])
+      expect(allocator.getAllocations().size).toBe(0)
+    })
+  })
+
+  describe('allocation', () => {
+    it('allocates the first port for a channel', () => {
+      const allocator = createPortAllocator([8000, 8001, 8002])
+      const result = allocator.allocate('books-api')
+      expect(result).toEqual({ success: true, port: 8000 })
+    })
+
+    it('allocates sequential ports for different channels', () => {
+      const allocator = createPortAllocator([8000, 8001, 8002])
+      const first = allocator.allocate('books-api')
+      const second = allocator.allocate('movies-api')
+      expect(first).toEqual({ success: true, port: 8000 })
+      expect(second).toEqual({ success: true, port: 8001 })
+    })
+
+    it('is idempotent: same channel returns same port', () => {
+      const allocator = createPortAllocator([8000, 8001])
+      const first = allocator.allocate('books-api')
+      const second = allocator.allocate('books-api')
+      expect(first).toEqual({ success: true, port: 8000 })
+      expect(second).toEqual({ success: true, port: 8000 })
+    })
+
+    it('idempotent allocation does not consume additional ports', () => {
+      const allocator = createPortAllocator([8000, 8001])
+      allocator.allocate('books-api')
+      allocator.allocate('books-api') // idempotent
+      expect(allocator.availableCount()).toBe(1)
+    })
+
+    it('returns error when pool is exhausted', () => {
+      const allocator = createPortAllocator([8000])
+      allocator.allocate('books-api')
+      const result = allocator.allocate('movies-api')
+      expect(result).toEqual({ success: false, error: 'No ports available' })
+    })
+
+    it('decrements availableCount on allocation', () => {
+      const allocator = createPortAllocator([8000, 8001, 8002])
+      expect(allocator.availableCount()).toBe(3)
+      allocator.allocate('books-api')
+      expect(allocator.availableCount()).toBe(2)
+    })
+  })
+
+  describe('release', () => {
+    it('frees a previously allocated port', () => {
+      const allocator = createPortAllocator([8000, 8001])
+      allocator.allocate('books-api')
+      expect(allocator.availableCount()).toBe(1)
+      allocator.release('books-api')
+      expect(allocator.availableCount()).toBe(2)
+    })
+
+    it('released port becomes available for next allocation', () => {
+      const allocator = createPortAllocator([8000])
+      allocator.allocate('books-api')
+      allocator.release('books-api')
+      const result = allocator.allocate('movies-api')
+      expect(result).toEqual({ success: true, port: 8000 })
+    })
+
+    it('releasing unallocated name is a no-op', () => {
+      const allocator = createPortAllocator([8000])
+      allocator.release('unknown-service')
+      expect(allocator.availableCount()).toBe(1)
+    })
+
+    it('getPort returns undefined after release', () => {
+      const allocator = createPortAllocator([8000])
+      allocator.allocate('books-api')
+      allocator.release('books-api')
+      expect(allocator.getPort('books-api')).toBeUndefined()
+    })
+  })
+
+  describe('getters', () => {
+    it('getPort returns allocated port', () => {
+      const allocator = createPortAllocator([8000, 8001])
+      allocator.allocate('books-api')
+      expect(allocator.getPort('books-api')).toBe(8000)
+    })
+
+    it('getPort returns undefined for unknown channel', () => {
+      const allocator = createPortAllocator([8000])
+      expect(allocator.getPort('unknown')).toBeUndefined()
+    })
+
+    it('getAllocations returns current allocations', () => {
+      const allocator = createPortAllocator([8000, 8001])
+      allocator.allocate('books-api')
+      allocator.allocate('movies-api')
+      const allocs = allocator.getAllocations()
+      expect(allocs.size).toBe(2)
+      expect(allocs.get('books-api')).toBe(8000)
+      expect(allocs.get('movies-api')).toBe(8001)
+    })
+
+    it('getAllocations returns ReadonlyMap (snapshot)', () => {
+      const allocator = createPortAllocator([8000])
+      allocator.allocate('books-api')
+      const allocs = allocator.getAllocations()
+      expect(allocs.get('books-api')).toBe(8000)
+    })
+  })
+
+  describe('restart recovery', () => {
+    it('accepts existing allocations for re-hydration', () => {
+      const existing = new Map<string, number>([['books-api', 8001]])
+      const allocator = createPortAllocator([8000, 8001, 8002], existing)
+      expect(allocator.getPort('books-api')).toBe(8001)
+    })
+
+    it('re-hydrated ports are marked as used', () => {
+      const existing = new Map<string, number>([['books-api', 8001]])
+      const allocator = createPortAllocator([8000, 8001, 8002], existing)
+      // 3 total ports minus 1 re-hydrated = 2 available
+      expect(allocator.availableCount()).toBe(2)
+    })
+
+    it('new allocations skip re-hydrated ports', () => {
+      const existing = new Map<string, number>([['books-api', 8000]])
+      const allocator = createPortAllocator([8000, 8001, 8002], existing)
+      const result = allocator.allocate('movies-api')
+      expect(result).toEqual({ success: true, port: 8001 })
+    })
+
+    it('re-hydrated allocations appear in getAllocations', () => {
+      const existing = new Map<string, number>([
+        ['books-api', 8000],
+        ['movies-api', 8002],
+      ])
+      const allocator = createPortAllocator([8000, 8001, 8002], existing)
+      const allocs = allocator.getAllocations()
+      expect(allocs.size).toBe(2)
+      expect(allocs.get('books-api')).toBe(8000)
+      expect(allocs.get('movies-api')).toBe(8002)
+    })
+
+    it('can allocate after re-hydration fills some ports', () => {
+      const existing = new Map<string, number>([
+        ['books-api', 8000],
+        ['movies-api', 8001],
+      ])
+      const allocator = createPortAllocator([8000, 8001, 8002], existing)
+      const result = allocator.allocate('orders-api')
+      expect(result).toEqual({ success: true, port: 8002 })
+    })
+
+    it('empty existing allocations map works like fresh allocator', () => {
+      const allocator = createPortAllocator([8000, 8001], new Map())
+      expect(allocator.availableCount()).toBe(2)
+      expect(allocator.getAllocations().size).toBe(0)
+    })
+  })
+})

--- a/apps/envoy/tsconfig.json
+++ b/apps/envoy/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

- Scaffold `apps/envoy` package (`@catalyst/envoy-service`) with package.json and tsconfig
- Implement `expandPortRange()` — expands `PortEntry[]` (single ports + [start, end] tuples) into flat port list
- Implement `createPortAllocator()` — pure synchronous port allocator with idempotent allocation, release, and restart recovery via re-hydration
- 29 unit tests covering expansion, allocation, release, getters, exhaustion, and restart recovery

## Changes

| File | Change |
|------|--------|
| `apps/envoy/package.json` | New package scaffold |
| `apps/envoy/tsconfig.json` | Extends root tsconfig |
| `apps/envoy/src/port-allocator.ts` | Port allocator implementation |
| `apps/envoy/tests/port-allocator.test.ts` | 29 unit tests |

## Test plan

- [x] 29 port allocator tests pass
- [x] ESLint clean
- [x] Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)