### PR TITLE
docs: rename project from Catalyst Node to Catalyst Router

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,645 @@
+# Catalyst Router API Design
+
+This document describes the API design philosophy, transport layer, and progressive API patterns used across the Catalyst Router platform. It serves as both a reference for contributors and an architectural guide for understanding how services communicate.
+
+## Table of Contents
+
+- [API Design Philosophy](#api-design-philosophy)
+- [Capnweb Transport Layer](#capnweb-transport-layer)
+- [The Progressive API Pattern](#the-progressive-api-pattern)
+- [Orchestrator API](#orchestrator-api)
+- [Auth API](#auth-api)
+- [Discriminated Union Response Pattern](#discriminated-union-response-pattern)
+- [REST Comparison](#rest-comparison)
+- [Client Usage Examples](#client-usage-examples)
+- [Connection Management](#connection-management)
+
+---
+
+## API Design Philosophy
+
+Catalyst Router uses **progressive APIs** over **Capnweb** (Cap'n Proto serialization over WebSocket) rather than traditional REST endpoints. This choice is driven by several requirements of a distributed routing platform:
+
+1. **Persistent connections** -- Nodes maintain long-lived WebSocket sessions to peers for route propagation. REST's request/response model would require reconnecting or polling.
+
+2. **Auth-gated capability sets** -- Rather than checking authorization on every method call, authentication happens once at the entry point, which returns a scoped set of handlers. Subsequent calls on that handler set do not re-authenticate.
+
+3. **Bidirectional communication** -- The iBGP (internal BGP) protocol requires the server to push route updates back to the client. WebSocket connections naturally support this, while REST would require webhooks or server-sent events.
+
+4. **Type safety** -- TypeScript interfaces define the full API contract. Client stubs are generic over these interfaces, making remote calls look and feel like local function calls.
+
+5. **Pipelined RPC** -- Capnweb supports pipelined calls where the client can issue dependent calls without waiting for intermediate results, reducing round trips.
+
+## Capnweb Transport Layer
+
+All inter-service communication in Catalyst uses **Capnweb**, which provides:
+
+### Core Primitives
+
+| Primitive                        | Role                                                                                                                                         |
+| :------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RpcTarget`                      | Base class for server-side API implementations. Services extend this to expose methods.                                                      |
+| `RpcStub<T>`                     | Client-side typed proxy. Makes remote calls appear as local function invocations on interface `T`.                                           |
+| `newWebSocketRpcSession<T>(url)` | Creates a WebSocket-based `RpcStub<T>` connected to the given endpoint. Supports bidirectional communication, server push, and callbacks.    |
+| `newHttpBatchRpcSession<T>(url)` | Creates an HTTP batch-based `RpcStub<T>`. Collects multiple calls and sends them in a single HTTP request. Suitable for one-shot operations. |
+
+### Session Modes
+
+**WebSocket sessions** are the primary transport. They maintain a persistent connection and support:
+
+- Progressive API handler references that persist across calls
+- Server-to-client callbacks (used by iBGP for route updates)
+- Bidirectional streaming
+
+**HTTP batch sessions** are available for simpler use cases. They collect pipelined calls and send them in a single request, but do not support callbacks or persistent handler references.
+
+### Server-Side Wiring
+
+Services extend `RpcTarget` and are mounted via the `@hono/capnweb` adapter:
+
+```typescript
+import { newRpcResponse } from '@hono/capnweb'
+import { RpcTarget } from 'capnweb'
+import { upgradeWebSocket } from 'hono/bun'
+
+class MyRpcServer extends RpcTarget {
+  async myMethod(arg: string): Promise<{ success: true } | { success: false; error: string }> {
+    // implementation
+  }
+}
+
+const app = new Hono()
+app.get('/', (c) => {
+  return newRpcResponse(c, rpcServer, { upgradeWebSocket })
+})
+```
+
+## The Progressive API Pattern
+
+The progressive API pattern is the central design pattern in Catalyst. A single `PublicApi` entry point exposes methods that authenticate the caller and return domain-specific handler sets.
+
+### How It Works
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant PublicApi as PublicApi (Entry Point)
+    participant Handlers as Domain Handlers
+
+    Client->>PublicApi: getNetworkClient(token)
+    PublicApi->>PublicApi: Validate token + check permissions
+    alt Token valid
+        PublicApi-->>Client: { success: true, client: NetworkClient }
+        Client->>Handlers: client.addPeer(peer)
+        Handlers-->>Client: { success: true }
+        Client->>Handlers: client.listPeers()
+        Handlers-->>Client: PeerRecord[]
+    else Token invalid
+        PublicApi-->>Client: { success: false, error: "..." }
+    end
+```
+
+Key characteristics:
+
+1. **Single entry point** -- Each service exposes one `PublicApi` interface with entry-point methods.
+2. **Auth at the gate** -- Each entry-point method takes a token, validates it, and checks permissions before returning handlers.
+3. **Scoped handler sets** -- The returned object contains only the methods relevant to that domain (e.g., `NetworkClient` has peer operations, not route operations).
+4. **No re-authentication** -- Once a handler set is obtained, all calls on it are pre-authorized. The token was validated when the handler set was created.
+
+### Why Not Per-Method Auth?
+
+In a traditional REST API, every endpoint independently validates the `Authorization` header. In the progressive pattern, auth happens once when the handler set is created. This has several advantages:
+
+- **Less redundancy** -- A single validation call gates access to multiple methods.
+- **Cleaner interfaces** -- Handler methods accept only their domain-specific parameters, not auth tokens.
+- **Persistent sessions** -- Over WebSocket, the handler reference persists across calls without re-authenticating.
+
+## Orchestrator API
+
+The Orchestrator exposes a `PublicApi` with three token-gated entry points, each returning a different domain handler set, plus a direct `dispatch` method.
+
+### PublicApi Interface
+
+```typescript
+// Source: apps/orchestrator/src/orchestrator.ts
+
+export interface PublicApi {
+  getNetworkClient(
+    token: string
+  ): Promise<{ success: true; client: NetworkClient } | { success: false; error: string }>
+
+  getDataChannelClient(
+    token: string
+  ): Promise<{ success: true; client: DataChannel } | { success: false; error: string }>
+
+  getIBGPClient(
+    token: string
+  ): Promise<{ success: true; client: IBGPClient } | { success: false; error: string }>
+
+  dispatch(action: Action): Promise<{ success: true } | { success: false; error: string }>
+}
+```
+
+Each `get*Client` method validates the provided token against the auth service (if configured) and checks the caller's permissions for the relevant action (`PEER_CREATE`, `ROUTE_CREATE`, `IBGP_CONNECT`).
+
+### NetworkClient -- Peer Management
+
+Returned by `getNetworkClient(token)`. Manages the node's peer connections.
+
+```typescript
+export interface NetworkClient {
+  addPeer(peer: PeerInfo): Promise<{ success: true } | { success: false; error: string }>
+  updatePeer(peer: PeerInfo): Promise<{ success: true } | { success: false; error: string }>
+  removePeer(
+    peer: Pick<PeerInfo, 'name'>
+  ): Promise<{ success: true } | { success: false; error: string }>
+  listPeers(): Promise<PeerRecord[]>
+}
+```
+
+### DataChannel -- Route Management
+
+Returned by `getDataChannelClient(token)`. Manages local route definitions (service endpoints advertised by this node).
+
+```typescript
+export interface DataChannel {
+  addRoute(
+    route: DataChannelDefinition
+  ): Promise<{ success: true } | { success: false; error: string }>
+  removeRoute(
+    route: DataChannelDefinition
+  ): Promise<{ success: true } | { success: false; error: string }>
+  listRoutes(): Promise<{ local: DataChannelDefinition[]; internal: InternalRoute[] }>
+}
+```
+
+### IBGPClient -- Internal Routing Protocol
+
+Returned by `getIBGPClient(token)`. Used for inter-node BGP-style route exchange.
+
+```typescript
+export interface IBGPClient {
+  open(peer: PeerInfo): Promise<{ success: true } | { success: false; error: string }>
+  close(
+    peer: PeerInfo,
+    code: number,
+    reason?: string
+  ): Promise<{ success: true } | { success: false; error: string }>
+  update(
+    peer: PeerInfo,
+    update: UpdateMessage
+  ): Promise<{ success: true } | { success: false; error: string }>
+}
+```
+
+### Progressive Call Flow (iBGP)
+
+This diagram shows how two nodes establish a peering session using the progressive API:
+
+```mermaid
+sequenceDiagram
+    participant NodeA as Node A
+    participant PubB as Node B (PublicApi)
+    participant IBGP as Node B (IBGPClient)
+
+    Note over NodeA: 1. Authenticate & get handler set
+    NodeA->>PubB: getIBGPClient(peerToken)
+    PubB->>PubB: Validate token (IBGP_CONNECT)
+    PubB-->>NodeA: { success: true, client: IBGPClient }
+
+    Note over NodeA: 2. Open session
+    NodeA->>IBGP: client.open(nodeA.peerInfo)
+    IBGP-->>NodeA: { success: true }
+
+    Note over NodeA: 3. Exchange routes
+    NodeA->>IBGP: client.update(nodeA.peerInfo, { updates: [...] })
+    IBGP-->>NodeA: { success: true }
+```
+
+### Management SDK
+
+The CLI and management tools use an alternative entry point (`connectionFromManagementSDK`) that returns a `ManagementScope` with higher-level operations:
+
+```typescript
+// Source: apps/cli/src/clients/orchestrator-client.ts
+
+export interface OrchestratorPublicApi {
+  connectionFromManagementSDK(): RpcStub<ManagementScope>
+}
+
+export interface ManagementScope {
+  applyAction(action: unknown): Promise<ActionResult>
+  listLocalRoutes(): Promise<{
+    routes: { local: DataChannelDefinition[]; internal: InternalRoute[] }
+  }>
+  listMetrics(): Promise<unknown>
+  listPeers(): Promise<{ peers: PeerInfo[] }>
+  deletePeer(peerId: string): Promise<ActionResult>
+}
+```
+
+## Auth API
+
+The Auth service (`AuthRpcServer`) exposes four progressive entry points, each gating access to a domain-specific handler set.
+
+### Entry Points
+
+```typescript
+// Source: packages/authorization/src/service/rpc/server.ts
+
+class AuthRpcServer extends RpcTarget {
+  async tokens(token: string): Promise<TokenHandlers | { error: string }>
+  async certs(token: string): Promise<CertHandlers | { error: string }>
+  async validation(token: string): Promise<ValidationHandlers | { error: string }>
+  async permissions(token: string): Promise<PermissionsHandlers | { error: string }>
+}
+```
+
+Each entry point verifies the provided JWT and checks Cedar-based authorization policies before returning handlers.
+
+### TokenHandlers -- Token Lifecycle
+
+Requires `ADMIN` principal. Manages the creation, revocation, and listing of JWTs.
+
+```typescript
+// Source: packages/authorization/src/service/rpc/schema.ts
+
+export interface TokenHandlers {
+  create(request: {
+    subject: string
+    entity: { id: string; name: string; type: 'user' | 'service'; nodeId?: string }
+    principal: Principal
+    sans?: string[]
+    expiresIn?: string
+  }): Promise<string>
+
+  revoke(request: { jti?: string; san?: string }): Promise<void>
+
+  list(request: { certificateFingerprint?: string; san?: string }): Promise<TokenRecord[]>
+}
+```
+
+### CertHandlers -- Key Management
+
+Requires `ADMIN` principal. Manages signing keys and certificates.
+
+```typescript
+export interface CertHandlers {
+  list(): Promise<GetJwksResponse>
+  rotate(request?: { immediate?: boolean; gracePeriodMs?: number }): Promise<RotateResponse>
+  getTokensByCert(request: { fingerprint: string }): Promise<TokenRecord[]>
+}
+```
+
+### ValidationHandlers -- Token Verification
+
+Accessible with any valid token. Provides JWT validation, revocation list access, and the public JWKS endpoint.
+
+```typescript
+export interface ValidationHandlers {
+  validate(request: { token: string; audience?: string }): Promise<VerifyTokenResponse>
+  getRevocationList(): Promise<string[]>
+  getJWKS(): Promise<GetJwksResponse>
+}
+```
+
+### PermissionsHandlers -- Cedar Policy Evaluation
+
+Accessible with any valid token. Evaluates Cedar authorization policies.
+
+```typescript
+export interface PermissionsHandlers {
+  authorizeAction(request: AuthorizeActionRequest): Promise<AuthorizeActionResult>
+}
+```
+
+Where:
+
+```typescript
+interface AuthorizeActionRequest {
+  action: string
+  nodeContext: { nodeId: string; domains: string[] }
+}
+```
+
+### Auth Progressive Call Flow
+
+```mermaid
+sequenceDiagram
+    participant CLI
+    participant Auth as AuthRpcServer
+    participant Tokens as TokenHandlers
+
+    CLI->>Auth: tokens(adminToken)
+    Auth->>Auth: Verify JWT
+    Auth->>Auth: Check Cedar policy (MANAGE on AdminPanel)
+    alt Authorized
+        Auth-->>CLI: TokenHandlers { create, revoke, list }
+        CLI->>Tokens: create({ subject: "svc-a", principal: "NODE", ... })
+        Tokens-->>CLI: "eyJhbG..." (signed JWT)
+    else Denied
+        Auth-->>CLI: { error: "Permission denied: ADMIN principal required" }
+    end
+```
+
+## Discriminated Union Response Pattern
+
+All API methods in Catalyst return **discriminated unions** to enforce error handling at the type level. The discriminant field varies by context:
+
+### Standard Success/Failure
+
+Most operations use `success` as the discriminant:
+
+```typescript
+{ success: true }
+| { success: false; error: string }
+```
+
+Or with data:
+
+```typescript
+{ success: true; client: NetworkClient }
+| { success: false; error: string }
+```
+
+### Validation Responses
+
+Token verification uses `valid` as the discriminant:
+
+```typescript
+{ valid: true; payload: Record<string, unknown> }
+| { valid: false; error: string }
+```
+
+### Typed Error Responses
+
+The permissions API uses typed error discriminants for granular error handling:
+
+```typescript
+// Source: packages/authorization/src/service/rpc/schema.ts
+
+type AuthorizeActionResult =
+  | { success: true; allowed: boolean }
+  | { success: false; errorType: 'token_expired'; reason: string }
+  | { success: false; errorType: 'token_malformed'; reason: string }
+  | { success: false; errorType: 'token_revoked'; reason: string }
+  | { success: false; errorType: 'permission_denied'; reasons: string[] }
+  | { success: false; errorType: 'system_error'; reason: string }
+```
+
+### Progressive Entry Points
+
+Handler-returning entry points use a simpler union, returning either the handler object or an error:
+
+```typescript
+Promise<TokenHandlers | { error: string }>
+```
+
+Callers check for the error case with `'error' in result`.
+
+### Schema Validation
+
+Response shapes are validated with Zod discriminated union schemas:
+
+```typescript
+export const SignTokenResponseSchema = z.discriminatedUnion('success', [
+  z.object({ success: z.literal(true), token: z.string() }),
+  z.object({ success: z.literal(false), error: z.string() }),
+])
+```
+
+## REST Comparison
+
+The progressive API pattern maps conceptually to REST, but with persistent connections, pre-authenticated scopes, and type-safe contracts.
+
+### Orchestrator API
+
+| Progressive API Call                 | REST Equivalent                 | Notes                                 |
+| :----------------------------------- | :------------------------------ | :------------------------------------ |
+| `api.getNetworkClient(token)`        | `Authorization: Bearer {token}` | Auth happens once, not per-request    |
+| `networkClient.addPeer(peer)`        | `POST /peers`                   | No token needed -- already authorized |
+| `networkClient.updatePeer(peer)`     | `PUT /peers/{name}`             |                                       |
+| `networkClient.removePeer({ name })` | `DELETE /peers/{name}`          |                                       |
+| `networkClient.listPeers()`          | `GET /peers`                    |                                       |
+| `api.getDataChannelClient(token)`    | `Authorization: Bearer {token}` | Separate auth gate for routes         |
+| `dataChannel.addRoute(route)`        | `POST /routes`                  |                                       |
+| `dataChannel.removeRoute(route)`     | `DELETE /routes/{name}`         |                                       |
+| `dataChannel.listRoutes()`           | `GET /routes`                   |                                       |
+
+### Auth API
+
+| Progressive API Call                       | REST Equivalent                 | Notes                                    |
+| :----------------------------------------- | :------------------------------ | :--------------------------------------- |
+| `api.tokens(token)`                        | `Authorization: Bearer {token}` | Returns handler set for token operations |
+| `tokenHandlers.create(req)`                | `POST /tokens`                  |                                          |
+| `tokenHandlers.revoke(req)`                | `DELETE /tokens/{jti}`          |                                          |
+| `tokenHandlers.list(req)`                  | `GET /tokens`                   |                                          |
+| `api.validation(token)`                    | `Authorization: Bearer {token}` | Lower privilege than `tokens()`          |
+| `validationHandlers.validate(req)`         | `POST /tokens/validate`         |                                          |
+| `validationHandlers.getJWKS()`             | `GET /.well-known/jwks.json`    |                                          |
+| `api.permissions(token)`                   | `Authorization: Bearer {token}` |                                          |
+| `permissionsHandlers.authorizeAction(req)` | `POST /authorize`               |                                          |
+
+### Benefits Over REST
+
+| Aspect        | REST                                                 | Progressive API                            |
+| :------------ | :--------------------------------------------------- | :----------------------------------------- |
+| Auth overhead | Per-request `Authorization` header validation        | Once per handler set acquisition           |
+| Connection    | New TCP connection per request (or HTTP/2 multiplex) | Persistent WebSocket                       |
+| Server push   | Requires webhooks or SSE                             | Native via same WebSocket                  |
+| Type safety   | OpenAPI spec (separate from code)                    | TypeScript interfaces (code _is_ the spec) |
+| Pipelining    | Not possible (request-response)                      | Supported via Capnweb batching             |
+| Error model   | HTTP status codes + body                             | Discriminated unions enforced by compiler  |
+
+## Client Usage Examples
+
+### Orchestrator: Managing Peers (CLI Handler)
+
+```typescript
+// Source: apps/cli/src/handlers/node-peer-handlers.ts
+
+import { createOrchestratorClient } from '../clients/orchestrator-client.js'
+
+async function createPeerHandler(input: CreatePeerInput): Promise<CreatePeerResult> {
+  const client = await createOrchestratorClient(input.orchestratorUrl)
+  const mgmtScope = client.connectionFromManagementSDK()
+
+  const result = await mgmtScope.applyAction({
+    resource: 'internalBGPConfig',
+    resourceAction: 'create',
+    data: {
+      name: input.name,
+      endpoint: input.endpoint,
+      domains: input.domains,
+      peerToken: input.peerToken,
+    },
+  })
+
+  if (result.success) {
+    return { success: true, data: { name: input.name } }
+  } else {
+    return { success: false, error: result.error || 'Unknown error' }
+  }
+}
+```
+
+### Auth: Minting a Token (CLI Handler)
+
+```typescript
+// Source: apps/cli/src/handlers/auth-token-handlers.ts
+
+import { createAuthClient } from '../clients/auth-client.js'
+
+async function mintTokenHandler(input: MintTokenInput): Promise<MintTokenResult> {
+  // 1. Create client (establishes WebSocket connection)
+  const client = await createAuthClient(input.authUrl)
+
+  // 2. Get token handler set (progressive entry point -- validates admin token)
+  const tokensApi = await client.tokens(input.token || '')
+  if ('error' in tokensApi) {
+    return { success: false, error: `Auth failed: ${tokensApi.error}` }
+  }
+
+  // 3. Use the handler set (no re-authentication needed)
+  const newToken = await tokensApi.create({
+    subject: input.subject,
+    entity: {
+      id: input.subject,
+      name: input.name,
+      type: input.type,
+      nodeId: input.nodeId,
+    },
+    principal: input.principal,
+    expiresIn: input.expiresIn,
+  })
+
+  return { success: true, data: { token: newToken } }
+}
+```
+
+### Auth: Verifying a Token
+
+```typescript
+// Source: apps/cli/src/handlers/auth-token-handlers.ts
+
+async function verifyTokenHandler(input: VerifyTokenInput): Promise<VerifyTokenResult> {
+  const client = await createAuthClient(input.authUrl)
+  const validationApi = await client.validation(input.token || '')
+
+  if ('error' in validationApi) {
+    return { success: false, error: `Auth failed: ${validationApi.error}` }
+  }
+
+  const result = await validationApi.validate({
+    token: input.tokenToVerify,
+    audience: input.audience,
+  })
+
+  if (result.valid) {
+    return { success: true, data: { valid: true, payload: result.payload || {} } }
+  } else {
+    return { success: true, data: { valid: false, error: result.error || 'Invalid token' } }
+  }
+}
+```
+
+### Orchestrator: Node-to-Node iBGP Communication
+
+```typescript
+// Source: apps/orchestrator/src/orchestrator.ts (handleBGPNotify)
+
+// When a new peer is added, the orchestrator opens a connection to it:
+const stub = connectionPool.get(peer.endpoint)
+const token = peer.peerToken || nodeToken || ''
+
+// Progressive entry: authenticate and get iBGP handler set
+const connectionResult = await stub.getIBGPClient(token)
+
+if (connectionResult.success) {
+  // Open session with the remote node
+  await connectionResult.client.open(localNodeInfo)
+
+  // Propagate routes
+  await connectionResult.client.update(localNodeInfo, {
+    updates: [{ action: 'add', route: routeDefinition, nodePath: [localNodeName] }],
+  })
+}
+```
+
+## Connection Management
+
+### ConnectionPool
+
+The `ConnectionPool` class manages persistent RPC connections to peer nodes. It caches `RpcStub<PublicApi>` instances keyed by endpoint URL, supporting both WebSocket and HTTP batch transports.
+
+```typescript
+// Source: apps/orchestrator/src/orchestrator.ts
+
+export class ConnectionPool {
+  private stubs: Map<string, RpcStub<PublicApi>>
+
+  constructor(private type: 'ws' | 'http' = 'http') {
+    this.stubs = new Map()
+  }
+
+  get(endpoint: string): RpcStub<PublicApi> | undefined {
+    if (this.stubs.has(endpoint)) {
+      return this.stubs.get(endpoint)
+    }
+    // Create new stub based on transport type
+    const stub =
+      this.type === 'ws'
+        ? newWebSocketRpcSession<PublicApi>(endpoint)
+        : newHttpBatchRpcSession<PublicApi>(endpoint)
+    this.stubs.set(endpoint, stub)
+    return stub
+  }
+}
+```
+
+### Client Creation
+
+CLI clients create connections via factory functions that resolve the service URL from arguments, environment variables, or defaults:
+
+```typescript
+// Source: apps/cli/src/clients/orchestrator-client.ts
+
+export async function createOrchestratorClient(url?: string): Promise<OrchestratorPublicApi> {
+  const resolved = resolveServiceUrl({
+    url,
+    envVar: 'CATALYST_ORCHESTRATOR_URL',
+    defaultPort: 3000,
+  })
+  return newWebSocketRpcSession<OrchestratorPublicApi>(resolved)
+}
+```
+
+```typescript
+// Source: apps/cli/src/clients/auth-client.ts
+
+export async function createAuthClient(url?: string): Promise<AuthPublicApi> {
+  const resolved = resolveServiceUrl({
+    url,
+    envVar: 'CATALYST_AUTH_URL',
+    defaultPort: 4000,
+  })
+  return newWebSocketRpcSession<AuthPublicApi>(resolved)
+}
+```
+
+### Transport Selection Guide
+
+| Use Case                   | Transport            | Reason                                               |
+| :------------------------- | :------------------- | :--------------------------------------------------- |
+| Node-to-node iBGP peering  | WebSocket            | Persistent session, route update callbacks           |
+| CLI management commands    | WebSocket            | Progressive handler sets, multiple calls per session |
+| One-shot internal calls    | HTTP batch           | Stateless, simpler lifecycle                         |
+| Gateway configuration sync | HTTP batch (default) | Push-and-forget configuration updates                |
+
+### Session Lifecycle
+
+1. **Client creates stub** -- `newWebSocketRpcSession<T>(url)` returns an `RpcStub<T>` connected to the service.
+2. **Client calls entry point** -- e.g., `stub.getIBGPClient(token)` authenticates and returns a handler set.
+3. **Client uses handlers** -- Calls on the handler set are sent over the existing WebSocket. No re-authentication.
+4. **Session persists** -- The WebSocket connection stays open. Multiple handler sets can be obtained on the same connection.
+5. **Connection pooling** -- The `ConnectionPool` caches stubs by endpoint, reusing connections for repeated calls to the same peer.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,185 +1,441 @@
 # Architecture
 
-## System Overview: The Core Pod
+> **Licensor**: Orbis Operations LLC
+> **Last updated**: 2026-02-11
+> **Authoritative governance**: [constitution.md](./constitution.md)
 
-Catalyst Router runs as a cohesive set of containers ("The Core Pod") orchestrated by the main **Catalyst Router** process.
+---
+
+## 1. Overview
+
+Catalyst Router is a distributed control and data plane that uses a BGP-inspired protocol for L4-7 service routing. It enables organizations to peer services across trust boundaries without a centralized registry or coordinator -- each node maintains its own route table and exchanges routes with peers, converging to a consistent view of the network through eventually-consistent propagation.
+
+The system is built around a "Core Pod" deployment model: each node runs an orchestrator process alongside sidecar services (auth, GraphQL gateway, OTEL collector) that communicate over Capnweb RPC (Cap'n Proto over WebSocket). This architecture ensures operational simplicity while maintaining clear separation of concerns between control plane, data plane, and observability.
+
+The [constitution.md](./constitution.md) is the authoritative governance document for all architectural decisions. It defines 18 immutable principles covering structural patterns, quality standards, and operational requirements. All code changes must comply with these principles; violations are critical findings that block merge.
+
+---
+
+## 2. System Context
+
+The following diagram shows Catalyst Router in its operating environment at the C4 Level 1 (System Context) view.
+
+```mermaid
+C4Context
+    title System Context - Catalyst Router
+
+    Person(client, "External Client", "Application or user consuming services via the mesh")
+    Person(admin, "Administrator", "Manages nodes, peers, tokens, and routes via CLI")
+
+    System(catalyst, "Catalyst Router Node", "Distributed L4-7 service router with BGP-inspired peering")
+
+    System_Ext(peer, "Peer Catalyst Node", "Another Catalyst Router node exchanging routes via iBGP")
+    System_Ext(otelBackend, "Monitoring Backend", "Prometheus, Jaeger, InfluxDB, or other OTLP-compatible backend")
+    System_Ext(subgraph, "Subgraph Service", "Application exposing a GraphQL schema for federation")
+
+    Rel(client, catalyst, "Queries federated GraphQL API", "HTTP/GraphQL")
+    Rel(admin, catalyst, "Manages node configuration", "CLI / RPC")
+    Rel(catalyst, peer, "Exchanges routes and peering state", "Capnweb RPC over WebSocket")
+    Rel(catalyst, otelBackend, "Exports traces, metrics, logs", "OTLP gRPC/HTTP")
+    Rel(subgraph, catalyst, "Registers schema for federation", "HTTP/GraphQL introspection")
+```
+
+---
+
+## 3. Core Pod Architecture
+
+The deployment unit is a **Core Pod** -- a cohesive set of components orchestrated by the main Catalyst Router process. All inter-component communication uses Capnweb RPC over WebSocket (Constitution Principle II).
+
+```mermaid
+C4Container
+    title Core Pod Architecture - C4 Level 2
+
+    Person(client, "External Client")
+    Person(admin, "Administrator / CLI")
+
+    System_Boundary(pod, "Core Pod") {
+        Container(orchestrator, "Orchestrator", "Bun / TypeScript", "Control plane: BGP-inspired peer-to-peer route exchange via CatalystNodeBus. V2 dispatch pattern. Exposes RPC with NetworkClient, DataChannel, and IBGPClient interfaces.")
+        Container(auth, "Auth Service", "Bun / TypeScript", "JWT token lifecycle (mint/verify/revoke). JWKS endpoint. Cedar policy evaluation. Extends CatalystService.")
+        Container(gateway, "GraphQL Gateway", "Bun / TypeScript", "Schema stitching via @graphql-tools/stitch. Dynamic subgraph composition. Orchestrator pushes config updates via RPC.")
+        Container(otel, "OTEL Collector", "OpenTelemetry Collector", "Receives traces, metrics, logs via OTLP. Batch + memory limiter processors. Debug exporter (production backends TODO).")
+        Container(envoy, "Envoy Proxy", "Envoy", "Data plane (planned). xDS integration for L4 routing and TLS termination.")
+    }
+
+    System_Ext(peer, "Peer Node")
+
+    Rel(client, gateway, "GraphQL queries", "HTTP")
+    Rel(admin, orchestrator, "Management commands", "Capnweb RPC")
+    Rel(orchestrator, auth, "Token validation, Cedar authorization", "Capnweb RPC / WebSocket")
+    Rel(orchestrator, gateway, "Schema config updates", "Capnweb RPC / WebSocket")
+    Rel(orchestrator, peer, "BGP route exchange", "Capnweb RPC / WebSocket")
+    Rel(auth, otel, "Telemetry", "OTLP HTTP")
+    Rel(gateway, otel, "Telemetry", "OTLP HTTP")
+    Rel(orchestrator, otel, "Telemetry", "OTLP HTTP")
+    Rel(orchestrator, envoy, "xDS configuration (planned)", "REST")
+    Rel(client, envoy, "Proxied traffic (planned)", "HTTP/TLS")
+```
+
+### Component Responsibilities
+
+| Component           | App/Config                                  | Role                                                                                                                                                                                                                                                                                        |
+| ------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Orchestrator**    | `apps/orchestrator`                         | Control plane brain. BGP-inspired peer-to-peer route exchange via `CatalystNodeBus`. V2 dispatch pattern: `dispatch()` -> `handleAction()` (pure state transitions) -> `handleNotify()` (side effects). Exposes RPC with 3 client interfaces: `NetworkClient`, `DataChannel`, `IBGPClient`. |
+| **Auth Service**    | `apps/auth`                                 | JWT token lifecycle (mint, verify, revoke). JWKS endpoint for key distribution. Cedar policy evaluation for fine-grained authorization. Extends `CatalystService`.                                                                                                                          |
+| **GraphQL Gateway** | `apps/gateway`                              | Federation engine using `graphql-yoga` and `@graphql-tools/stitch`. Dynamically stitches remote GraphQL schemas into a unified API. Receives subgraph configuration from Orchestrator via RPC and hot-swaps schemas.                                                                        |
+| **OTEL Collector**  | `docker-compose/otel-collector-config.yaml` | Universal telemetry sink. Receives OTLP over gRPC (:4317) and HTTP (:4318). Runs `memory_limiter` then `batch` processors. Currently exports to `debug`; production backends are TODO.                                                                                                      |
+| **Envoy Proxy**     | Planned                                     | Data plane for L4 routing. Will receive dynamic configuration via xDS from the Orchestrator.                                                                                                                                                                                                |
+
+---
+
+## 4. Package Map
+
+### Applications
+
+| Package             | Name                             | Purpose                                                 |
+| ------------------- | -------------------------------- | ------------------------------------------------------- |
+| `apps/orchestrator` | `@catalyst/orchestrator-service` | Control plane, BGP routing, peer management, RPC server |
+| `apps/auth`         | `@catalyst/auth-service`         | JWT + Cedar authorization service                       |
+| `apps/gateway`      | `@catalyst/gateway-service`      | GraphQL federation gateway                              |
+| `apps/node`         | `@catalyst/node-service`         | Lightweight standalone node                             |
+| `apps/cli`          | `@catalyst/cli`                  | Command-line management tool                            |
+
+### Libraries
+
+| Package                  | Name                      | Purpose           | Key Exports                                                                                                                                 |
+| ------------------------ | ------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/authorization` | `@catalyst/authorization` | Auth subsystem    | `JWTTokenFactory`, Cedar engine, `AuthService`, key management, token stores (SQLite), `Role`, `Principal`, `Action` enums, `jwtToEntity()` |
+| `packages/config`        | `@catalyst/config`        | Configuration     | Zod-validated config schemas, env var loader (`CATALYST_*` variables), `NodeConfigSchema`, `OrchestratorConfigSchema`                       |
+| `packages/routing`       | `@catalyst/routing`       | Route management  | Route types, action definitions (`Actions`), `RouteTable` state, `DataChannelDefinition` schemas, `UpdateMessageSchema`                     |
+| `packages/service`       | `@catalyst/service`       | Service framework | `CatalystService` base class, `catalystHonoServer()`, lifecycle management (`create()` -> `initialize()` -> `ready` -> `shutdown()`)        |
+| `packages/telemetry`     | `@catalyst/telemetry`     | Observability     | `TelemetryBuilder`, OpenTelemetry integration, LogTape logging (`getLogger()`), Hono middleware, Capnweb RPC instrumentation                |
+| `packages/types`         | `@catalyst/types`         | Shared types      | Discriminated union `Result<T>`, `ValidationResult<T>`                                                                                      |
+| `packages/sdk`           | `@catalyst/sdk`           | External SDK      | Early stage                                                                                                                                 |
+
+---
+
+## 5. Dependency Graph
 
 ```mermaid
 graph TD
-    subgraph DataPlane [Data Plane]
-        Envoy["Envoy Proxy <br/> (Container)"]
+    subgraph Leaf Packages
+        types["@catalyst/types"]
+        config["@catalyst/config"]
+        telemetry["@catalyst/telemetry"]
+        sdk["@catalyst/sdk"]
     end
 
-    subgraph ControlPlane [Control Plane Pod]
-        Orchestrator["Catalyst Router <br/> (Orchestrator)"]
-        GQL["GraphQL Gateway <br/> (Sidecar)"]
-        Auth["Auth Service <br/> (Sidecar)"]
-        OTEL["OTEL Collector <br/> (Sidecar)"]
+    subgraph Core Packages
+        routing["@catalyst/routing"]
+        service["@catalyst/service"]
+        authorization["@catalyst/authorization"]
     end
 
-    %% xDS Configuration
-    Orchestrator --"xDS (REST)"--> Envoy
+    subgraph Applications
+        auth["apps/auth"]
+        gateway["apps/gateway"]
+        orchestrator["apps/orchestrator"]
+        node["apps/node"]
+        cli["apps/cli"]
+    end
 
-    %% RPC Coordination
-    Orchestrator <--"Capnweb RPC"--> GQL
-    Orchestrator <--"Capnweb RPC"--> Auth
+    routing --> config
+    service --> config
+    service --> telemetry
+    authorization --> service
+    authorization --> telemetry
+    authorization --> types
 
-    %% Metrics
-    GQL --"Push"--> OTEL
-    Auth --"Push"--> OTEL
-    Envoy --"Push"--> OTEL
+    auth --> authorization
+    auth --> config
+    auth --> service
 
-    %% Public Traffic
-    Client[Client] --> Envoy
-    Envoy --> GQL
-    Envoy -.-> Auth
+    gateway --> config
+    gateway --> service
+    gateway --> telemetry
+
+    orchestrator --> auth
+    orchestrator --> authorization
+    orchestrator --> config
+    orchestrator --> routing
+    orchestrator --> service
+    orchestrator --> telemetry
+
+    node --> config
+    node --> service
+    node --> telemetry
+
+    cli --> orchestrator
+    cli --> routing
+    cli --> authorization
 ```
 
-### Components
+Dependencies flow inward: applications depend on libraries, libraries depend on leaf packages. Cross-package internal imports are prohibited (Constitution Principle V).
 
-#### 1. Catalyst Router (The Orchestrator)
+---
 
-- **Role**: Central Brain.
-- **Responsibilities**:
-  - **BGP/Peering**: Handles inter-node discovery and route exchange.
-  - **xDS Server**: Generates dynamic configuration for Envoy.
-  - **Sidecar Management**: Configures GraphQL and Auth services via RPC.
+## 6. Key Data Flows
 
-#### 2. Envoy Proxy (Data Plane)
+### 6a. V2 Dispatch Pattern
 
-- **Role**: High-performance Edge Router & Local Service Transport.
-- **Config**: Fully dynamic via xDS (LDS/CDS/RDS/EDS) served by the Orchestrator.
-- **Traffic**:
-  - **Peer-to-Peer**: Handles all ingress/egress, terminating TLS.
-  - **Local-to-Gateway**: Acts as the local transport for services to reach the GraphQL Gateway (e.g., `http://localhost:10000/graphql` -> Envoy -> Gateway).
+The Orchestrator's control plane follows a strict two-phase dispatch pattern (Constitution Principle III). All state mutations flow through `dispatch()` on the `CatalystNodeBus`:
 
-#### 3. GraphQL Gateway (Sidecar)
-
-- **Role**: TypeScript-based Federation Engine (Apollo/Yoga).
-- **Control**: Receives federation config (supergraph) from Orchestrator via RPC.
-- **Data**: Executes queries, delegating to local services or remote peers.
-
-#### 4. Auth Service (Sidecar)
-
-- **Role**: Identity & Crypto Engine.
-- **Responsibilities**:
-  - **Key Generation**: Creates/Rotates AS keys.
-  - **JWKS Hosting**: Serves public keys.
-  - **Signing**: Signs JWTs upon request (via RPC from Orchestrator/CLI).
-
-#### 5. OTEL Collector (Sidecar)
-
-- **Role**: Universal Metrics Sink.
-- **Input**: Receives OTLP/StatsD from all other containers.
-- **Output**: Exporters configured by the user (DataDog, Prometheus, etc.).
-
-## Control Plane Internals
-
-The Control Plane is designed as a functional event loop. It maintains an internal **State** (Route Table, Peer List, Local Services) and evolves it via a strict pipeline of plugins.
-
-### 1. The Core Loop
-
-All inputs (Incoming RPC messages, Time-based Tickers, Local Service Events) enter a unified event channel. These events flow through a pipeline of functional interfaces.
+1. **`handleAction()`** -- Pure state transition. Receives an `Action` and the current `RouteTable`, returns a new `RouteTable`. No I/O.
+2. **`handleNotify()`** -- Side effects. Propagates state changes to peers, updates the gateway, and triggers follow-up actions.
 
 ```mermaid
 sequenceDiagram
-    participant Source as Event Source
-    participant PL as Pipeline
-    participant State as System State
-    participant Plug1 as RouteTable Plugin
-    participant Plug2 as LocalService Plugin
-    participant Plug3 as Propagation Plugin
-    participant SideEffect as Side Effects
+    participant Caller as Caller (CLI / Peer / Timer)
+    participant Bus as CatalystNodeBus
+    participant Action as handleAction()
+    participant State as RouteTable
+    participant Notify as handleNotify()
+    participant Peer as Peer Nodes
+    participant GW as GraphQL Gateway
 
-    Source->>PL: Emit Event (Message/Ticker)
-    PL->>State: Get Current State
+    Caller->>Bus: dispatch(action)
+    Bus->>Bus: prevState = state
 
-    rect rgb(240, 240, 255)
-        note right of PL: Phase 1: State Mutation
-        PL->>Plug1: Apply(Event, State)
-        Plug1->>PL: Return New State Delta
-        PL->>Plug2: Apply(Event, State)
-        Plug2->>PL: Return New State Delta
+    rect rgb(235, 245, 255)
+        note right of Bus: Phase 1: Pure State Transition
+        Bus->>Action: handleAction(action, state)
+        Action->>Action: switch(action.action) -- validate and compute new state
+        Action-->>Bus: { success: true, state: newState }
+        Bus->>State: state = newState
     end
 
-    PL->>State: Commit New State
+    Bus-->>Caller: { success: true }
 
     rect rgb(255, 240, 240)
-        note right of PL: Phase 2: Reaction & Propagation
-        PL->>Plug3: Evaluate(New State)
-        Plug3->>SideEffect: Emit(Peer Message / Envoy Config)
+        note right of Bus: Phase 2: Side Effects (fire-and-forget)
+        Bus->>Notify: handleNotify(action, newState, prevState)
+        Notify->>Peer: iBGP UPDATE (route propagation)
+        Notify->>GW: Schema configuration update
+        Notify->>Bus: dispatch(followUpAction) if needed
     end
 ```
 
-### 2. Plugin Interfaces
+### 6b. Peering Flow
 
-The system is extensible via three primary interfaces.
+Nodes establish iBGP sessions and exchange routes. Loop prevention uses the node path (similar to BGP AS_PATH).
 
-#### A. Route Table Updater (`IRouteTablePlugin`)
+```mermaid
+sequenceDiagram
+    participant Admin as Administrator
+    participant NodeA as Node A (Orchestrator)
+    participant NodeB as Node B (Orchestrator)
 
-- **Responsibility**: Decides how the routing table changes given an input.
-- **Inputs**: Incoming Peer Message, Ticker (for expiration).
-- **Outputs**: Updated Route Entries (Add/Remove routes).
-- **Example**: "Received 'Add Service X' from Peer A -> Add Entry X via Peer A to Table."
+    Admin->>NodeA: NetworkClient.addPeer(nodeB)
+    NodeA->>NodeA: dispatch(LocalPeerCreate)
+    NodeA->>NodeA: handleNotify: initiate iBGP session
 
-#### B. Service Registry & Configurator (`IServicePlugin`)
+    NodeA->>NodeB: IBGPClient.open(peerInfo)
+    NodeB->>NodeB: dispatch(IBGPPeerOpen)
+    NodeB-->>NodeA: { success: true }
 
-- **Responsibility**: Manages the registry of known services.
-- **Inputs**:
-  - **Local Registration**: Services registering via Config (`catalyst.json`) or Admin API.
-  - **Health Checks**: Periodic liveness probes.
-- **Actions**:
-  - **Federation Update**: Triggers an RPC call to the **GraphQL Gateway** to federate the new service endpoint.
-  - **Envoy Config**: Updates xDS (CDS/RDS) to allow traffic to/from the service.
-- **Example**: "API registers 'Inventory Service' on port 5001 -> Orchestrator updates GraphQL Gateway to stitch `http://localhost:5001/graphql`."
+    note over NodeA,NodeB: iBGP Session Established
 
-#### C. Propagation Configurator (`IPropagationPlugin`)
+    NodeA->>NodeB: IBGPClient.update(routes)
+    NodeB->>NodeB: dispatch(IBGPRouteUpdate)
+    NodeB->>NodeB: handleAction: merge routes into RouteTable (skip if node in path)
+    NodeB->>NodeB: handleNotify: propagate to other peers
 
-- **Responsibility**: Decides what to tell neighbors.
-- **Inputs**: State Changes, Periodic Tickers.
-- **Outputs**: Outbound RPC Messages.
-- **Example**: "Route Table changed -> Send standard Route Update to all Peers."
+    NodeB->>NodeA: IBGPClient.update(routes)
+    NodeA->>NodeA: dispatch(IBGPRouteUpdate)
+    NodeA->>NodeA: handleAction: merge routes (loop prevention via node path)
+```
 
-## Data Plane Integration (xDS)
+### 6c. Request Flow
 
-We utilize Envoy's **xDS Protocol** (Discovery Service) for zero-downtime reconfiguration.
+Client requests flow through the GraphQL Gateway, which federates across subgraph services.
 
-1.  **Transport**: REST-based State of the World (SotW) or Delta (future).
-2.  **Resources**:
-    - **LDS (Listeners)**: API Ports, Peering Ports.
-    - **RDS (Routes)**: Routing logic for "/graphql", "/.well-known/jwks.json", and Peer prefixes.
-    - **CDS (Clusters)**: Upstream definitions (Local Sidecars, Remote Peers).
-    - **EDS (Endpoints)**: Specific IP:Port assignments.
+```mermaid
+sequenceDiagram
+    participant Client as External Client
+    participant GW as GraphQL Gateway
+    participant Sub as Subgraph Service
+    participant Auth as Auth Service
 
-The Orchestrator implements a lightweight xDS Control Plane that pushes JSON updates to Envoy whenever the internal Route Table changes.
+    Client->>GW: GraphQL query (HTTP)
+    GW->>Auth: Validate JWT (Capnweb RPC)
+    Auth-->>GW: Token valid + Cedar authorization result
+    GW->>Sub: Delegated subgraph query (HTTP)
+    Sub-->>GW: Subgraph response
+    GW-->>Client: Unified GraphQL response
+```
 
-## Identity & API Management
+---
 
-Catalyst Router supports three strategies for API Key management and service authentication.
+## 7. Authorization Model
 
-### Option 1: Completely External Service
+Authorization uses the [Cedar policy engine](https://www.cedarpolicy.com/) with a typed schema (see `packages/authorization/src/policy/src/definitions/schema.cedar`).
 
-- **Description**: Identity is handled entirely outside the Catalyst mesh.
-- **Flow**:
-  1.  Client gets token from External Auth Provider (Auth0, Okta, etc.).
-  2.  Client sends token to Catalyst Router.
-  3.  Envoy/Auth Service validates the token signature against absolute external JWKS.
-- **Use Case**: Enterprise integration where Identity is already solved.
+### Principals (Roles)
 
-### Option 2: Centralized API Service (Single Node)
+| Role             | Cedar Entity Type          | Purpose                                     |
+| ---------------- | -------------------------- | ------------------------------------------- |
+| `ADMIN`          | `CATALYST::ADMIN`          | Full system access -- all actions permitted |
+| `NODE`           | `CATALYST::NODE`           | Node identity for iBGP operations           |
+| `NODE_CUSTODIAN` | `CATALYST::NODE_CUSTODIAN` | Peer management authority                   |
+| `DATA_CUSTODIAN` | `CATALYST::DATA_CUSTODIAN` | Route management authority                  |
+| `USER`           | `CATALYST::USER`           | Basic login access                          |
 
-- **Description**: One specific Catalyst Router acts as the "Identity Authority" for the cluster.
-- **Flow**:
-  1.  Admin generates API Keys/Tokens on the Leader Node.
-  2.  Other Nodes are configured to delegate auth decisions or sync JWKS from the Leader.
-  3.  **Core Pod B** trusts **Core Pod A** (Leader) as the issuer.
-- **Use Case**: Small-to-medium clusters (Stage 1B) where simplicity is preferred over HA.
+### Actions
 
-### Option 3: Decentralized PKI (Hierarchical)
+| Action            | Permitted Principals                              |
+| ----------------- | ------------------------------------------------- |
+| `LOGIN`           | ADMIN, NODE, DATA_CUSTODIAN, NODE_CUSTODIAN, USER |
+| `MANAGE`          | ADMIN, NODE, DATA_CUSTODIAN, NODE_CUSTODIAN, USER |
+| `IBGP_CONNECT`    | ADMIN, NODE, NODE_CUSTODIAN                       |
+| `IBGP_DISCONNECT` | ADMIN, NODE, NODE_CUSTODIAN                       |
+| `IBGP_UPDATE`     | ADMIN, NODE, NODE_CUSTODIAN                       |
+| `PEER_CREATE`     | ADMIN, NODE_CUSTODIAN                             |
+| `PEER_UPDATE`     | ADMIN, NODE_CUSTODIAN                             |
+| `PEER_DELETE`     | ADMIN, NODE_CUSTODIAN                             |
+| `ROUTE_CREATE`    | ADMIN, DATA_CUSTODIAN                             |
+| `ROUTE_DELETE`    | ADMIN, DATA_CUSTODIAN                             |
+| `TOKEN_CREATE`    | ADMIN                                             |
+| `TOKEN_REVOKE`    | ADMIN                                             |
+| `TOKEN_LIST`      | ADMIN                                             |
 
-- **Description**: Each Node manages its own Service Accounts, rooted in a shared PKI.
-- **Flow**:
-  1.  **Root CA** issues intermediate certs to each Node.
-  2.  Each Node mints its own API Keys for its local services.
-  3.  Validation works via trust chain; no central online authority required for steady state.
-- **Use Case**: Large scale, high-availability, multi-region deployments.
+### Authorization Flow
+
+JWT tokens carry a `principal` field (Cedar entity type, e.g., `CATALYST::ADMIN`) and an `entity` payload. At authorization time, `jwtToEntity()` converts the JWT payload into a Cedar entity, which is then evaluated against Cedar policies. See [ADR-0008](./docs/adr/0008-permission-policy-schema.md) for the full policy schema design.
+
+---
+
+## 8. Persistence
+
+All persistent state uses SQLite via `bun:sqlite` (Constitution Principle X). No external databases.
+
+| Store       | Implementation        | Location                 | Purpose                                   |
+| ----------- | --------------------- | ------------------------ | ----------------------------------------- |
+| Key Store   | `BunSqliteKeyStore`   | `packages/authorization` | Signing key storage with rotation support |
+| Token Store | `BunSqliteTokenStore` | `packages/authorization` | Token tracking, revocation lists          |
+
+### SQLite Configuration
+
+All SQLite databases are initialized with required pragmas:
+
+```sql
+PRAGMA journal_mode = WAL;    -- Concurrent reads during writes
+PRAGMA foreign_keys = ON;     -- Referential integrity
+PRAGMA busy_timeout = 5000;   -- Wait up to 5s on lock contention
+```
+
+In-memory stores (`InMemoryStore` variants) are used for testing only. Ephemeral `:memory:` mode is available for test doubles, but production must use file-backed SQLite.
+
+See [ADR-0004](./docs/adr/0004-sqlite-storage-backend.md) for the decision rationale.
+
+---
+
+## 9. Observability
+
+All observability flows through the `@catalyst/telemetry` package and the OTEL Collector. `console.log()` is prohibited (Constitution Principle XVI).
+
+### TelemetryBuilder
+
+Each service configures observability via the fluent `TelemetryBuilder` API:
+
+```typescript
+const telemetry = new TelemetryBuilder('auth-service')
+  .withLogger()
+  .withMetrics()
+  .withTracing()
+  .build()
+```
+
+`CatalystService` handles `TelemetryBuilder` setup automatically -- individual services do not configure it directly (Constitution Principle XVIII).
+
+### Signal Pipeline
+
+| Signal      | Source                  | Transport | Collector Processing    | Export                  |
+| ----------- | ----------------------- | --------- | ----------------------- | ----------------------- |
+| **Logs**    | LogTape (`getLogger()`) | OTLP HTTP | memory_limiter -> batch | debug (production TODO) |
+| **Metrics** | OpenTelemetry SDK       | OTLP HTTP | memory_limiter -> batch | debug (production TODO) |
+| **Traces**  | OpenTelemetry SDK       | OTLP HTTP | memory_limiter -> batch | debug (production TODO) |
+
+### Instrumentation Points
+
+- **Hono middleware**: Automatic request/response telemetry for all HTTP services
+- **Capnweb RPC**: Automatic span creation for inter-component RPC calls
+- **W3C Trace Context**: Propagated across service boundaries for distributed tracing
+- **Hierarchical log categories**: e.g., `['catalyst', 'orchestrator']`, `['catalyst', 'auth', 'jwt']`
+
+See [ADR-0001](./docs/adr/0001-unified-opentelemetry-observability.md), [ADR-0002](./docs/adr/0002-logging-library-selection.md), [ADR-0003](./docs/adr/0003-observability-backends.md).
+
+---
+
+## 10. Configuration
+
+All configuration uses `CATALYST_*` environment variables, validated at startup by Zod schemas in `@catalyst/config` (Constitution Principle VII).
+
+| Variable                            | Required     | Purpose                                  |
+| ----------------------------------- | ------------ | ---------------------------------------- |
+| `CATALYST_NODE_ID`                  | Yes          | Unique node identifier                   |
+| `CATALYST_PEERING_ENDPOINT`         | Orchestrator | This node's peering endpoint URL         |
+| `CATALYST_DOMAINS`                  | No           | Comma-separated domain list              |
+| `CATALYST_GQL_GATEWAY_ENDPOINT`     | No           | GraphQL Gateway endpoint URL             |
+| `CATALYST_AUTH_ENDPOINT`            | No           | Auth Service endpoint URL                |
+| `CATALYST_SYSTEM_TOKEN`             | No           | System-level auth token                  |
+| `CATALYST_AUTH_KEYS_DB`             | No           | Path to signing keys SQLite database     |
+| `CATALYST_AUTH_TOKENS_DB`           | No           | Path to token store SQLite database      |
+| `CATALYST_AUTH_REVOCATION`          | No           | Enable token revocation (`true`/`false`) |
+| `CATALYST_AUTH_REVOCATION_MAX_SIZE` | No           | Max revocation list size                 |
+| `CATALYST_BOOTSTRAP_TOKEN`          | No           | Initial bootstrap token value            |
+| `CATALYST_BOOTSTRAP_TTL`            | No           | Bootstrap token TTL in seconds           |
+
+---
+
+## 11. Architectural Invariants
+
+The [constitution.md](./constitution.md) defines 18 immutable principles. Key invariants that shape daily development:
+
+| Principle                         | Summary                                                 | Impact                                                            |
+| --------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------- |
+| I. Decentralized Routing          | No centralized coordinator for routing decisions        | Peer-to-peer route exchange only; no single point of failure      |
+| II. Core Pod Architecture         | Orchestrator + sidecars, Capnweb RPC between components | All new components must fit the pod topology                      |
+| III. V2 Dispatch Pattern          | `dispatch()` -> `handleAction()` -> `handleNotify()`    | No V1 plugin interfaces; state mutations only in `handleAction()` |
+| IV. Dependency Inversion          | Accept interfaces, not concrete implementations         | Constructors accept optional interface parameters with defaults   |
+| V. Package Boundary Integrity     | Inward dependencies, no cross-package internal imports  | Import from barrel `index.ts` files only                          |
+| VI. ESM Module Conventions        | `.js` extensions, `type` imports, kebab-case files      | All imports must include extensions                               |
+| VII. Schema-First Validation      | Zod schemas on all external boundaries                  | Types derived from schemas via `z.infer<>`                        |
+| VIII. Discriminated Union Results | `{ success, data/error }` for fallible operations       | No thrown exceptions for expected failures                        |
+| X. SQLite Persistence             | `bun:sqlite` with WAL mode for all persistent state     | No in-memory Maps for durable state; no external databases        |
+| XVIII. Unified Service Lifecycle  | All services extend `CatalystService`                   | No manual `Bun.serve()`, signal handling, or telemetry bootstrap  |
+
+---
+
+## 12. Architecture Decision Records
+
+All ADRs are in [`docs/adr/`](./docs/adr/). ADRs elaborate on constitutional principles but cannot contradict them.
+
+| ADR                                                            | Title                                        | Status   |
+| -------------------------------------------------------------- | -------------------------------------------- | -------- |
+| [0001](./docs/adr/0001-unified-opentelemetry-observability.md) | Unified OpenTelemetry Observability          | Accepted |
+| [0002](./docs/adr/0002-logging-library-selection.md)           | Logging Library Selection (LogTape vs Pino)  | Accepted |
+| [0003](./docs/adr/0003-observability-backends.md)              | Observability Backend Selection              | Proposed |
+| [0004](./docs/adr/0004-sqlite-storage-backend.md)              | SQLite as Unified Storage Backend            | Accepted |
+| [0005](./docs/adr/0005-docker-as-container-runtime.md)         | Docker as Container Runtime                  | Accepted |
+| [0006](./docs/adr/0006-node-orchestrator-architecture.md)      | Node Orchestrator Architecture               | Accepted |
+| [0007](./docs/adr/0007-certificate-bound-access-tokens.md)     | Certificate Bound Access Tokens for BGP      | Proposed |
+| [0008](./docs/adr/0008-permission-policy-schema.md)            | Permission Policy Schema                     | Proposed |
+| [0009](./docs/adr/0009-relational-database-style-guide.md)     | Relational Database Style Guide              | Accepted |
+| [0010](./docs/adr/0010-catalyst-service-base-class.md)         | Unified Service Base Class (CatalystService) | Accepted |
+
+---
+
+## 13. Technology Stack
+
+| Category           | Technology                                    | Notes                                                                                   |
+| ------------------ | --------------------------------------------- | --------------------------------------------------------------------------------------- |
+| **Runtime**        | Bun                                           | JavaScript/TypeScript runtime and package manager                                       |
+| **Web Framework**  | Hono                                          | Lightweight HTTP framework; all services use `CatalystService` + `catalystHonoServer()` |
+| **RPC**            | Capnweb                                       | Cap'n Proto serialization over WebSocket for inter-component communication              |
+| **Authentication** | Jose                                          | JWT signing, verification, and JWKS                                                     |
+| **Authorization**  | @cedar-policy/cedar-wasm                      | Cedar policy engine compiled to WASM for fine-grained access control                    |
+| **API**            | GraphQL (graphql-yoga, @graphql-tools/stitch) | Schema stitching for federated GraphQL                                                  |
+| **Validation**     | Zod                                           | Runtime schema validation; source of truth for TypeScript types                         |
+| **Persistence**    | SQLite (bun:sqlite)                           | Embedded database with WAL mode; zero external dependencies                             |
+| **Observability**  | OpenTelemetry + LogTape                       | Traces, metrics, and logs via OTLP to OTEL Collector                                    |
+| **Testing**        | Vitest, Testcontainers, Playwright            | Unit, integration, topology, and E2E tests                                              |
+| **Containers**     | Docker                                        | Container runtime for the Core Pod deployment model                                     |

--- a/README.md
+++ b/README.md
@@ -1,109 +1,121 @@
 # Catalyst Router
 
-**Catalyst Router** is a distributed control and data plane designed to bridge organizations, clouds, and disparate fabrics. It enables different organizations to "peer" and offer services to each other in a cloud-native, edge-compatible way.
+Decentralized L4-7 service routing across trust boundaries
 
-Modeled after BGP, Catalyst Router brings decentralized routing to Layers 4-7, allowing for service discovery and traffic propagation across trust boundaries without relying on centralized coordination like a single Kubernetes cluster or mesh.
+![License](https://img.shields.io/badge/License-ELv2%20%2B%20Commons%20Clause-blue)
 
-## Mission
+## What is Catalyst Router?
 
-Traditional service meshes (like Istio/Linkerd) excel at managing traffic _within_ a cluster or organization. Catalyst Router is built for the spaces _between_ them. We aim to:
+Traditional service meshes like Istio and Linkerd manage traffic within a single cluster or organization. Catalyst Router is built for the spaces between them. It is a distributed control and data plane that bridges organizations, clouds, and disparate fabrics, enabling them to "peer" and offer services to each other in a cloud-native, edge-compatible way.
 
-- **Bridge Disparate Networks**: Connect on-prem datacenters, public clouds, and edge devices (even Raspberry Pis) into a unified service fabric.
-- **Enable Organizational Peering**: Allow Organization A to securely expose specific services to Organization B via standard peering agreements, similar to how ISPs peer on the internet.
-- **Run Anywhere**: Minimal resource footprint, suitable for small compute devices.
+Modeled after BGP, Catalyst Router brings decentralized routing to Layers 4-7. There is no single control plane to operate or negotiate access through. Instead, each node maintains its own routing table and exchanges routes with its peers, just as autonomous systems do on the internet. This makes it a natural fit for platform engineers building multi-organization service meshes, cross-cloud federations, or edge topologies that span heterogeneous infrastructure.
 
-## Core Architecture
-
-Catalyst Router runs as a **Core Pod** containing 5 specialized containers:
-
-### 1. Control Plane (The Orchestrator)
-
-The "brain" of the node.
-
-- **Function**: Handles BGP peering, xDS configuration generation, and sidecar management.
-- **Transport**: Uses `capnweb` RPC to coordinate with sidecars and other nodes.
-
-### 2. Data Plane (Envoy Proxy)
-
-The "muscle" of the node.
-
-- **Function**: High-performance edge router terminating TLS.
-- **Operation**: Configured dynamically via **xDS** (REST) by the Orchestrator.
-
-### 3. Sidecars (Specialized Functions)
-
-- **GraphQL Gateway**: TypeScript-based federation engine.
-- **Auth Service**: Handles Key signing and JWKS.
-- **OTEL Collector**: Central metrics sink for the pod.
+Unlike centralized approaches, Catalyst Router requires no shared Kubernetes cluster, no central registry, and no mutual trust authority beyond pairwise peering agreements. Organizations retain full sovereignty over what they expose, to whom, and under what policy constraints.
 
 ## Key Features
 
-- **Decentralized**: No single point of failure or control.
-- **Plugin-Driven**: Extensible architecture for defining custom behaviors for routing, local services, and propagation.
-- **Local Services**: Easily spin up and advertise local resources (e.g., VPN clients, GraphQL federations) as network services.
+- BGP-inspired peer-to-peer route exchange across trust boundaries
+- GraphQL federation gateway with schema stitching
+- Cedar policy engine for fine-grained authorization
+- Principal-based JWT authentication with certificate-bound tokens
+- OpenTelemetry-native observability (logs, metrics, traces)
+- Docker-native deployment with Core Pod architecture
+- SQLite persistence with zero external database dependencies
+- Runs on Bun with a minimal resource footprint
 
-## Protocol Support
+## Architecture Overview
 
-We support a variety of protocols for service definitions. Currently, **GraphQL** receives first-class support for federation.
+Each Catalyst Router node runs as a **Core Pod** -- a set of cooperating containers that together form a complete routing unit:
 
-| Protocol       | Status        | Notes                           |
-| :------------- | :------------ | :------------------------------ |
-| `tcp`          | ✅ Stabilized | Generic TCP tunneling           |
-| `udp`          | ✅ Stabilized | Generic UDP tunneling           |
-| `http`         | 🚧 Beta       | Generic HTTP proxying           |
-| `http:graphql` | ✅ Live       | Fully federated GraphQL support |
-| `http:gql`     | ✅ Live       | Alias for `http:graphql`        |
-| `http:grpc`    | 🗓️ Planned    | gRPC transcoding and routing    |
+```mermaid
+C4Container
+  title Catalyst Router - Core Pod
 
-## Testing
+  Container(orchestrator, "Orchestrator", "TypeScript / Bun", "Control plane: BGP peering, route exchange, sidecar coordination")
+  Container(auth, "Auth Service", "TypeScript / Bun", "JWT signing, JWKS endpoint, key management")
+  Container(gateway, "Gateway", "TypeScript / Bun", "GraphQL federation, schema stitching, request routing")
+  Container(otel, "OTEL Collector", "OpenTelemetry", "Metrics, logs, and traces aggregation")
 
-Catalyst Router employs a multi-tiered testing strategy to ensure reliability across its distributed components. We primarily use `bun:test` as our test runner for its speed and native TypeScript support.
-
-### Test Categories
-
-#### 1. Unit Tests
-
-Low-level tests for individual modules and logic. These are fast and have no external dependencies.
-
-```bash
-# Run all unit tests in the repository
-bun test {apps,packages}/**/*.test.ts --ignore "*.container.*"
+  Rel(orchestrator, auth, "Issues tokens")
+  Rel(orchestrator, gateway, "Pushes schema config")
+  Rel(orchestrator, otel, "Emits telemetry")
+  Rel(auth, otel, "Emits telemetry")
+  Rel(gateway, otel, "Emits telemetry")
+  Rel(gateway, auth, "Validates tokens")
 ```
 
-#### 2. Local Topology Tests
+The Orchestrator is the brain of the pod -- it manages peering sessions, computes routes, and coordinates the Auth and Gateway sidecars. All components emit telemetry to the OTEL Collector.
 
-Simulate multi-node orchestration using mocks. These validate routing and synchronization logic WITHOUT needing a container runtime.
+See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design.
 
-```bash
-# Example: Run topology tests for the orchestrator
-bun test apps/orchestrator/src/next/*.topology.test.ts
-```
+## Quick Start
 
-#### 3. Container Integration Tests
+### Prerequisites
 
-End-to-end tests that spin up actual node containers using Docker and `testcontainers`. These are used for validating network-level handshakes and gateway synchronization.
+- [Bun](https://bun.sh) >= 1.1
+- [Docker](https://www.docker.com/) (for compose deployments)
 
-```bash
-# Run container-based integration tests
-bun test {apps,packages}/**/*.container.test.ts
-```
-
-### Docker Environment Setup
-
-Container-based tests are disabled by default to prevent environment-related failures. To enable them, you must have a working Docker installation and set the following environment variable:
+### Install
 
 ```bash
-export CATALYST_CONTAINER_TESTS_ENABLED=true
+bun install
 ```
 
-> [!TIP]
-> You can add `export CATALYST_CONTAINER_TESTS_ENABLED=true` to your shell profile (~/.zshrc or ~/.bashrc) if you frequently run integration tests.
-
-### Running Tests by Package
-
-Apps live in `apps/` and libraries in `packages/`. You can run tests individually:
+### Run a single-node example
 
 ```bash
-cd apps/auth && bun test
-cd apps/orchestrator && bun test
+docker compose -f docker-compose/example.m0p2.compose.yaml up
 ```
+
+### Run tests
+
+```bash
+bun test
+```
+
+## Repository Structure
+
+| Directory                | Package                          | Description                                    |
+| :----------------------- | :------------------------------- | :--------------------------------------------- |
+| `apps/auth`              | `@catalyst/auth-service`         | JWT signing, JWKS, key management              |
+| `apps/cli`               | `@catalyst/cli`                  | Command-line interface for node management     |
+| `apps/gateway`           | `@catalyst/gateway-service`      | GraphQL federation gateway                     |
+| `apps/node`              | `@catalyst/node-service`         | Composite node entrypoint                      |
+| `apps/orchestrator`      | `@catalyst/orchestrator-service` | Control plane: peering, routing, coordination  |
+| `packages/authorization` | `@catalyst/authorization`        | Cedar policy engine integration                |
+| `packages/config`        | `@catalyst/config`               | Shared configuration schemas and loaders       |
+| `packages/routing`       | `@catalyst/routing`              | Route table, path computation, exchange        |
+| `packages/sdk`           | `@catalyst/sdk`                  | Client SDK for interacting with Catalyst nodes |
+| `packages/service`       | `@catalyst/service`              | Base service class with built-in telemetry     |
+| `packages/telemetry`     | `@catalyst/telemetry`            | OpenTelemetry setup and instrumentation        |
+| `packages/types`         | `@catalyst/types`                | Shared TypeScript type definitions             |
+| `examples/books-api`     | --                               | Example federated subgraph                     |
+| `examples/movies-api`    | --                               | Example federated subgraph                     |
+| `examples/orders-api`    | --                               | Example federated subgraph                     |
+| `examples/product-api`   | --                               | Example federated subgraph                     |
+
+## Documentation
+
+- [Architecture](./ARCHITECTURE.md) -- system design and component interactions
+- [Constitution](./constitution.md) -- architectural principles and constraints
+- [Security](./SECURITY.md) -- peer security protocol and threat model
+- [ADRs](./docs/adr/) -- architecture decision records
+- [CLI Reference](./CLI.md) -- command-line usage and options
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for development guidelines. All contributors must sign the [Contributor License Agreement](./CLA.md).
+
+This project uses [Graphite](https://graphite.dev) for stacked PRs and follows [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
+
+## Security
+
+Catalyst Router uses mTLS for node-to-node communication, JWT with certificate-bound tokens for request authentication, and Cedar policies for fine-grained authorization. See [SECURITY.md](./SECURITY.md) for the full security protocol.
+
+## License
+
+Source-available under the [Commons Clause + Elastic License 2.0](./LICENSE). See [LICENSE_HUMAN_READABLE.md](./LICENSE_HUMAN_READABLE.md) for a plain-language summary.
+
+Licensor: **Orbis Operations LLC**
+
+This software is **not** open source. The Commons Clause restricts commercial use of the software as a hosted or managed service. See the license files for full terms.


### PR DESCRIPTION
docs: rename project from Catalyst Node to Catalyst Router

Update all documentation references across 34 files to reflect the
project rename. Includes root docs, ADRs, PRDs, package READMEs, and
license files. Root package.json name changed from catalyst-monorepo
to catalyst-router. Code symbols (env vars, class names, package names)
left unchanged for a separate migration.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

docs: rewrite README, ARCHITECTURE, and add API design documentation

Comprehensive rewrite of README.md with quickstart, repo structure,
license info, and architecture overview. Full ARCHITECTURE.md rewrite
with C4 diagrams, package map, dependency graph, data flows, and
authorization model. New API.md documenting the Capnweb progressive
API pattern, transport layer, and REST comparison.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>