### PR TITLE
ci: add CI workflow with lint, test, and docker validate jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Lint, Format & Typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-repo
+
+      - run: bun run lint
+      - run: bun run format:check
+      - run: bunx turbo run typecheck
+
+  test-unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-repo
+
+      - run: bunx turbo run test:unit
+
+  test-container:
+    name: Container Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-repo
+
+      - run: bunx turbo run test:container
+        env:
+          CATALYST_CONTAINER_TESTS_ENABLED: 'true'
+
+  docker-validate:
+    name: Docker Build (Bake)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - uses: docker/bake-action@76cc37d36fff4af4670fabf52a021eb1ca77591f # v6.10.0
+        with:
+          targets: core
+          set: |
+            *.platform=linux/amd64
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max


### PR DESCRIPTION
### TL;DR

Added GitHub Actions CI workflow to automate testing and validation processes.

### What changed?

Created a new CI workflow file (`.github/workflows/ci.yml`) that:
- Runs on pull requests to main and pushes to main
- Includes four key jobs:
  1. Quality checks (linting, formatting, and type checking)
  2. Unit tests
  3. Container tests
  4. Docker build validation (only for PRs)
- Implements concurrency controls to prevent redundant workflow runs
- Uses GitHub's cache for Docker builds to improve performance

### How to test?

- Create a pull request to verify all CI jobs run correctly
- Check that linting, formatting, and type checking pass
- Verify unit tests and container tests execute successfully
- Confirm Docker build validation works for PRs

### Why make this change?

To establish automated quality controls and testing for the codebase, ensuring that all contributions meet quality standards before being merged. This automation helps catch issues early in the development process and maintains consistent code quality across the project.