### PR TITLE
docs: rename project from Catalyst Node to Catalyst Router

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## System Overview: The Core Pod
 
-Catalyst Node runs as a cohesive set of containers ("The Core Pod") orchestrated by the main **Catalyst Node** process.
+Catalyst Router runs as a cohesive set of containers ("The Core Pod") orchestrated by the main **Catalyst Router** process.
 
 ```mermaid
 graph TD
@@ -11,7 +11,7 @@ graph TD
     end
 
     subgraph ControlPlane [Control Plane Pod]
-        Orchestrator["Catalyst Node <br/> (Orchestrator)"]
+        Orchestrator["Catalyst Router <br/> (Orchestrator)"]
         GQL["GraphQL Gateway <br/> (Sidecar)"]
         Auth["Auth Service <br/> (Sidecar)"]
         OTEL["OTEL Collector <br/> (Sidecar)"]
@@ -37,7 +37,7 @@ graph TD
 
 ### Components
 
-#### 1. Catalyst Node (The Orchestrator)
+#### 1. Catalyst Router (The Orchestrator)
 
 - **Role**: Central Brain.
 - **Responsibilities**:
@@ -155,20 +155,20 @@ The Orchestrator implements a lightweight xDS Control Plane that pushes JSON upd
 
 ## Identity & API Management
 
-Catalyst Node supports three strategies for API Key management and service authentication.
+Catalyst Router supports three strategies for API Key management and service authentication.
 
 ### Option 1: Completely External Service
 
 - **Description**: Identity is handled entirely outside the Catalyst mesh.
 - **Flow**:
   1.  Client gets token from External Auth Provider (Auth0, Okta, etc.).
-  2.  Client sends token to Catalyst Node.
+  2.  Client sends token to Catalyst Router.
   3.  Envoy/Auth Service validates the token signature against absolute external JWKS.
 - **Use Case**: Enterprise integration where Identity is already solved.
 
 ### Option 2: Centralized API Service (Single Node)
 
-- **Description**: One specific Catalyst Node acts as the "Identity Authority" for the cluster.
+- **Description**: One specific Catalyst Router acts as the "Identity Authority" for the cluster.
 - **Flow**:
   1.  Admin generates API Keys/Tokens on the Leader Node.
   2.  Other Nodes are configured to delegate auth decisions or sync JWKS from the Leader.

--- a/BGP_PROTOCOL.md
+++ b/BGP_PROTOCOL.md
@@ -1,6 +1,6 @@
 # BGP Service Discovery Protocol
 
-This document outlines the adaptation of the Border Gateway Protocol (BGP) for service discovery within the Catalyst Node ecosystem. Instead of routing IP packets between Autonomous Systems (AS) based on CIDR blocks, we propagate service availability and routing information for logical domains.
+This document outlines the adaptation of the Border Gateway Protocol (BGP) for service discovery within the Catalyst Router ecosystem. Instead of routing IP packets between Autonomous Systems (AS) based on CIDR blocks, we propagate service availability and routing information for logical domains.
 
 ## Overview
 
@@ -9,7 +9,7 @@ In this system, an **Autonomous System (AS)** represents a logical domain of ser
 - **Standard BGP**: Routes `10.0.0.0/24` -> Next Hop IP.
 - **Catalyst BGP**: Routes `*.mydatacenter.mycompany` -> Envoy Node ID / Service Endpoint.
 
-Traffic is routed via Envoy proxies, not at the IP layer. The "Next Hop" is a catalyst node that can forward the request or terminate it at a local service.
+Traffic is routed via Envoy proxies, not at the IP layer. The "Next Hop" is a catalyst router that can forward the request or terminate it at a local service.
 
 ## Architecture
 

--- a/CLA.md
+++ b/CLA.md
@@ -1,6 +1,6 @@
-# Catalyst Node Individual Contributor License Agreement ("Agreement") v1.0
+# Catalyst Router Individual Contributor License Agreement ("Agreement") v1.0
 
-Thank you for your interest in contributing to Catalyst Node, a project
+Thank you for your interest in contributing to Catalyst Router, a project
 maintained by Orbis Operations LLC ("the Company"). In order to clarify the
 intellectual property licenses granted with Contributions from any person or
 entity, the Company must have a Contributor License Agreement ("CLA") on file
@@ -44,7 +44,7 @@ of, the Company for the purpose of discussing and improving the Work, but
 excluding communication that is conspicuously marked or otherwise designated in
 writing by You as "Not a Contribution."
 
-"Work" shall mean the Catalyst Node project and any other project owned or
+"Work" shall mean the Catalyst Router project and any other project owned or
 managed by the Company to which Contributions may be made.
 
 ## 1. Grant of Copyright License
@@ -123,10 +123,10 @@ By signing below, You accept and agree to the terms of this Contributor
 License Agreement for all present and future Contributions Submitted to the
 Company.
 
-| Field           | Value                                |
-| --------------- | ------------------------------------ |
-| Full Name       | **************\_\_\_\_************** |
-| Date            | **************\_\_\_\_************** |
-| Email Address   | **************\_\_\_\_************** |
-| Mailing Address | **************\_\_\_\_************** |
-| Signature       | **************\_\_\_\_************** |
+| Field           | Value                                    |
+| --------------- | ---------------------------------------- |
+| Full Name       | ******\*\*******\_\_\_\_******\*\******* |
+| Date            | ******\*\*******\_\_\_\_******\*\******* |
+| Email Address   | ******\*\*******\_\_\_\_******\*\******* |
+| Mailing Address | ******\*\*******\_\_\_\_******\*\******* |
+| Signature       | ******\*\*******\_\_\_\_******\*\******* |

--- a/CLI.md
+++ b/CLI.md
@@ -1,6 +1,6 @@
-# Catalyst Node CLI
+# Catalyst Router CLI
 
-The `catalyst-node` project uses `commander.js` to provide a robust command-line interface. The primary entry point is the `catalystd` command, which starts the server.
+The `catalyst-router` project uses `commander.js` to provide a robust command-line interface. The primary entry point is the `catalystd` command, which starts the server.
 
 ## Installation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Contributing to Catalyst Node
+# Contributing to Catalyst Router
 
-Thank you for your interest in contributing to Catalyst Node. This document
+Thank you for your interest in contributing to Catalyst Router. This document
 explains the process for contributing to the project, from signing the
 Contributor License Agreement to submitting your first pull request.
 
-Catalyst Node is maintained by **Orbis Operations LLC**.
+Catalyst Router is maintained by **Orbis Operations LLC**.
 
 ---
 
@@ -44,7 +44,7 @@ Pull requests from contributors who have not signed the CLA will not be reviewed
 
 ## Development workflow
 
-Catalyst Node uses **Graphite** for stacked pull requests. All branching,
+Catalyst Router uses **Graphite** for stacked pull requests. All branching,
 committing, and submitting should use `gt` commands rather than raw `git`.
 
 ### Creating a branch and PR
@@ -128,7 +128,7 @@ for coding standards. Key conventions include:
 
 ## Testing
 
-Catalyst Node follows test-driven development. Write tests before or alongside
+Catalyst Router follows test-driven development. Write tests before or alongside
 your implementation, not as an afterthought.
 
 - **Unit tests**: `*.test.ts` -- for core logic, no external dependencies
@@ -168,6 +168,6 @@ constructively, and collaborate in good faith.
 
 ## License
 
-By contributing to Catalyst Node, you agree that your contributions will be
+By contributing to Catalyst Router, you agree that your contributions will be
 licensed under the project's [LICENSE](./LICENSE) (Commons Clause + Elastic
 License 2.0) and that you have signed the [CLA](./CLA.md).

--- a/CROSSWALK.md
+++ b/CROSSWALK.md
@@ -1,6 +1,6 @@
 # Catalyst Project Crosswalk
 
-This document maps the concepts from the legacy `catalyst` project (GitHub) to the new `catalyst-node` objectives, annotated with the specific **Implementation Phase** that delivers the capability.
+This document maps the concepts from the legacy `catalyst` project (GitHub) to the new `catalyst-router` objectives, annotated with the specific **Implementation Phase** that delivers the capability.
 
 ## Conceptual Mapping
 

--- a/INTERNAL_PEERING.md
+++ b/INTERNAL_PEERING.md
@@ -1,6 +1,6 @@
 # Internal Peering Architecture
 
-This document describes the implementation of Internal Peering (iBGP) for the Catalyst Node orchestrator, focusing on the use of Cap'n Proto RPC for bidirectional communication and route propagation between nodes within the same Autonomous System (AS).
+This document describes the implementation of Internal Peering (iBGP) for the Catalyst Router orchestrator, focusing on the use of Cap'n Proto RPC for bidirectional communication and route propagation between nodes within the same Autonomous System (AS).
 
 ## Overview: BGP in Catalyst
 

--- a/LICENSE
+++ b/LICENSE
@@ -25,7 +25,7 @@ substantially, from the functionality of the Software. Any license
 notice or attribution required by the License must also include this
 Commons Clause License Condition notice.
 
-Software:  Catalyst Node
+Software:  Catalyst Router
 License:   Elastic License 2.0 (ELv2)
 Licensor:  Orbis Operations LLC
 

--- a/LICENSE_HUMAN_READABLE.md
+++ b/LICENSE_HUMAN_READABLE.md
@@ -1,6 +1,6 @@
-# Catalyst Node License -- Human-Readable Summary
+# Catalyst Router License -- Human-Readable Summary
 
-**This is a plain-language summary of the Catalyst Node license for quick reference.
+**This is a plain-language summary of the Catalyst Router license for quick reference.
 It is NOT the license itself and has no legal force. See the [LICENSE](./LICENSE)
 file for the complete, binding legal terms. If anything in this summary conflicts
 with the LICENSE file, the LICENSE file governs.**
@@ -9,7 +9,7 @@ with the LICENSE file, the LICENSE file governs.**
 
 ## What kind of license is this?
 
-Catalyst Node is **source-available** software. The source code is publicly
+Catalyst Router is **source-available** software. The source code is publicly
 viewable, but commercial use is restricted.
 
 The project is licensed under two layers:

--- a/MILESTONE.md
+++ b/MILESTONE.md
@@ -1,12 +1,12 @@
-# Catalyst Node Implementation Milestones
+# Catalyst Router Implementation Milestones
 
-This document outlines the step-by-step implementation strategy for **Catalyst Node**, consolidated from the architectural vision and the roll-out strategy.
+This document outlines the step-by-step implementation strategy for **Catalyst Router**, consolidated from the architectural vision and the roll-out strategy.
 
 > **Note on Configuration**: For all phases below, configuration is considered **a priori** (static at startup). We must verify that the node can be fully configured via both **JSON config file** and **CLI arguments/flags**. Dynamic configuration is out of scope for these initial phases.
 
 ## Feature Crosswalk (Legacy vs New)
 
-This table maps legacy `catalyst` capabilities to the specific Milestone that delivers them in `catalyst-node`.
+This table maps legacy `catalyst` capabilities to the specific Milestone that delivers them in `catalyst-router`.
 
 | Legacy Capability    | New Objective                  | Fulfillment Milestone              |
 | :------------------- | :----------------------------- | :--------------------------------- |

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Catalyst Node
+# Catalyst Router
 
-**Catalyst Node** is a distributed control and data plane designed to bridge organizations, clouds, and disparate fabrics. It enables different organizations to "peer" and offer services to each other in a cloud-native, edge-compatible way.
+**Catalyst Router** is a distributed control and data plane designed to bridge organizations, clouds, and disparate fabrics. It enables different organizations to "peer" and offer services to each other in a cloud-native, edge-compatible way.
 
-Modeled after BGP, Catalyst Node brings decentralized routing to Layers 4-7, allowing for service discovery and traffic propagation across trust boundaries without relying on centralized coordination like a single Kubernetes cluster or mesh.
+Modeled after BGP, Catalyst Router brings decentralized routing to Layers 4-7, allowing for service discovery and traffic propagation across trust boundaries without relying on centralized coordination like a single Kubernetes cluster or mesh.
 
 ## Mission
 
-Traditional service meshes (like Istio/Linkerd) excel at managing traffic _within_ a cluster or organization. Catalyst Node is built for the spaces _between_ them. We aim to:
+Traditional service meshes (like Istio/Linkerd) excel at managing traffic _within_ a cluster or organization. Catalyst Router is built for the spaces _between_ them. We aim to:
 
 - **Bridge Disparate Networks**: Connect on-prem datacenters, public clouds, and edge devices (even Raspberry Pis) into a unified service fabric.
 - **Enable Organizational Peering**: Allow Organization A to securely expose specific services to Organization B via standard peering agreements, similar to how ISPs peer on the internet.
@@ -14,7 +14,7 @@ Traditional service meshes (like Istio/Linkerd) excel at managing traffic _withi
 
 ## Core Architecture
 
-Catalyst Node runs as a **Core Pod** containing 5 specialized containers:
+Catalyst Router runs as a **Core Pod** containing 5 specialized containers:
 
 ### 1. Control Plane (The Orchestrator)
 
@@ -57,7 +57,7 @@ We support a variety of protocols for service definitions. Currently, **GraphQL*
 
 ## Testing
 
-Catalyst Node employs a multi-tiered testing strategy to ensure reliability across its distributed components. We primarily use `bun:test` as our test runner for its speed and native TypeScript support.
+Catalyst Router employs a multi-tiered testing strategy to ensure reliability across its distributed components. We primarily use `bun:test` as our test runner for its speed and native TypeScript support.
 
 ### Test Categories
 

--- a/SDK.md
+++ b/SDK.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The **Catalyst SDK** (`@catalyst/sdk`) is a TypeScript-based framework designed to accelerate the development of microservices that run alongside the **Catalyst Node**. It enforces patterns for observability, API design, and service discovery.
+The **Catalyst SDK** (`@catalyst/sdk`) is a TypeScript-based framework designed to accelerate the development of microservices that run alongside the **Catalyst Router**. It enforces patterns for observability, API design, and service discovery.
 
 ## Features
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-# Catalyst Node Peer Security Protocol
+# Catalyst Router Peer Security Protocol
 
 ## Overview
 
@@ -82,7 +82,7 @@ We support three models for Identity and JWT signing. **Strategy 2 (Root Authori
 **Mechanism**:
 
 - An external Identity Provider (IdP) or dedicated signing service handles all key operations.
-- The Catalyst Node is configured with a `jwks_uri` pointing to this external service.
+- The Catalyst Router is configured with a `jwks_uri` pointing to this external service.
 - **Use Case**: Integrating with existing corporate SSO (Okta, Auth0) or Cloud KMS.
 
 #### Strategy 3: Distributed PKI (Mesh Identity)

--- a/apps/auth/README.md
+++ b/apps/auth/README.md
@@ -1,6 +1,6 @@
 # Catalyst Auth Service
 
-The Auth service provides centralized authentication and authorization for the Catalyst node. It manages cryptographic keys, JWT issuance/verification, and principal-based access control via [Cedar Policy](https://www.cedarpolicy.com/).
+The Auth service provides centralized authentication and authorization for the Catalyst router. It manages cryptographic keys, JWT issuance/verification, and principal-based access control via [Cedar Policy](https://www.cedarpolicy.com/).
 
 ## Principals & Permissions
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,6 +1,6 @@
 # Catalyst CLI
 
-The Catalyst Node CLI provides command-line utilities for managing the Catalyst network node, including registering services and viewing metrics.
+The Catalyst Router CLI provides command-line utilities for managing the Catalyst network router, including registering services and viewing metrics.
 
 ## Development
 

--- a/constitution.md
+++ b/constitution.md
@@ -1,8 +1,8 @@
-# Catalyst Node Constitution
+# Catalyst Router Constitution
 
 **Version**: 1.1.0 | **Ratified**: 2026-02-05 | **Last Amended**: 2026-02-09
 
-> This constitution defines the immutable architectural principles for the Catalyst Node project.
+> This constitution defines the immutable architectural principles for the Catalyst Router project.
 > All specifications, implementation plans, and code changes MUST comply with these principles.
 > Violations are CRITICAL findings that block merge. No exceptions.
 
@@ -37,7 +37,7 @@
 
 ### I. Decentralized Service Routing
 
-**Statement**: Catalyst Node operates as a decentralized service mesh using a BGP-inspired protocol for Layers 4-7. No centralized coordinator may be introduced that creates a single point of failure for routing decisions.
+**Statement**: Catalyst Router operates as a decentralized service mesh using a BGP-inspired protocol for Layers 4-7. No centralized coordinator may be introduced that creates a single point of failure for routing decisions.
 
 | DO                                                          | DON'T                                                  |
 | ----------------------------------------------------------- | ------------------------------------------------------ |
@@ -420,7 +420,7 @@ gt fold                                    # Merge current branch into parent
 
 ### Scope
 
-All packages in the `catalyst-node` monorepo.
+All packages in the `catalyst-router` monorepo.
 
 ### Precedence
 

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -1,6 +1,6 @@
 # Docker Compose Examples
 
-This directory contains Docker Compose configurations for running Catalyst Node in different topologies.
+This directory contains Docker Compose configurations for running Catalyst Router in different topologies.
 TODO: Need to actually add the telemetry to the services for docker.compose.yaml and two-node.compose.yaml.
 
 | File                        | Topology           | Observability  | Auth Model          |
@@ -11,7 +11,7 @@ TODO: Need to actually add the telemetry to the services for docker.compose.yaml
 
 ## Single Node (`docker.compose.yaml`)
 
-A single Catalyst node with OpenTelemetry observability. Good for local development and testing.
+A single Catalyst router with OpenTelemetry observability. Good for local development and testing.
 
 ### Services
 
@@ -32,7 +32,7 @@ All services emit traces, metrics, and logs to the OTEL Collector via `OTEL_EXPO
 
 ## Two-Node Peering (`two-node.compose.yaml`)
 
-Two Catalyst nodes peered on the same domain, each with their own gateway and subgraph service. Demonstrates BGP-inspired service route exchange between nodes.
+Two Catalyst routers peered on the same domain, each with their own gateway and subgraph service. Demonstrates BGP-inspired service route exchange between nodes.
 
 ### Services
 

--- a/docs/adr/0001-unified-opentelemetry-observability.md
+++ b/docs/adr/0001-unified-opentelemetry-observability.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-Catalyst-node is a distributed control plane with multiple services:
+Catalyst-router is a distributed control plane with multiple services:
 
 - **Orchestrator** - BGP-style peering, route table management
 - **Gateway** - GraphQL federation via schema stitching
@@ -43,7 +43,7 @@ The existing observability is fragmented:
 
 ### Licensing Constraints
 
-Since catalyst-node is distributed software, we cannot use AGPL-licensed components. This affects backend selection:
+Since catalyst-router is distributed software, we cannot use AGPL-licensed components. This affects backend selection:
 
 | Component        | License    | Status     |
 | ---------------- | ---------- | ---------- |

--- a/docs/adr/0002-logging-library-selection.md
+++ b/docs/adr/0002-logging-library-selection.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-As part of implementing unified observability for catalyst-node (see ADR-0001), we need to select a logging library that:
+As part of implementing unified observability for catalyst-router (see ADR-0001), we need to select a logging library that:
 
 1. Provides a developer-friendly API for structured logging
 2. Supports automatic trace_id injection for log correlation
@@ -40,7 +40,7 @@ Services currently use inconsistent logging approaches:
 
 **Chosen Option: LogTape**
 
-We will adopt LogTape as the logging library for all catalyst-node services.
+We will adopt LogTape as the logging library for all catalyst-router services.
 
 ### Rationale
 

--- a/docs/adr/0003-observability-backends.md
+++ b/docs/adr/0003-observability-backends.md
@@ -51,7 +51,7 @@
 
 ### Licensing Constraints
 
-Since catalyst-node is distributed software, we cannot include or bundle AGPL-licensed components:
+Since catalyst-router is distributed software, we cannot include or bundle AGPL-licensed components:
 
 | License    | Can Use? | Reason                           |
 | ---------- | -------- | -------------------------------- |
@@ -125,7 +125,7 @@ Since catalyst-node is distributed software, we cannot include or bundle AGPL-li
 ### Positive
 
 - **Full license compliance** — All backends are Apache 2.0 or MIT
-- **Distribution-safe** — Can bundle observability stack with catalyst-node
+- **Distribution-safe** — Can bundle observability stack with catalyst-router
 - **Native UIs** — Each backend provides built-in visualization
 - **Industry standards** — Prometheus and Jaeger are CNCF projects
 - **Simple operations** — No complex dependencies (no Kafka, no Cassandra)
@@ -155,7 +155,7 @@ If license constraints change or we use backends as external services (not bundl
 ## Compliance
 
 - All selected backends are Apache 2.0 or MIT licensed
-- Safe to distribute with catalyst-node
+- Safe to distribute with catalyst-router
 - No AGPL or SSPL components included
 
 ## Related Decisions

--- a/docs/adr/0004-sqlite-storage-backend.md
+++ b/docs/adr/0004-sqlite-storage-backend.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-The catalyst-node codebase currently uses in-memory `Map<K,V>` objects for storing application state. While simple to implement, this approach has significant limitations for production deployments.
+The catalyst-router codebase currently uses in-memory `Map<K,V>` objects for storing application state. While simple to implement, this approach has significant limitations for production deployments.
 
 ### Current State
 
@@ -60,7 +60,7 @@ This ADR does **NOT** apply to:
 
 **Chosen Option: SQLite via `bun:sqlite`**
 
-SQLite provides the best balance of reliability, performance, and operational simplicity for catalyst-node's requirements.
+SQLite provides the best balance of reliability, performance, and operational simplicity for catalyst-router's requirements.
 
 ### Rationale
 

--- a/docs/adr/0005-docker-as-container-runtime.md
+++ b/docs/adr/0005-docker-as-container-runtime.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-The catalyst-node project requires a container runtime for local development, integration testing (testcontainers), and CI/CD pipelines (GitHub Actions). The team initially attempted to avoid Docker Desktop due to its commercial licensing requirements, exploring free alternatives instead.
+The catalyst-router project requires a container runtime for local development, integration testing (testcontainers), and CI/CD pipelines (GitHub Actions). The team initially attempted to avoid Docker Desktop due to its commercial licensing requirements, exploring free alternatives instead.
 
 ### Current State
 

--- a/docs/adr/0006-node-orchestrator-architecture.md
+++ b/docs/adr/0006-node-orchestrator-architecture.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-The Catalyst Node Orchestrator is the central control plane component responsible for BGP peering, route management, and sidecar configuration (Envoy, GraphQL Gateway, Auth Service). As the system scales, we need a clear architectural definition of how management operations are handled and how state evolves in response to events.
+The Catalyst Router Orchestrator is the central control plane component responsible for BGP peering, route management, and sidecar configuration (Envoy, GraphQL Gateway, Auth Service). As the system scales, we need a clear architectural definition of how management operations are handled and how state evolves in response to events.
 
 ### Current State
 

--- a/docs/adr/0007-certificate-bound-access-tokens.md
+++ b/docs/adr/0007-certificate-bound-access-tokens.md
@@ -6,7 +6,7 @@ Proposed
 
 ## Context
 
-Catalyst Node peering currently relies on Pre-Shared Keys (PSKs) for session establishment. While simple, PSKs present several challenges:
+Catalyst Router peering currently relies on Pre-Shared Keys (PSKs) for session establishment. While simple, PSKs present several challenges:
 
 1. **Rotation Complexity**: Updating a PSK requires synchronized changes across all nodes in a cluster.
 2. **Weak Identity Assurance**: A PSK only proves knowledge of a secret, not the identity of the holder.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,6 +1,6 @@
 # Architecture Decision Records
 
-This directory contains Architecture Decision Records (ADRs) for the catalyst-node project.
+This directory contains Architecture Decision Records (ADRs) for the catalyst-router project.
 
 ## What is an ADR?
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Example Services
 
-Example GraphQL services for testing Catalyst Node routing.
+Example GraphQL services for testing Catalyst Router routing.
 
 ## Services
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "catalyst-monorepo",
+  "name": "catalyst-router",
   "private": true,
   "scripts": {
     "start:m0p2": "docker compose -f docker-compose/example.m0p2.compose.yaml up --build",

--- a/packages/authorization/src/jwt/README.md
+++ b/packages/authorization/src/jwt/README.md
@@ -21,8 +21,8 @@ The `TokenManager` sits on top of the `KeyManager`:
 ### Initialization
 
 ```typescript
-import { LocalTokenManager } from '@catalyst-node/authorization/jwt'
-import { BunSqliteTokenStore } from '@catalyst-node/authorization/jwt/local/sqlite-store'
+import { LocalTokenManager } from '@catalyst-router/authorization/jwt'
+import { BunSqliteTokenStore } from '@catalyst-router/authorization/jwt/local/sqlite-store'
 
 const tokenStore = new BunSqliteTokenStore('./tokens.db')
 const tokenManager = new LocalTokenManager(keyManager, tokenStore, 'node-01')

--- a/packages/authorization/src/key-manager/README.md
+++ b/packages/authorization/src/key-manager/README.md
@@ -33,8 +33,8 @@ Key rotation is a critical security feature. When `rotate()` is called:
 ## Usage
 
 ```typescript
-import { PersistentLocalKeyManager } from '@catalyst-node/authorization/key-manager'
-import { BunSqliteKeyStore } from '@catalyst-node/authorization/key-manager/sqlite-key-store'
+import { PersistentLocalKeyManager } from '@catalyst-router/authorization/key-manager'
+import { BunSqliteKeyStore } from '@catalyst-router/authorization/key-manager/sqlite-key-store'
 
 // 1. Initialize Store
 const store = new BunSqliteKeyStore('./keys.db')

--- a/packages/authorization/src/policy/docs/CUSTOM_ENTITY_PROVIDERS.md
+++ b/packages/authorization/src/policy/docs/CUSTOM_ENTITY_PROVIDERS.md
@@ -10,7 +10,7 @@ The recommended approach is to use the `addFromZod` method directly on the `Enti
 
 ```typescript
 import { z } from 'zod'
-import { EntityBuilderFactory } from '@catalyst-node/authorization-engine'
+import { EntityBuilderFactory } from '@catalyst-router/authorization-engine'
 
 // Define your Zod schema
 const UserSchema = z.object({
@@ -72,7 +72,7 @@ The legacy approach involved instantiating a `GenericZodModel` class.
 
 ```typescript
 // Legacy Code
-import { GenericZodModel } from '@catalyst-node/authorization-engine'
+import { GenericZodModel } from '@catalyst-router/authorization-engine'
 
 const userModel = new GenericZodModel('User', UserSchema, data, 'username')
 builder.add(userModel)
@@ -93,7 +93,7 @@ builder.add(userModel)
 You can implement your own `EntityProvider`:
 
 ```typescript
-import type { EntityProvider, Entity, EntityCollection, DefaultDomain } from '@catalyst-node/authorization-engine'
+import type { EntityProvider, Entity, EntityCollection, DefaultDomain } from '@catalyst-router/authorization-engine'
 
 class DatabaseUserProvider implements EntityProvider<DefaultDomain> {
   constructor(private userId: string) {}

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,6 +1,6 @@
 # @catalyst/config
 
-Centralized configuration management for the Catalyst Node system.
+Centralized configuration management for the Catalyst Router system.
 
 ## Environment Variables
 

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,6 +1,6 @@
 # @catalyst/types
 
-Shared type definitions and schemas for Catalyst Node.
+Shared type definitions and schemas for Catalyst Router.
 
 ## Overview
 

--- a/prd/01/doc.md
+++ b/prd/01/doc.md
@@ -1,6 +1,6 @@
 # PRODUCT REQUIREMENTS DOCUMENT
 
-**Product:** Catalyst Node
+**Product:** Catalyst Router
 **Project:** POC — GraphQL Parity
 **Version:** 1.0.0
 **Date:** 2026-02-05
@@ -10,11 +10,11 @@
 
 ## 1. Executive Summary
 
-Catalyst Node is a distributed GraphQL federation and cross-organization data sharing system that uses BGP-inspired peering for decentralized service routing. This PRD defines the scope for a Proof of Concept (POC) that demonstrates Catalyst running as a portable virtual appliance — a self-contained, containerized system deployable via Docker Compose on x86_64 infrastructure and Raspberry Pi 5 (8GB). Catalyst v2 is an effort to inject new requirements on hosting and connectivity while consolidating functionality of the sprawling core.
+Catalyst Router is a distributed GraphQL federation and cross-organization data sharing system that uses BGP-inspired peering for decentralized service routing. This PRD defines the scope for a Proof of Concept (POC) that demonstrates Catalyst running as a portable virtual appliance — a self-contained, containerized system deployable via Docker Compose on x86_64 infrastructure and Raspberry Pi 5 (8GB). Catalyst v2 is an effort to inject new requirements on hosting and connectivity while consolidating functionality of the sprawling core.
 
 **Why now:** Catalyst currently exists as a SaaS-only offering. Many organizations in regulated or other data environments cannot use SaaS. The virtual appliance model enables these organizations to participate in federated data sharing by hosting Catalyst on their own infrastructure.
 
-**POC goal:** Demonstrate that two Catalyst nodes can be deployed via Docker Compose, establish a peering relationship, and share GraphQL services across organizational boundaries, running as a self-contained appliance with no external dependencies on both x86_64 servers and Raspberry Pi 5 (8GB ARM64) hardware.
+**POC goal:** Demonstrate that two Catalyst routers can be deployed via Docker Compose, establish a peering relationship, and share GraphQL services across organizational boundaries, running as a self-contained appliance with no external dependencies on both x86_64 servers and Raspberry Pi 5 (8GB ARM64) hardware.
 
 ---
 
@@ -126,7 +126,7 @@ The system must compose multiple GraphQL schemas into a unified endpoint via sch
 
 ### FR-2: Cross-Organization Data Sharing
 
-Two Catalyst nodes must be able to peer and share service routes.
+Two Catalyst routers must be able to peer and share service routes.
 
 **Requirements:**
 

--- a/prd/01/progress.md
+++ b/prd/01/progress.md
@@ -1,6 +1,6 @@
 # PRD Progress Tracking
 
-**PRD:** Catalyst Node POC — GraphQL Parity (v1.0.0)
+**PRD:** Catalyst Router POC — GraphQL Parity (v1.0.0)
 **Last Updated:** 2026-02-10
 **Overall POC Readiness:** ~95%
 
@@ -29,13 +29,13 @@
 
 ### Implementation Status
 
-| Requirement               | Implementation               | Files                                   |
-| ------------------------- | ---------------------------- | --------------------------------------- |
-| Register services via CLI | `catalyst node route create` | `apps/cli/src/commands/node/route.ts`   |
-| Register services via API | `DataChannel.addRoute()`     | `apps/orchestrator/src/orchestrator.ts` |
-| Schema stitching          | `@graphql-tools/stitch`      | `apps/gateway/src/graphql/server.ts`    |
-| Query delegation          | AsyncExecutor per-service    | `apps/gateway/src/graphql/server.ts`    |
-| Zero-downtime reload      | RPC `updateConfig()`         | `apps/gateway/src/rpc/server.ts`        |
+| Requirement               | Implementation                 | Files                                   |
+| ------------------------- | ------------------------------ | --------------------------------------- |
+| Register services via CLI | `catalyst router route create` | `apps/cli/src/commands/node/route.ts`   |
+| Register services via API | `DataChannel.addRoute()`       | `apps/orchestrator/src/orchestrator.ts` |
+| Schema stitching          | `@graphql-tools/stitch`        | `apps/gateway/src/graphql/server.ts`    |
+| Query delegation          | AsyncExecutor per-service      | `apps/gateway/src/graphql/server.ts`    |
+| Zero-downtime reload      | RPC `updateConfig()`           | `apps/gateway/src/rpc/server.ts`        |
 
 ---
 
@@ -52,7 +52,7 @@
 
 | Requirement        | Implementation                            | Files                                   |
 | ------------------ | ----------------------------------------- | --------------------------------------- |
-| Add peer via CLI   | `catalyst node peer create`               | `apps/cli/src/commands/node/peer.ts`    |
+| Add peer via CLI   | `catalyst router peer create`             | `apps/cli/src/commands/node/peer.ts`    |
 | Route propagation  | BGP-style with `nodePath` loop prevention | `apps/orchestrator/src/orchestrator.ts` |
 | Route withdrawal   | `propagateWithdrawalsForPeer()`           | `apps/orchestrator/src/orchestrator.ts` |
 | Gateway federation | Internal routes synced to gateway         | `apps/orchestrator/src/orchestrator.ts` |


### PR DESCRIPTION
Update all documentation references across 34 files to reflect the
project rename. Includes root docs, ADRs, PRDs, package READMEs, and
license files. Root package.json name changed from catalyst-monorepo
to catalyst-router. Code symbols (env vars, class names, package names)
left unchanged for a separate migration.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>