### PR TITLE
refactor(cli): update handlers to use publicApi progressive pattern

### DIFF
--- a/apps/cli/src/clients/orchestrator-client.ts
+++ b/apps/cli/src/clients/orchestrator-client.ts
@@ -1,9 +1,6 @@
-import type { RpcStub } from 'capnweb'
 import { newWebSocketRpcSession } from 'capnweb'
 import { resolveServiceUrl } from './resolve-url.js'
-import type { PeerInfo } from '@catalyst/orchestrator'
-import type { DataChannelDefinition } from '@catalyst/orchestrator'
-import type { InternalRoute } from '@catalyst/orchestrator'
+import type { PeerInfo, DataChannelDefinition, InternalRoute } from '@catalyst/routing'
 
 // Polyfill Symbol.asyncDispose if necessary
 // @ts-expect-error - polyfilling Symbol.asyncDispose
@@ -11,18 +8,44 @@ Symbol.asyncDispose ??= Symbol('Symbol.asyncDispose')
 
 export type ActionResult = { success: true } | { success: false; error: string }
 
-export interface OrchestratorPublicApi {
-  connectionFromManagementSDK(): RpcStub<ManagementScope>
+/**
+ * Data channel client — manages local and internal routes.
+ *
+ * Matches the server-side `DataChannel` interface from the orchestrator's
+ * `publicApi().getDataChannelClient(token)` progressive RPC pattern.
+ */
+export interface DataChannelClient {
+  addRoute(route: DataChannelDefinition): Promise<ActionResult>
+  removeRoute(route: DataChannelDefinition): Promise<ActionResult>
+  listRoutes(): Promise<{ local: DataChannelDefinition[]; internal: InternalRoute[] }>
 }
 
-export interface ManagementScope {
-  applyAction(action: unknown): Promise<ActionResult>
-  listLocalRoutes(): Promise<{
-    routes: { local: DataChannelDefinition[]; internal: InternalRoute[] }
-  }>
-  listMetrics(): Promise<unknown>
-  listPeers(): Promise<{ peers: PeerInfo[] }>
-  deletePeer(peerId: string): Promise<ActionResult>
+/**
+ * Network client — manages peer connections.
+ *
+ * Matches the server-side `NetworkClient` interface from the orchestrator's
+ * `publicApi().getNetworkClient(token)` progressive RPC pattern.
+ */
+export interface NetworkClient {
+  addPeer(peer: PeerInfo): Promise<ActionResult>
+  updatePeer(peer: PeerInfo): Promise<ActionResult>
+  removePeer(peer: Pick<PeerInfo, 'name'>): Promise<ActionResult>
+  listPeers(): Promise<PeerInfo[]>
+}
+
+/**
+ * Orchestrator public API — progressive RPC pattern.
+ *
+ * Each method authenticates with a token and returns a scoped client
+ * for a specific domain (data channels, networking, etc.).
+ */
+export interface OrchestratorPublicApi {
+  getDataChannelClient(
+    token: string
+  ): Promise<{ success: true; client: DataChannelClient } | { success: false; error: string }>
+  getNetworkClient(
+    token: string
+  ): Promise<{ success: true; client: NetworkClient } | { success: false; error: string }>
 }
 
 export async function createOrchestratorClient(url?: string): Promise<OrchestratorPublicApi> {

--- a/apps/cli/src/commands/node/route.ts
+++ b/apps/cli/src/commands/node/route.ts
@@ -47,7 +47,8 @@ export function routeCommands(): Command {
         process.exit(1)
       }
 
-      const result = await createRouteHandler(validation.data)
+      try {
+        const result = await createRouteHandler(validation.data)
 
         if (result.success) {
           console.log(chalk.green(`[ok] Route '${name}' created successfully.`))
@@ -81,23 +82,28 @@ export function routeCommands(): Command {
         process.exit(1)
       }
 
-      const result = await listRoutesHandler(validation.data)
+      try {
+        const result = await listRoutesHandler(validation.data)
 
-      if (result.success) {
-        if (result.data.routes.length === 0) {
-          console.log(chalk.yellow('No routes found.'))
+        if (result.success) {
+          if (result.data.routes.length === 0) {
+            console.log(chalk.yellow('No routes found.'))
+          } else {
+            console.table(
+              result.data.routes.map((r) => ({
+                Name: r.name,
+                Endpoint: r.endpoint || 'N/A',
+                Protocol: r.protocol,
+                Source: r.source,
+                Peer: 'peer' in r ? r.peer : '-',
+              }))
+            )
+          }
+          process.exit(0)
         } else {
-          console.table(
-            result.data.routes.map((r) => ({
-              Name: r.name,
-              Endpoint: r.endpoint || 'N/A',
-              Protocol: r.protocol,
-              Source: r.source,
-              Peer: 'peer' in r ? r.peer : '-',
-            }))
-          )
+          console.error(chalk.red(`[error] Failed to list routes: ${result.error}`))
+          process.exit(1)
         }
-        process.exit(0)
       } catch (error) {
         console.error(chalk.red(`[error] Error: ${error instanceof Error ? error.message : error}`))
         process.exit(1)
@@ -125,7 +131,8 @@ export function routeCommands(): Command {
         process.exit(1)
       }
 
-      const result = await deleteRouteHandler(validation.data)
+      try {
+        const result = await deleteRouteHandler(validation.data)
 
         if (result.success) {
           console.log(chalk.green(`[ok] Route '${name}' deleted.`))

--- a/apps/cli/tests/clients/orchestrator-client.unit.test.ts
+++ b/apps/cli/tests/clients/orchestrator-client.unit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test'
+import { createOrchestratorClient } from '../../src/clients/orchestrator-client.js'
+
+describe('Orchestrator Client', () => {
+  it('should create client with default URL', async () => {
+    const client = await createOrchestratorClient()
+    expect(client).toBeDefined()
+    expect(typeof client.getDataChannelClient).toBe('function')
+    expect(typeof client.getNetworkClient).toBe('function')
+  })
+
+  it('should create client with custom URL', async () => {
+    const client = await createOrchestratorClient('ws://custom:3000/rpc')
+    expect(client).toBeDefined()
+    expect(typeof client.getDataChannelClient).toBe('function')
+    expect(typeof client.getNetworkClient).toBe('function')
+  })
+
+  it('should use CATALYST_ORCHESTRATOR_URL env var if set', async () => {
+    const originalEnv = process.env.CATALYST_ORCHESTRATOR_URL
+    process.env.CATALYST_ORCHESTRATOR_URL = 'ws://env-test:3000/rpc'
+
+    const client = await createOrchestratorClient()
+    expect(client).toBeDefined()
+
+    // Restore env
+    if (originalEnv) {
+      process.env.CATALYST_ORCHESTRATOR_URL = originalEnv
+    } else {
+      delete process.env.CATALYST_ORCHESTRATOR_URL
+    }
+  })
+})


### PR DESCRIPTION
Replace connectionFromManagementSDK() calls with the orchestrator's
actual publicApi() progressive RPC pattern: getDataChannelClient(token)
and getNetworkClient(token).

- orchestrator-client.ts: new DataChannelClient/NetworkClient interfaces
  matching server-side DataChannel and NetworkClient types
- node-route-handlers.ts: use dcClient.addRoute/removeRoute/listRoutes
- node-peer-handlers.ts: use netClient.addPeer/removePeer/listPeers
- commands/node/route.ts: fix pre-existing broken try/catch blocks
- Unit and container tests updated to assert new API shape

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>