### PR TITLE
fix(auth): remove NODE from stream publish/subscribe and reject when auth unconfigured

### DIFF
--- a/apps/orchestrator/Dockerfile
+++ b/apps/orchestrator/Dockerfile
@@ -72,6 +72,7 @@ RUN bun install --omit=dev --ignore-scripts
 WORKDIR /app/apps/orchestrator
 
 ENV PORT=3000
+ENV OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
 EXPOSE 3000
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@catalyst/orchestrator-service",
   "main": "./src/index.ts",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/apps/orchestrator/src/orchestrator.ts
+++ b/apps/orchestrator/src/orchestrator.ts
@@ -140,7 +140,7 @@ export class CatalystNodeBus extends RpcTarget {
     connectionPool?: { type?: 'ws' | 'http'; pool?: ConnectionPool }
     config: OrchestratorConfig
     nodeToken?: string
-    authEndpoint?: string
+    authEndpoint: string
   }) {
     super()
     this.state = opts.state ?? newRouteTable()
@@ -187,11 +187,6 @@ export class CatalystNodeBus extends RpcTarget {
     callerToken: string,
     action: string
   ): Promise<{ valid: true } | { valid: false; error: string }> {
-    // If no auth client is configured, allow the operation (for testing/development)
-    if (!this.authClient) {
-      return { valid: true }
-    }
-
     try {
       // Use permissions API to validate the caller's token
       const permissionsApi = await this.authClient.permissions(callerToken)

--- a/apps/orchestrator/tests/orchestrator.test.ts
+++ b/apps/orchestrator/tests/orchestrator.test.ts
@@ -7,7 +7,6 @@ import {
   type StartedTestContainer,
 } from 'testcontainers'
 
-
 import path from 'path'
 import type { Readable } from 'node:stream'
 import { newWebSocketRpcSession, type RpcStub } from 'capnweb'
@@ -299,6 +298,42 @@ class MockConnectionPool extends ConnectionPool {
     return this.mockStubs.get(endpoint) as unknown as RpcStub<PublicApi>
   }
 }
+
+describe('CatalystNodeBus > validateToken rejects when authClient is not configured', () => {
+  let bus: CatalystNodeBus
+
+  beforeEach(() => {
+    bus = new CatalystNodeBus({
+      config: { node: MOCK_NODE },
+      connectionPool: { pool: new MockConnectionPool('http') },
+      authEndpoint: '',
+    })
+  })
+
+  it('getNetworkClient rejects with no auth client', async () => {
+    const result = await bus.publicApi().getNetworkClient('any-token')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toContain('Token validation failed')
+    }
+  })
+
+  it('getDataChannelClient rejects with no auth client', async () => {
+    const result = await bus.publicApi().getDataChannelClient('any-token')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toContain('Token validation failed')
+    }
+  })
+
+  it('getIBGPClient rejects with no auth client', async () => {
+    const result = await bus.publicApi().getIBGPClient('any-token')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toContain('Token validation failed')
+    }
+  })
+})
 
 describe('CatalystNodeBus > GraphQL Gateway Sync', () => {
   let bus: CatalystNodeBus

--- a/packages/authorization/src/policy/src/definitions/index.ts
+++ b/packages/authorization/src/policy/src/definitions/index.ts
@@ -1,10 +1,11 @@
 import type { AuthorizationEngine } from '../authorization-engine.js'
 import adminPolicy from './admin.cedar' with { type: 'text' }
 import dataCustodianPolicy from './data-custodian.cedar' with { type: 'text' }
-import type { Action, IBGPEntity, PeerEntity, Role, RouteEntity } from './models.js'
+import type { Action, IBGPEntity, PeerEntity, Role, RouteEntity, StreamEntity } from './models.js'
 import nodeCustodianPolicy from './node-custodian.cedar' with { type: 'text' }
 import nodePolicy from './node.cedar' with { type: 'text' }
 import CATALYST_SCHEMA from './schema.cedar' with { type: 'text' }
+import streamDataCustodianPolicy from './stream-data-custodian.cedar' with { type: 'text' }
 import telemetryExporterPolicy from './telemetry-exporter.cedar' with { type: 'text' }
 import userPolicy from './user.cedar' with { type: 'text' }
 
@@ -14,6 +15,7 @@ export {
   dataCustodianPolicy,
   nodeCustodianPolicy,
   nodePolicy,
+  streamDataCustodianPolicy,
   telemetryExporterPolicy,
   userPolicy,
 }
@@ -27,6 +29,7 @@ export const ALL_POLICIES = [
   nodeCustodianPolicy,
   dataCustodianPolicy,
   userPolicy,
+  streamDataCustodianPolicy,
   telemetryExporterPolicy,
 ].join('\n')
 
@@ -51,6 +54,7 @@ export type CatalystPolicyDomain = [
       Token: Record<string, unknown>
       AdminPanel: Record<string, unknown>
       Collector: Record<string, unknown>
+      Stream: StreamEntity
     }
   },
 ]

--- a/packages/authorization/src/policy/src/definitions/models.ts
+++ b/packages/authorization/src/policy/src/definitions/models.ts
@@ -24,10 +24,17 @@ export type PeerEntity = {
 
 export type RouteEntity = {
   name: string
-  protocol: 'http' | 'http:graphql' | 'http:gql' | 'http:grpc'
+  protocol: 'http' | 'http:graphql' | 'http:gql' | 'http:grpc' | 'media'
   endpoint?: string | undefined
   region?: string | undefined
   tags?: string[] | undefined
+}
+
+export type StreamEntity = {
+  streamId: string
+  sourceNode: string
+  domainId: string
+  nodeId: string
 }
 
 /**
@@ -87,6 +94,8 @@ export enum Action {
   TOKEN_REVOKE = 'TOKEN_REVOKE',
   TOKEN_LIST = 'TOKEN_LIST',
   TELEMETRY_EXPORT = 'TELEMETRY_EXPORT',
+  STREAM_PUBLISH = 'STREAM_PUBLISH',
+  STREAM_SUBSCRIBE = 'STREAM_SUBSCRIBE',
 }
 
 /**
@@ -104,7 +113,12 @@ export const ROLE_PERMISSIONS: Record<Role, Action[]> = {
     Action.IBGP_DISCONNECT,
     Action.IBGP_UPDATE,
   ],
-  [Role.DATA_CUSTODIAN]: [Action.ROUTE_CREATE, Action.ROUTE_DELETE],
-  [Role.USER]: [Action.LOGIN],
+  [Role.DATA_CUSTODIAN]: [
+    Action.ROUTE_CREATE,
+    Action.ROUTE_DELETE,
+    Action.STREAM_PUBLISH,
+    Action.STREAM_SUBSCRIBE,
+  ],
+  [Role.USER]: [Action.LOGIN, Action.STREAM_SUBSCRIBE],
   [Role.TELEMETRY_EXPORTER]: [Action.TELEMETRY_EXPORT],
 }

--- a/packages/authorization/src/policy/src/definitions/schema.cedar
+++ b/packages/authorization/src/policy/src/definitions/schema.cedar
@@ -67,6 +67,12 @@ namespace CATALYST {
         nodeId: String,
         domainId: String
     };
+    entity Stream {
+        streamId: String,
+        sourceNode: String,
+        domainId: String,
+        nodeId: String
+    };
 
     action LOGIN appliesTo {
         principal: [ADMIN, NODE, DATA_CUSTODIAN, NODE_CUSTODIAN, USER],
@@ -141,5 +147,15 @@ namespace CATALYST {
     action TELEMETRY_EXPORT appliesTo {
         principal: [ADMIN, TELEMETRY_EXPORTER],
         resource: [Collector]
+    };
+
+    action STREAM_PUBLISH appliesTo {
+        principal: [ADMIN, DATA_CUSTODIAN],
+        resource: [Stream, AdminPanel]
+    };
+
+    action STREAM_SUBSCRIBE appliesTo {
+        principal: [ADMIN, DATA_CUSTODIAN, USER],
+        resource: [Stream, AdminPanel]
     };
 }

--- a/packages/authorization/src/policy/src/definitions/stream-data-custodian.cedar
+++ b/packages/authorization/src/policy/src/definitions/stream-data-custodian.cedar
@@ -1,0 +1,11 @@
+// DATA_CUSTODIAN principals can publish and subscribe to streams
+// within their trusted domains/nodes.
+permit (
+    principal is CATALYST::DATA_CUSTODIAN,
+    action in [CATALYST::Action::"STREAM_PUBLISH", CATALYST::Action::"STREAM_SUBSCRIBE"],
+    resource is CATALYST::Stream
+)
+when {
+    principal.trustedDomains.contains(resource.domainId) &&
+    (principal.trustedNodes.isEmpty() || principal.trustedNodes.contains(resource.nodeId))
+};

--- a/packages/authorization/tests/cedar-stream-policies.test.ts
+++ b/packages/authorization/tests/cedar-stream-policies.test.ts
@@ -1,0 +1,192 @@
+import { describe, test, expect, beforeAll } from 'bun:test'
+import { AuthorizationEngine } from '../src/policy/src/authorization-engine.js'
+import {
+  CATALYST_SCHEMA,
+  ALL_POLICIES,
+  type CatalystPolicyDomain,
+} from '../src/policy/src/definitions/index.js'
+
+/**
+ * Cedar stream policy evaluation tests.
+ *
+ * WHY a role x action matrix:
+ * The Cedar schema's `appliesTo` clauses structurally restrict which principals
+ * can even attempt an action. The policy `permit` rules then further constrain
+ * based on trusted domains/nodes. This test verifies both layers:
+ * - Structural: Can this principal type invoke this action? (appliesTo)
+ * - Policy: Does a permit rule grant access? (when clause)
+ *
+ * WHY raw entity arrays instead of EntityBuilder:
+ * Cedar WASM expects Set<String> attributes as plain JSON arrays.
+ * The EntityBuilder's .setAttributes() with JS Set objects doesn't
+ * serialize correctly for cedar-wasm. Raw arrays work.
+ */
+
+function makeEntities(
+  principalType: string,
+  principalId: string,
+  opts: { trustedDomains: string[]; trustedNodes: string[] }
+) {
+  return [
+    {
+      uid: { type: principalType, id: principalId },
+      attrs: {
+        id: principalId,
+        name: principalId,
+        type: principalType.split('::').pop()!,
+        trustedDomains: opts.trustedDomains,
+        trustedNodes: opts.trustedNodes,
+      },
+      parents: [],
+    },
+    {
+      uid: { type: 'CATALYST::Stream', id: 'test-stream' },
+      attrs: {
+        streamId: 'test-stream',
+        sourceNode: 'field-node-1',
+        domainId: 'domain-1',
+        nodeId: 'field-node-1',
+      },
+      parents: [],
+    },
+  ]
+}
+
+describe('Cedar Stream Policies', () => {
+  let engine: AuthorizationEngine<CatalystPolicyDomain>
+
+  beforeAll(() => {
+    engine = new AuthorizationEngine<CatalystPolicyDomain>(CATALYST_SCHEMA, ALL_POLICIES)
+    const valid = engine.validatePolicies({ failOnWarnings: false })
+    expect(valid).toBe(true)
+  })
+
+  function evaluate(
+    principalType: string,
+    principalId: string,
+    action: string,
+    trustedDomains: string[] = ['domain-1'],
+    trustedNodes: string[] = []
+  ): { allowed: boolean; type: string } {
+    const entities = makeEntities(principalType, principalId, {
+      trustedDomains,
+      trustedNodes,
+    })
+
+    const result = engine.isAuthorized({
+      principal: { type: principalType, id: principalId } as any,
+      action: `CATALYST::Action::${action}` as any,
+      resource: { type: 'CATALYST::Stream', id: 'test-stream' } as any,
+      entities: entities as any,
+      context: {},
+    })
+
+    if (result.type === 'evaluated') {
+      return { allowed: result.allowed, type: 'evaluated' }
+    }
+    return { allowed: false, type: 'failure' }
+  }
+
+  describe('ADMIN — has all permissions', () => {
+    test('ADMIN can STREAM_PUBLISH', () => {
+      const result = evaluate('CATALYST::ADMIN', 'admin-1', 'STREAM_PUBLISH')
+      expect(result.type).toBe('evaluated')
+      expect(result.allowed).toBe(true)
+    })
+
+    test('ADMIN can STREAM_SUBSCRIBE', () => {
+      const result = evaluate('CATALYST::ADMIN', 'admin-1', 'STREAM_SUBSCRIBE')
+      expect(result.type).toBe('evaluated')
+      expect(result.allowed).toBe(true)
+    })
+  })
+
+  describe('NODE — no stream permissions', () => {
+    test('NODE cannot STREAM_PUBLISH (not in appliesTo)', () => {
+      const result = evaluate('CATALYST::NODE', 'node-1', 'STREAM_PUBLISH')
+      expect(result.allowed).toBe(false)
+    })
+
+    test('NODE cannot STREAM_SUBSCRIBE (not in appliesTo)', () => {
+      const result = evaluate('CATALYST::NODE', 'node-1', 'STREAM_SUBSCRIBE')
+      expect(result.allowed).toBe(false)
+    })
+  })
+
+  describe('NODE_CUSTODIAN — no stream permissions', () => {
+    test('NODE_CUSTODIAN cannot STREAM_PUBLISH (not in appliesTo)', () => {
+      const result = evaluate('CATALYST::NODE_CUSTODIAN', 'nc-1', 'STREAM_PUBLISH')
+      expect(result.allowed).toBe(false)
+    })
+
+    test('NODE_CUSTODIAN cannot STREAM_SUBSCRIBE (not in appliesTo)', () => {
+      const result = evaluate('CATALYST::NODE_CUSTODIAN', 'nc-1', 'STREAM_SUBSCRIBE')
+      expect(result.allowed).toBe(false)
+    })
+  })
+
+  describe('DATA_CUSTODIAN — can publish and subscribe', () => {
+    test('DATA_CUSTODIAN can STREAM_PUBLISH in trusted domain', () => {
+      const result = evaluate('CATALYST::DATA_CUSTODIAN', 'dc-1', 'STREAM_PUBLISH')
+      expect(result.type).toBe('evaluated')
+      expect(result.allowed).toBe(true)
+    })
+
+    test('DATA_CUSTODIAN can STREAM_SUBSCRIBE in trusted domain', () => {
+      const result = evaluate('CATALYST::DATA_CUSTODIAN', 'dc-1', 'STREAM_SUBSCRIBE')
+      expect(result.type).toBe('evaluated')
+      expect(result.allowed).toBe(true)
+    })
+
+    test('DATA_CUSTODIAN denied STREAM_PUBLISH outside trusted domain', () => {
+      const result = evaluate('CATALYST::DATA_CUSTODIAN', 'dc-1', 'STREAM_PUBLISH', [
+        'other-domain',
+      ])
+      expect(result.type).toBe('evaluated')
+      expect(result.allowed).toBe(false)
+    })
+  })
+
+  describe('USER — can subscribe only', () => {
+    test('USER can STREAM_SUBSCRIBE in trusted domain', () => {
+      const result = evaluate('CATALYST::USER', 'user-1', 'STREAM_SUBSCRIBE')
+      expect(result.type).toBe('evaluated')
+      expect(result.allowed).toBe(true)
+    })
+
+    test('USER cannot STREAM_PUBLISH (not in appliesTo)', () => {
+      const result = evaluate('CATALYST::USER', 'user-1', 'STREAM_PUBLISH')
+      expect(result.allowed).toBe(false)
+    })
+
+    test('USER denied STREAM_SUBSCRIBE outside trusted domain', () => {
+      const result = evaluate('CATALYST::USER', 'user-1', 'STREAM_SUBSCRIBE', ['other-domain'])
+      expect(result.type).toBe('evaluated')
+      expect(result.allowed).toBe(false)
+    })
+  })
+
+  describe('trustedNodes constraint', () => {
+    test('DATA_CUSTODIAN with specific trustedNodes — matches stream nodeId → allowed', () => {
+      const result = evaluate(
+        'CATALYST::DATA_CUSTODIAN',
+        'dc-1',
+        'STREAM_PUBLISH',
+        ['domain-1'],
+        ['field-node-1']
+      )
+      expect(result.allowed).toBe(true)
+    })
+
+    test('DATA_CUSTODIAN with specific trustedNodes — does not match stream nodeId → denied', () => {
+      const result = evaluate(
+        'CATALYST::DATA_CUSTODIAN',
+        'dc-1',
+        'STREAM_PUBLISH',
+        ['domain-1'],
+        ['other-node']
+      )
+      expect(result.allowed).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Remove NODE principal from STREAM_PUBLISH and STREAM_SUBSCRIBE Cedar
policies — nodes should not have stream permissions. Resolve merge
conflicts across authorization definition files to include both
telemetry and stream changes. Add tests verifying validateToken rejects
all public API calls when authClient is not configured.