### PR TITLE
docs: add source-available license, CLA, and contribution guidelines

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,132 @@
+# Catalyst Node Individual Contributor License Agreement ("Agreement") v1.0
+
+Thank you for your interest in contributing to Catalyst Node, a project
+maintained by Orbis Operations LLC ("the Company"). In order to clarify the
+intellectual property licenses granted with Contributions from any person or
+entity, the Company must have a Contributor License Agreement ("CLA") on file
+that has been agreed to by each Contributor, indicating agreement to the
+license terms below.
+
+This license is for your protection as a Contributor as well as the protection
+of the Company and its users; it does not change your rights to use your own
+Contributions for any other purpose.
+
+To agree to this CLA, please complete and sign the signature block at the
+bottom of this document and submit it to the Company by opening a pull request
+that adds your name and details to the CONTRIBUTORS file in the project
+repository, or by sending a signed copy to the Company via the method specified
+in the project's contributing guidelines.
+
+Please read this document carefully before signing and keep a copy for your
+records.
+
+## Definitions
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized by
+the copyright owner that is making this Agreement with the Company. For legal
+entities, the entity making a Contribution and all other entities that control,
+are controlled by, or are under common control with that entity are considered
+to be a single Contributor. For the purposes of this definition, "control"
+means (i) the power, direct or indirect, to cause the direction or management
+of such entity, whether by contract or otherwise, or (ii) ownership of fifty
+percent (50%) or more of the outstanding shares, or (iii) beneficial ownership
+of such entity.
+
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally Submitted
+by You to the Company for inclusion in, or documentation of, any of the
+products or projects owned or managed by the Company (the "Work"). For the
+purposes of this definition, "Submitted" means any form of electronic, verbal,
+or written communication sent to the Company or its representatives, including
+but not limited to communication on electronic mailing lists, source code
+control systems, and issue tracking systems that are managed by, or on behalf
+of, the Company for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise designated in
+writing by You as "Not a Contribution."
+
+"Work" shall mean the Catalyst Node project and any other project owned or
+managed by the Company to which Contributions may be made.
+
+## 1. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Company and to recipients of software distributed by the Company a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright
+license to reproduce, prepare derivative works of, publicly display, publicly
+perform, sublicense, and distribute Your Contributions and such derivative
+works.
+
+## 2. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Company and to recipients of software distributed by the Company a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as
+stated in this section) patent license to make, have made, use, offer to sell,
+sell, import, and otherwise transfer the Work, where such license applies only
+to those patent claims licensable by You that are necessarily infringed by Your
+Contribution(s) alone or by combination of Your Contribution(s) with the Work
+to which such Contribution(s) was submitted. If any entity institutes patent
+litigation against You or any other entity (including a cross-claim or
+counterclaim in a lawsuit) alleging that Your Contribution, or the Work to
+which You have contributed, constitutes direct or contributory patent
+infringement, then any patent licenses granted to that entity under this
+Agreement for that Contribution or Work shall terminate as of the date such
+litigation is filed.
+
+## 3. Representations
+
+You represent that:
+
+(a) You are legally entitled to grant the above licenses. If Your employer(s)
+has rights to intellectual property that You create that includes Your
+Contributions, You represent that You have received permission to make
+Contributions on behalf of that employer, that Your employer has waived such
+rights for Your Contributions to the Company, or that Your employer has
+executed a separate Corporate CLA with the Company.
+
+(b) Each of Your Contributions is Your original creation (see Section 5 for
+submissions on behalf of others).
+
+(c) Your Contribution submissions include complete details of any third-party
+license or other restriction (including, but not limited to, related patents
+and trademarks) of which You are personally aware and which are associated with
+any part of Your Contributions.
+
+## 4. No Warranty
+
+Your Contributions are provided on an "AS IS" basis, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including, without
+limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are not expected to
+provide support for Your Contributions, except to the extent You desire to
+provide support.
+
+## 5. Third-Party Submissions
+
+Should You wish to Submit work that is not Your original creation, You may
+Submit it to the Company separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which You are personally aware, and conspicuously marking the
+work as "Submitted on behalf of a third party: [named here]."
+
+## 6. Notification
+
+You agree to notify the Company of any facts or circumstances of which You
+become aware that would make these representations inaccurate in any respect.
+
+---
+
+## Signature
+
+By signing below, You accept and agree to the terms of this Contributor
+License Agreement for all present and future Contributions Submitted to the
+Company.
+
+| Field           | Value                                |
+| --------------- | ------------------------------------ |
+| Full Name       | **************\_\_\_\_************** |
+| Date            | **************\_\_\_\_************** |
+| Email Address   | **************\_\_\_\_************** |
+| Mailing Address | **************\_\_\_\_************** |
+| Signature       | **************\_\_\_\_************** |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,173 @@
+# Contributing to Catalyst Node
+
+Thank you for your interest in contributing to Catalyst Node. This document
+explains the process for contributing to the project, from signing the
+Contributor License Agreement to submitting your first pull request.
+
+Catalyst Node is maintained by **Orbis Operations LLC**.
+
+---
+
+## Contributor License Agreement (CLA)
+
+Before any contribution can be accepted, you must sign the project's Contributor
+License Agreement. This is a one-time requirement.
+
+The CLA ensures that:
+
+- You **retain full copyright** over your contributions
+- You grant Orbis Operations LLC a broad, irrevocable license to use, modify,
+  sublicense, and distribute the contributed work
+- The project can be maintained and, if necessary, relicensed in the future
+
+### How to sign
+
+1. Read the full agreement in [CLA.md](./CLA.md)
+2. Print, sign, and scan the agreement (or apply a digital signature)
+3. Email the signed copy to the project maintainers
+4. Wait for confirmation before opening your first pull request
+
+Pull requests from contributors who have not signed the CLA will not be reviewed.
+
+---
+
+## Getting started
+
+1. **Fork** the repository on GitHub
+2. **Clone** your fork locally
+3. **Install dependencies** with `bun install`
+4. **Read** the [constitution.md](./constitution.md) -- it defines the
+   architectural principles that all code must follow. Constitutional violations
+   block merge with no exceptions.
+
+---
+
+## Development workflow
+
+Catalyst Node uses **Graphite** for stacked pull requests. All branching,
+committing, and submitting should use `gt` commands rather than raw `git`.
+
+### Creating a branch and PR
+
+```bash
+# Sync with trunk
+gt sync
+
+# Stage your changes and create a stacked branch
+gt add <files>
+gt create -m "type(scope): description"
+
+# Push immediately so the team has visibility
+gt submit
+```
+
+### Commit message format
+
+All commits must follow the **Conventional Commits** specification, enforced by
+commitlint:
+
+```
+type(scope): description
+```
+
+- **type**: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, or `perf`
+- **scope**: the package or area of the codebase (e.g., `auth`, `gateway`,
+  `orchestrator`)
+- **description**: lowercase, max 100 characters, no trailing period
+
+Examples:
+
+```
+feat(gateway): add telemetry instrumentation
+fix(auth): handle expired bootstrap tokens
+test(orchestrator): add dispatch action coverage
+```
+
+---
+
+## Pull request guidelines
+
+### Size and scope
+
+- **Under 600 lines** per PR
+- **One logical change** per PR -- do not mix refactoring with new features
+- Use stacked PRs to break large changes into reviewable pieces
+
+### PR description
+
+- Provide a clear summary of what changed and why
+- Reference related issues where applicable
+- Note any architectural decisions or trade-offs
+
+### Checklist before submitting
+
+- [ ] Code compiles without errors (`bun run lint` and type checking pass)
+- [ ] Tests pass (`bun test`)
+- [ ] New features include tests committed alongside the implementation
+- [ ] Bug fixes include a regression test
+- [ ] Documentation is updated if the change affects APIs, config, or CLI
+- [ ] Commit messages follow the conventional format
+- [ ] The PR stays within the 600-line guideline
+
+---
+
+## Coding conventions
+
+The project's [constitution.md](./constitution.md) is the authoritative source
+for coding standards. Key conventions include:
+
+- **ESM modules** with `.js` extensions in all imports
+- **Strict TypeScript** -- no `any`, no `@ts-ignore` without justification
+- **Zod schemas** for validating all external boundaries
+- **Discriminated union results** for operations that can fail
+- **Dependency inversion** -- accept interfaces, not concrete implementations
+- **kebab-case** file names, **PascalCase** types, **camelCase** functions
+- **No `console.log`** -- use the `@catalyst/telemetry` package for all logging
+
+---
+
+## Testing
+
+Catalyst Node follows test-driven development. Write tests before or alongside
+your implementation, not as an afterthought.
+
+- **Unit tests**: `*.test.ts` -- for core logic, no external dependencies
+- **Integration tests**: `*.integration.test.ts` -- for cross-package boundaries
+- **Topology tests**: `*.topology.test.ts` -- for orchestrator and peering flows
+- **Container tests**: `*.container.test.ts` -- for end-to-end Docker-based
+  validation (requires `CATALYST_CONTAINER_TESTS_ENABLED=true`)
+
+Run tests with:
+
+```bash
+bun test
+```
+
+---
+
+## Code review process
+
+1. Submit your PR via `gt submit`
+2. A maintainer will review your changes
+3. Address any feedback by amending with `gt modify` and resubmitting
+4. Once approved, a maintainer will merge the PR
+
+Reviews focus on correctness, adherence to the constitution, test coverage, and
+clarity. Constitutional violations are treated as critical findings and block
+merge.
+
+---
+
+## Code of conduct
+
+This project intends to adopt a formal code of conduct. In the meantime, all
+participants are expected to treat each other with respect, communicate
+constructively, and collaborate in good faith.
+
+---
+
+## License
+
+By contributing to Catalyst Node, you agree that your contributions will be
+licensed under the project's [LICENSE](./LICENSE) (Commons Clause + Elastic
+License 2.0) and that you have signed the [CLA](./CLA.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,130 @@
+Copyright (c) 2025 Orbis Operations LLC. All Rights Reserved.
+
+The software is provided under a combination of the "Commons Clause"
+License Condition v1.0 and the Elastic License 2.0 (ELv2), as set
+forth below. By using, copying, modifying, or distributing this
+software, you agree to the terms and conditions of both.
+
+========================================================================
+
+"Commons Clause" License Condition v1.0
+
+The Software is provided to you by the Licensor under the License, as
+defined below, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights
+under the License will not include, and the License does not grant to
+you, the right to Sell the Software.
+
+For purposes of the foregoing, "Sell" means practicing any or all of
+the rights granted to you under the License to provide to third
+parties, for a fee or other consideration (including without limitation
+fees for hosting or consulting/support services related to the
+Software), a product or service whose value derives, entirely or
+substantially, from the functionality of the Software. Any license
+notice or attribution required by the License must also include this
+Commons Clause License Condition notice.
+
+Software:  Catalyst Node
+License:   Elastic License 2.0 (ELv2)
+Licensor:  Orbis Operations LLC
+
+========================================================================
+
+Elastic License 2.0 (ELv2)
+
+Acceptance
+
+By using the software, you agree to all of the terms and conditions
+below.
+
+Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute,
+make available, and prepare derivative works of the software, in each
+case subject to the limitations and conditions below.
+
+Limitations
+
+You may not provide the software to third parties as a hosted or
+managed service, where the service provides users with access to any
+substantial set of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key
+functionality in the software, and you may not remove or obscure any
+functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or
+other notices of the licensor in the software. Any use of the
+licensor's trademarks is subject to applicable law.
+
+Patents
+
+The licensor grants you a license, under any patent claims the licensor
+can license, or becomes able to license, to make, have made, use, sell,
+offer for sale, import and have imported the software, in each case
+subject to the limitations and conditions in this license. This license
+does not cover any patent claims that you cause to be infringed by
+modifications or additions to the software. If you or your company make
+any written claim that the software infringes or contributes to
+infringement of any patent, your patent license for the software
+granted under these terms ends immediately. If your company makes such
+a claim, your patent license ends immediately for work on behalf of
+your company.
+
+Notices
+
+You must ensure that anyone who gets a copy of any part of the software
+from you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of
+the software prominent notices stating that you have modified the
+software.
+
+No Other Rights
+
+These terms do not imply any licenses other than those expressly
+granted in these terms.
+
+Termination
+
+If you use the software in violation of these terms, such use is not
+licensed, and your licenses will automatically terminate. If the
+licensor provides you with a notice of your violation, and you cease
+all violation of this license no later than 30 days after you receive
+that notice, your licenses will be reinstated retroactively. However,
+if you violate these terms after such reinstatement, any additional
+violation of these terms will cause your licenses to terminate
+automatically and permanently.
+
+No Liability
+
+As far as the law allows, the software comes as is, without any
+warranty or condition, and the licensor will not be liable to you for
+any damages arising out of these terms or the use or nature of the
+software, under any kind of legal claim.
+
+Definitions
+
+The "licensor" is the entity offering these terms, and the "software"
+is the software the licensor makes available under these terms,
+including any portion of it.
+
+"you" refers to the individual or entity agreeing to these terms.
+
+"your company" is any legal entity, sole proprietorship, or other kind
+of organization that you work for, plus all organizations that have
+control over, are under the control of, or are under common control
+with that organization. "control" means ownership of substantially all
+the assets of an entity, or the power to direct its management and
+policies by vote, contract, or otherwise. Control can be direct or
+indirect.
+
+"your licenses" are all the licenses granted to you for the software
+under these terms.
+
+"use" means anything you do with the software requiring one of your
+licenses.
+
+"trademark" means trademarks, service marks, and similar rights.

--- a/LICENSE_HUMAN_READABLE.md
+++ b/LICENSE_HUMAN_READABLE.md
@@ -1,0 +1,91 @@
+# Catalyst Node License -- Human-Readable Summary
+
+**This is a plain-language summary of the Catalyst Node license for quick reference.
+It is NOT the license itself and has no legal force. See the [LICENSE](./LICENSE)
+file for the complete, binding legal terms. If anything in this summary conflicts
+with the LICENSE file, the LICENSE file governs.**
+
+---
+
+## What kind of license is this?
+
+Catalyst Node is **source-available** software. The source code is publicly
+viewable, but commercial use is restricted.
+
+The project is licensed under two layers:
+
+1. **Elastic License 2.0 (ELv2)** -- a permissive source-available license
+2. **Commons Clause v1.0** -- an additional condition that restricts selling
+
+The licensor is **Orbis Operations LLC**.
+
+---
+
+## What you CAN do
+
+- **Use** the software for personal, internal, or non-commercial purposes
+- **View, study, and learn** from the source code
+- **Modify** the software and create derivative works
+- **Distribute** copies to others, provided you include the license and all
+  required notices
+
+---
+
+## What you CANNOT do
+
+- **Sell** the software or derivative works for a fee
+- **Offer the software as a paid hosted or managed service** where users get
+  access to any substantial set of its features or functionality
+- **Provide paid consulting or support services** where the value derives
+  entirely or substantially from the software's functionality
+- **Circumvent or remove license key functionality** in the software, or
+  obscure features protected by a license key
+- **Remove or alter** copyright, licensing, or attribution notices
+
+---
+
+## Patent rights
+
+The licensor grants you a patent license covering the software, subject to the
+same limitations described above.
+
+If you or your company file a written patent claim alleging that the software
+infringes any patent, your patent license under this agreement **terminates
+immediately**.
+
+---
+
+## Contributing
+
+Contributions are welcome, but every contributor must sign the project's
+Contributor License Agreement before any contribution can be accepted. See
+[CLA.md](./CLA.md) for the full agreement.
+
+Key points of the CLA:
+
+- Contributors **retain copyright** over their contributions
+- Contributors grant Orbis Operations LLC a broad, irrevocable license to use,
+  modify, sublicense, and distribute the contributed work
+- The CLA ensures the project can be maintained and relicensed if needed while
+  respecting contributor ownership
+
+---
+
+## Termination and reinstatement
+
+- Your license **terminates automatically** if you violate the terms
+- If the licensor notifies you of a violation and you **cure it within 30 days**,
+  your license is reinstated retroactively
+- Any further violation after reinstatement causes **permanent termination**
+
+---
+
+## No warranty
+
+The software is provided **as-is**, without any warranty or condition. The
+licensor is not liable for any damages arising from its use.
+
+---
+
+_This summary is provided for convenience only. For the authoritative terms,
+refer to the [LICENSE](./LICENSE) file._


### PR DESCRIPTION
Add Commons Clause v1.0 + Elastic License 2.0 (ELv2) as the project
license, establishing Catalyst Node as source-available software with
commercial restrictions. Include an Apache-style Individual Contributor
License Agreement and contributing guidelines.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>