### PR TITLE
feat(progressive-api-policy): updated policy changes and new split authentication and authorization

### DIFF
--- a/apps/auth/tests/container.test.ts
+++ b/apps/auth/tests/container.test.ts
@@ -34,15 +34,17 @@ describe('Auth Service Container', () => {
     }
 
     container = await new GenericContainer('auth-service:test')
-      .withExposedPorts(4020)
+      .withExposedPorts(5000)
       .withEnvironment({
-        CATALYST_AUTH_PORT: '4020',
-        CATALYST_AUTH_KEYS_DIR: '/tmp/keys',
+        PORT: '5000',
+        CATALYST_NODE_ID: 'test-node',
+        CATALYST_AUTH_KEYS_DB: ':memory:',
+        CATALYST_AUTH_TOKENS_DB: ':memory:',
       })
-      .withWaitStrategy(Wait.forHttp('/health', 4020))
+      .withWaitStrategy(Wait.forLogMessage('Catalyst server [auth] listening'))
       .start()
 
-    port = container.getMappedPort(4020)
+    port = container.getMappedPort(5000)
     console.log(`Container started on port ${port}`)
   }, TIMEOUT)
 

--- a/apps/auth/tests/telemetry-token.test.ts
+++ b/apps/auth/tests/telemetry-token.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'bun:test'
+import { beforeAll, describe, expect, it } from 'bun:test'
 import * as jose from 'jose'
 
 describe('Telemetry Token', () => {
@@ -51,12 +51,11 @@ describe('Telemetry Token', () => {
       expect(decoded.iss).toBe('http://auth:4020')
       expect(decoded.sub).toBe('telemetry-exporter')
       expect(decoded.aud).toBe('otel-collector')
-      expect(decoded.roles).toEqual(['TELEMETRY_EXPORTER'])
+      expect(decoded.principal).toBe('CATALYST::TELEMETRY_EXPORTER')
       expect(decoded.entity).toMatchObject({
         id: 'telemetry-exporter',
         name: 'Telemetry Exporter',
         type: 'service',
-        role: 'TELEMETRY_EXPORTER',
       })
     })
 

--- a/apps/gateway/src/rpc/server.ts
+++ b/apps/gateway/src/rpc/server.ts
@@ -1,10 +1,10 @@
-import { z } from 'zod'
+import type { ServiceTelemetry } from '@catalyst/telemetry'
+import { TelemetryBuilder } from '@catalyst/telemetry'
+import { newRpcResponse } from '@hono/capnweb'
+import { newWebSocketRpcSession, RpcTarget, type RpcStub } from 'capnweb'
 import { Hono } from 'hono'
 import { upgradeWebSocket } from 'hono/bun'
-import { RpcTarget } from 'capnweb'
-import { newRpcResponse } from '@hono/capnweb'
-import { TelemetryBuilder } from '@catalyst/telemetry'
-import type { ServiceTelemetry } from '@catalyst/telemetry'
+import { z } from 'zod'
 
 // Define the configuration schema
 export const ServiceConfigSchema = z.object({
@@ -28,45 +28,195 @@ export const GatewayUpdateResultSchema = z.discriminatedUnion('success', [
 
 export type GatewayUpdateResult = z.infer<typeof GatewayUpdateResultSchema>
 
+export interface ConfigClient {
+  updateConfig(config: unknown): Promise<GatewayUpdateResult>
+}
+
+export interface GatewayPublicApi {
+  getConfigClient(
+    token: string
+  ): Promise<{ success: true; client: ConfigClient } | { success: false; error: string }>
+}
+
+/**
+ * Auth Service permissions API shape (mirrors orchestrator's pattern).
+ */
+interface AuthServicePermissionsHandlers {
+  authorizeAction(request: {
+    action: string
+    nodeContext: { nodeId: string; domains: string[] }
+  }): Promise<
+    | { success: true; allowed: boolean }
+    | {
+        success: false
+        errorType: string
+        reason?: string
+        reasons?: string[]
+      }
+  >
+}
+
+interface AuthServiceApi {
+  /** Pure JWT verification - checks signature, expiry, and revocation only */
+  authenticate(
+    token: string
+  ): Promise<{ valid: true; payload: Record<string, unknown> } | { valid: false; error: string }>
+  /** Cedar policy evaluation - verifies token AND checks action permissions */
+  permissions(token: string): Promise<AuthServicePermissionsHandlers | { error: string }>
+}
+
+export interface GatewayRpcServerOptions {
+  authEndpoint?: string
+  nodeId?: string
+  domains?: string[]
+}
+
 export class GatewayRpcServer extends RpcTarget {
   private updateCallback: ConfigUpdateCallback
   private readonly logger: ServiceTelemetry['logger']
+  private authClient?: RpcStub<AuthServiceApi>
+  private nodeId: string
+  private domains: string[]
 
   constructor(
     updateCallback: ConfigUpdateCallback,
-    telemetry: ServiceTelemetry = TelemetryBuilder.noop('gateway')
+    telemetry: ServiceTelemetry = TelemetryBuilder.noop('gateway'),
+    options: GatewayRpcServerOptions = {}
   ) {
     super()
     this.updateCallback = updateCallback
     this.logger = telemetry.logger.getChild('rpc')
+    this.nodeId = options.nodeId || 'unknown'
+    this.domains = options.domains || []
+    if (options.authEndpoint) {
+      this.authClient = newWebSocketRpcSession<AuthServiceApi>(options.authEndpoint)
+    }
   }
 
-  // The method exposed to RPC clients
-  async updateConfig(config: unknown): Promise<GatewayUpdateResult> {
-    this.logger.info`Config update received via RPC`
-    const result = GatewayConfigSchema.safeParse(config)
-    if (!result.success) {
-      this.logger.error`Invalid config received`
-      return {
-        success: false,
-        error: 'Malformed configuration received and unable to parse',
-      }
+  /**
+   * Authentication only: verifies the JWT token is valid (signature, expiry, revocation).
+   * Does NOT evaluate Cedar policies.
+   *
+   * Used at entry-point level (getConfigClient) to verify the caller has a valid token.
+   */
+  private async authenticateToken(
+    token: string
+  ): Promise<{ valid: true } | { valid: false; error: string }> {
+    if (!this.authClient) {
+      return { valid: true }
     }
 
     try {
-      return await this.updateCallback(result.data)
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error)
-      this.logger.error`Config update failed: ${message}`
-      return {
-        success: false,
-        error: `Failed to apply configuration: ${message}`,
+      const result = await this.authClient.authenticate(token)
+      if (!result.valid) {
+        return { valid: false, error: `Authentication failed: ${result.error}` }
       }
+      return { valid: true }
+    } catch (error) {
+      return { valid: false, error: `Authentication failed: ${error}` }
+    }
+  }
+
+  /**
+   * Authorization: evaluates Cedar policy for a specific action.
+   * Verifies the token AND checks if the action is permitted.
+   *
+   * Used inside handler methods (updateConfig) to enforce fine-grained access control.
+   */
+  private async authorizeToken(
+    token: string,
+    action: string
+  ): Promise<{ valid: true } | { valid: false; error: string }> {
+    if (!this.authClient) {
+      return { valid: true }
+    }
+
+    try {
+      const permissionsApi = await this.authClient.permissions(token)
+      if ('error' in permissionsApi) {
+        return { valid: false, error: `Invalid token: ${permissionsApi.error}` }
+      }
+
+      const result = await permissionsApi.authorizeAction({
+        action,
+        nodeContext: { nodeId: this.nodeId, domains: this.domains },
+      })
+
+      if (!result.success) {
+        const detail = result.reason || result.reasons?.join(', ') || 'Permission denied'
+        return {
+          valid: false,
+          error: `Authorization failed: ${result.errorType} - ${detail}`,
+        }
+      }
+
+      if (!result.allowed) {
+        return { valid: false, error: 'Permission denied' }
+      }
+
+      return { valid: true }
+    } catch (error) {
+      return { valid: false, error: `Authorization failed: ${error}` }
+    }
+  }
+
+  /**
+   * Returns the public API for the gateway RPC server.
+   * This follows the orchestrator's progressive disclosure pattern:
+   * callers first authenticate via getConfigClient(token), then interact
+   * with the returned client's methods, each independently authorized.
+   */
+  publicApi(): GatewayPublicApi {
+    return {
+      getConfigClient: async (
+        token: string
+      ): Promise<{ success: true; client: ConfigClient } | { success: false; error: string }> => {
+        // Authentication only: verify the token is valid (no policy evaluation)
+        const authentication = await this.authenticateToken(token)
+        if (!authentication.valid) {
+          return { success: false, error: authentication.error }
+        }
+
+        return {
+          success: true,
+          client: {
+            updateConfig: async (config: unknown): Promise<GatewayUpdateResult> => {
+              this.logger.info`Config update received via RPC`
+
+              // Authorization: evaluate Cedar policy for GATEWAY_UPDATE
+              const check = await this.authorizeToken(token, 'GATEWAY_UPDATE')
+              if (!check.valid) {
+                return { success: false, error: check.error }
+              }
+
+              const result = GatewayConfigSchema.safeParse(config)
+              if (!result.success) {
+                this.logger.error`Invalid config received`
+                return {
+                  success: false,
+                  error: 'Malformed configuration received and unable to parse',
+                }
+              }
+
+              try {
+                return await this.updateCallback(result.data)
+              } catch (error: unknown) {
+                const message = error instanceof Error ? error.message : String(error)
+                this.logger.error`Config update failed: ${message}`
+                return {
+                  success: false,
+                  error: `Failed to apply configuration: ${message}`,
+                }
+              }
+            },
+          },
+        }
+      },
     }
   }
 }
 
-export function createRpcHandler(rpcServer: GatewayRpcServer): Hono {
+export function createRpcHandler(rpcServer: GatewayPublicApi): Hono {
   const app = new Hono()
   app.get('/', (c) => {
     return newRpcResponse(c, rpcServer, {

--- a/apps/gateway/src/service.ts
+++ b/apps/gateway/src/service.ts
@@ -1,6 +1,6 @@
-import { Hono } from 'hono'
-import { CatalystService } from '@catalyst/service'
 import type { CatalystServiceOptions } from '@catalyst/service'
+import { CatalystService } from '@catalyst/service'
+import { Hono } from 'hono'
 import { GatewayGraphqlServer, createGatewayHandler } from './graphql/server.js'
 import { GatewayRpcServer, createRpcHandler } from './rpc/server.js'
 
@@ -8,21 +8,42 @@ export class GatewayService extends CatalystService {
   readonly info = { name: 'gateway', version: '0.0.0' }
   readonly handler = new Hono()
 
+  private _graphqlServer!: GatewayGraphqlServer
+  private _rpcServer!: GatewayRpcServer
+
   constructor(options: CatalystServiceOptions) {
     super(options)
   }
 
-  protected async onInitialize(): Promise<void> {
-    const { app: graphqlApp, server: gateway } = createGatewayHandler(
-      new GatewayGraphqlServer(this.telemetry)
-    )
+  get graphqlServer(): GatewayGraphqlServer {
+    return this._graphqlServer
+  }
 
-    const rpcServer = new GatewayRpcServer(async (config) => gateway.reload(config), this.telemetry)
-    const instrumentedRpc = this.telemetry.instrumentRpc(rpcServer)
-    const rpcApp = createRpcHandler(instrumentedRpc)
+  get rpcServer(): GatewayRpcServer {
+    return this._rpcServer
+  }
+
+  protected async onInitialize(): Promise<void> {
+    this._graphqlServer = new GatewayGraphqlServer(this.telemetry)
+    const { app: graphqlApp } = createGatewayHandler(this._graphqlServer)
+
+    this._rpcServer = new GatewayRpcServer(
+      async (config) => this._graphqlServer.reload(config),
+      this.telemetry,
+      {
+        authEndpoint: this.config.orchestrator?.auth?.endpoint,
+        nodeId: this.config.node.name,
+        domains: this.config.node.domains,
+      }
+    )
+    const rpcApp = createRpcHandler(this._rpcServer.publicApi())
 
     this.handler.get('/', (c) => c.text('Catalyst GraphQL Gateway is running.'))
     this.handler.route('/graphql', graphqlApp)
     this.handler.route('/api', rpcApp)
+  }
+
+  protected async onShutdown(): Promise<void> {
+    this.telemetry.logger.info`Gateway shutting down`
   }
 }

--- a/apps/gateway/tests/container.gateway.test.ts
+++ b/apps/gateway/tests/container.gateway.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
-import type { StartedTestContainer, StartedNetwork } from 'testcontainers'
-import { GenericContainer, Wait, Network } from 'testcontainers'
-import path from 'path'
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
 import { newWebSocketRpcSession } from 'capnweb'
+import path from 'path'
+import type { StartedNetwork, StartedTestContainer } from 'testcontainers'
+import { GenericContainer, Network, Wait } from 'testcontainers'
 
 const CONTAINER_RUNTIME = process.env.CONTAINER_RUNTIME || 'docker'
 const skipTests = !process.env.CATALYST_CONTAINER_TESTS_ENABLED
@@ -17,7 +17,12 @@ describe.skipIf(skipTests)('Gateway Container Integration', () => {
 
   // Gateway Access
   let gatewayPort: number
-  let rpcClient: { updateConfig(config: unknown): Promise<{ success: boolean }> } | null = null
+  let rpcClient: {
+    getConfigClient(token: string): Promise<{
+      success: boolean
+      client: { updateConfig(config: unknown): Promise<{ success: boolean }> }
+    }>
+  } | null = null
   let ws: WebSocket
   const repoRoot = path.resolve(__dirname, '../../..')
 
@@ -79,7 +84,16 @@ describe.skipIf(skipTests)('Gateway Container Integration', () => {
       gatewayContainer = await new GenericContainer(imageName)
         .withNetwork(network)
         .withExposedPorts(4000)
-        .withWaitStrategy(Wait.forHttp('/', 4000))
+        .withEnvironment({
+          PORT: '4000',
+          CATALYST_NODE_ID: 'gateway',
+        })
+        .withWaitStrategy(Wait.forLogMessage('Catalyst server [gateway] listening'))
+        .withLogConsumer((stream) => {
+          stream.on('data', (chunk: Buffer) => {
+            process.stdout.write(`[gateway] ${chunk.toString()}`)
+          })
+        })
         .start()
 
       gatewayPort = gatewayContainer.getMappedPort(4000)
@@ -106,7 +120,10 @@ describe.skipIf(skipTests)('Gateway Container Integration', () => {
       ws.addEventListener('error', (e: Event) => reject(e))
     })
     rpcClient = newWebSocketRpcSession(ws as unknown as WebSocket) as unknown as {
-      updateConfig(config: unknown): Promise<{ success: boolean }>
+      getConfigClient(token: string): Promise<{
+        success: boolean
+        client: { updateConfig(config: unknown): Promise<{ success: boolean }> }
+      }>
     }
     return rpcClient
   }
@@ -140,7 +157,9 @@ describe.skipIf(skipTests)('Gateway Container Integration', () => {
       ],
     }
 
-    const update = await client.updateConfig(config)
+    const configResult = await client.getConfigClient('')
+    expect(configResult.success).toBe(true)
+    const update = await configResult.client.updateConfig(config)
     expect(update).toEqual({ success: true })
 
     // Query Books
@@ -162,7 +181,9 @@ describe.skipIf(skipTests)('Gateway Container Integration', () => {
       ],
     }
 
-    const update = await client.updateConfig(config)
+    const configResult = await client.getConfigClient('')
+    expect(configResult.success).toBe(true)
+    const update = await configResult.client.updateConfig(config)
     expect(update).toEqual({ success: true })
 
     // Query Both
@@ -186,7 +207,9 @@ describe.skipIf(skipTests)('Gateway Container Integration', () => {
     // But let's try.
     const config = { services: [] }
 
-    const update = await client.updateConfig(config)
+    const configResult = await client.getConfigClient('')
+    expect(configResult.success).toBe(true)
+    const update = await configResult.client.updateConfig(config)
 
     // If the implementation allows clearing the schema (no services), it sets default schema or stays as is?
     // Checking `GatewayGraphqlServer.reload`:

--- a/apps/gateway/tests/integration.rpc.test.ts
+++ b/apps/gateway/tests/integration.rpc.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, mock, beforeAll, afterAll } from 'bun:test'
-import { websocket } from 'hono/bun'
+import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test'
 import { newWebSocketRpcSession } from 'capnweb'
+import { websocket } from 'hono/bun'
 import type { GatewayUpdateResult } from '../src/rpc/server.js'
 import { createRpcHandler, GatewayRpcServer } from '../src/rpc/server.js'
 
@@ -18,7 +18,7 @@ describe('RPC Integration', () => {
 
   beforeAll(async () => {
     const rpcServer = new GatewayRpcServer(updateCallback)
-    const app = createRpcHandler(rpcServer)
+    const app = createRpcHandler(rpcServer.publicApi())
 
     server = Bun.serve({
       fetch: app.fetch,
@@ -47,7 +47,9 @@ describe('RPC Integration', () => {
       services: [{ name: 'test-service', url: 'http://localhost:8080/graphql' }],
     }
 
-    const result = await rpcClient.updateConfig(config)
+    const configClient = await rpcClient.getConfigClient('')
+    expect(configClient.success).toBe(true)
+    const result = await configClient.client.updateConfig(config)
 
     expect(result).toEqual({ success: true })
     expect(updateCallback).toHaveBeenCalled()
@@ -69,7 +71,9 @@ describe('RPC Integration', () => {
       ],
     }
 
-    const result = await rpcClient.updateConfig(invalidConfig)
+    const configClient = await rpcClient.getConfigClient('')
+    expect(configClient.success).toBe(true)
+    const result = await configClient.client.updateConfig(invalidConfig)
 
     expect(result.success).toBe(false)
     if (!result.success) {
@@ -95,7 +99,9 @@ describe('RPC Integration', () => {
       services: [{ name: 'test-service', url: 'http://localhost:8080/graphql' }],
     }
 
-    const result = await rpcClient.updateConfig(config)
+    const configClient = await rpcClient.getConfigClient('')
+    expect(configClient.success).toBe(true)
+    const result = await configClient.client.updateConfig(config)
 
     expect(result.success).toBe(false)
     if (!result.success) {

--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -1,12 +1,12 @@
-import { CatalystNodeBus } from './orchestrator.js'
+import { CatalystNodeBus, type PublicApi } from './orchestrator.js'
 
-export { CatalystNodeBus }
 export { OrchestratorService } from './service.js'
+export { CatalystNodeBus, type PublicApi as OrchestratorPublicApi }
 
 // Re-export routing types for backward compatibility
 export {
   DataChannelDefinitionSchema as ServiceDefinitionSchema,
-  type PeerInfo,
-  type InternalRoute,
   type DataChannelDefinition,
+  type InternalRoute,
+  type PeerInfo,
 } from '@catalyst/routing'

--- a/apps/orchestrator/src/server.ts
+++ b/apps/orchestrator/src/server.ts
@@ -1,17 +1,13 @@
 import { loadDefaultConfig } from '@catalyst/config'
 import { catalystHonoServer } from '@catalyst/service'
-import { TelemetryBuilder } from '@catalyst/telemetry'
 import type { ServiceTelemetry } from '@catalyst/telemetry'
+import { TelemetryBuilder } from '@catalyst/telemetry'
 import { OrchestratorService, websocket } from './service.js'
 
 const config = loadDefaultConfig()
 
 // -- Telemetry token fetch for authenticated OTLP export --
 let otelToken = ''
-const OTEL_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000
-const OTEL_REFRESH_THRESHOLD = 0.8
-let otelTokenExpiresAt = 0
-
 async function fetchTelemetryToken() {
   if (!config.orchestrator?.auth) return
   const { endpoint, systemToken: sysToken } = config.orchestrator.auth
@@ -23,7 +19,6 @@ async function fetchTelemetryToken() {
     if (!res.ok) return
     const body = (await res.json()) as { token: string; expiresAt: string }
     otelToken = body.token
-    otelTokenExpiresAt = new Date(body.expiresAt).getTime()
   } catch {
     // Graceful — don't block startup
   }

--- a/apps/orchestrator/tests/mock-connection-pool.ts
+++ b/apps/orchestrator/tests/mock-connection-pool.ts
@@ -1,5 +1,5 @@
-import { ConnectionPool, type CatalystNodeBus, type PublicApi } from '../src/orchestrator.js'
 import type { RpcStub } from 'capnweb'
+import { ConnectionPool, type CatalystNodeBus, type PublicApi } from '../src/orchestrator.js'
 
 export class MockConnectionPool extends ConnectionPool {
   private nodes = new Map<string, CatalystNodeBus>()
@@ -26,7 +26,10 @@ export class MockConnectionPool extends ConnectionPool {
         if (!targetNode) return { success: false, error: 'Node not found' }
         return targetNode.publicApi().getIBGPClient(token)
       },
-      updateConfig: async () => ({ success: true }),
+      getConfigClient: async () => ({
+        success: true,
+        client: { updateConfig: async () => ({ success: true }) },
+      }),
     } as unknown as RpcStub<PublicApi>
   }
 }

--- a/apps/orchestrator/tests/orchestrator.gateway.test.ts
+++ b/apps/orchestrator/tests/orchestrator.gateway.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, mock } from 'bun:test'
 import { Actions, type PeerInfo } from '@catalyst/routing'
-import { CatalystNodeBus, ConnectionPool, type PublicApi } from '../src/orchestrator.js'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
 import type { RpcStub } from 'capnweb'
+import { CatalystNodeBus, ConnectionPool, type PublicApi } from '../src/orchestrator.js'
 
 const MOCK_NODE: PeerInfo = {
   name: 'node-a.somebiz.local.io',
@@ -27,10 +27,15 @@ class MockConnectionPool extends ConnectionPool {
   get(endpoint: string) {
     if (!this.mockStubs.has(endpoint)) {
       const stub = {
-        updateConfig: mock(async (config: GatewayConfig) => {
-          this.calls.push({ endpoint, config })
-          return { success: true }
-        }),
+        getConfigClient: mock(async (_token: string) => ({
+          success: true,
+          client: {
+            updateConfig: mock(async (config: GatewayConfig) => {
+              this.calls.push({ endpoint, config })
+              return { success: true }
+            }),
+          },
+        })),
         getIBGPClient: mock(async () => ({
           success: true,
           client: {
@@ -53,7 +58,7 @@ describe('CatalystNodeBus > GraphQL Gateway Sync', () => {
     pool = new MockConnectionPool('http')
     bus = new CatalystNodeBus({
       config: {
-        node: MOCK_NODE,
+        node: { ...MOCK_NODE, endpoint: MOCK_NODE.endpoint || '' },
         gqlGatewayConfig: { endpoint: GATEWAY_ENDPOINT },
       },
       connectionPool: { pool },

--- a/bun.lock
+++ b/bun.lock
@@ -274,13 +274,14 @@
       "name": "@catalyst/telemetry",
       "version": "0.0.0",
       "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
         "@logtape/logtape": "^0.12.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.200.0",
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/exporter-logs-otlp-http": "^0.200.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "^0.200.0",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "^0.200.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "^0.200.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.200.0",
         "@opentelemetry/resources": "^2.0.0",
         "@opentelemetry/sdk-logs": "^0.200.0",
         "@opentelemetry/sdk-metrics": "^2.0.0",
@@ -642,7 +643,7 @@
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
 
-    "@grpc/proto-loader": ["@grpc/proto-loader@0.7.15", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.2.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ=="],
+    "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
     "@hono/capnweb": ["@hono/capnweb@0.1.0", "", { "peerDependencies": { "capnweb": ">=0.2.0", "hono": ">=4.0.0" } }, "sha512-P+HZA5PoQss8zwfJlq3Tsnxq9pG8tbAY/AFeDIh4dCCn4k7ew24uYG1eSpH8tGDQGDF7gdw7Om9QEq27OLZnGA=="],
 
@@ -684,13 +685,17 @@
 
     "@opentelemetry/core": ["@opentelemetry/core@2.5.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ=="],
 
-    "@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.200.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.200.0", "@opentelemetry/core": "2.0.0", "@opentelemetry/otlp-exporter-base": "0.200.0", "@opentelemetry/otlp-transformer": "0.200.0", "@opentelemetry/sdk-logs": "0.200.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-KfWw49htbGGp9s8N4KI8EQ9XuqKJ0VG+yVYVYFiCYSjEV32qpQ5qZ9UZBzOZ6xRb+E16SXOSCT3RkqBVSABZ+g=="],
+    "@opentelemetry/exporter-logs-otlp-grpc": ["@opentelemetry/exporter-logs-otlp-grpc@0.200.0", "", { "dependencies": { "@grpc/grpc-js": "^1.7.1", "@opentelemetry/core": "2.0.0", "@opentelemetry/otlp-exporter-base": "0.200.0", "@opentelemetry/otlp-grpc-exporter-base": "0.200.0", "@opentelemetry/otlp-transformer": "0.200.0", "@opentelemetry/sdk-logs": "0.200.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-+3MDfa5YQPGM3WXxW9kqGD85Q7s9wlEMVNhXXG7tYFLnIeaseUt9YtCeFhEDFzfEktacdFpOtXmJuNW8cHbU5A=="],
+
+    "@opentelemetry/exporter-metrics-otlp-grpc": ["@opentelemetry/exporter-metrics-otlp-grpc@0.200.0", "", { "dependencies": { "@grpc/grpc-js": "^1.7.1", "@opentelemetry/core": "2.0.0", "@opentelemetry/exporter-metrics-otlp-http": "0.200.0", "@opentelemetry/otlp-exporter-base": "0.200.0", "@opentelemetry/otlp-grpc-exporter-base": "0.200.0", "@opentelemetry/otlp-transformer": "0.200.0", "@opentelemetry/resources": "2.0.0", "@opentelemetry/sdk-metrics": "2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-uHawPRvKIrhqH09GloTuYeq2BjyieYHIpiklOvxm9zhrCL2eRsnI/6g9v2BZTVtGp8tEgIa7rCQ6Ltxw6NBgew=="],
 
     "@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.200.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/otlp-exporter-base": "0.200.0", "@opentelemetry/otlp-transformer": "0.200.0", "@opentelemetry/resources": "2.0.0", "@opentelemetry/sdk-metrics": "2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-5BiR6i8yHc9+qW7F6LqkuUnIzVNA7lt0qRxIKcKT+gq3eGUPHZ3DY29sfxI3tkvnwMgtnHDMNze5DdxW39HsAw=="],
 
-    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.200.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/otlp-exporter-base": "0.200.0", "@opentelemetry/otlp-transformer": "0.200.0", "@opentelemetry/resources": "2.0.0", "@opentelemetry/sdk-trace-base": "2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Goi//m/7ZHeUedxTGVmEzH19NgqJY+Bzr6zXo1Rni1+hwqaksEyJ44gdlEMREu6dzX1DlAaH/qSykSVzdrdafA=="],
+    "@opentelemetry/exporter-trace-otlp-grpc": ["@opentelemetry/exporter-trace-otlp-grpc@0.200.0", "", { "dependencies": { "@grpc/grpc-js": "^1.7.1", "@opentelemetry/core": "2.0.0", "@opentelemetry/otlp-exporter-base": "0.200.0", "@opentelemetry/otlp-grpc-exporter-base": "0.200.0", "@opentelemetry/otlp-transformer": "0.200.0", "@opentelemetry/resources": "2.0.0", "@opentelemetry/sdk-trace-base": "2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-hmeZrUkFl1YMsgukSuHCFPYeF9df0hHoKeHUthRKFCxiURs+GwF1VuabuHmBMZnjTbsuvNjOB+JSs37Csem/5Q=="],
 
     "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.200.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/otlp-transformer": "0.200.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-IxJgA3FD7q4V6gGq4bnmQM5nTIyMDkoGFGrBrrDjB6onEiq1pafma55V+bHvGYLWvcqbBbRfezr1GED88lacEQ=="],
+
+    "@opentelemetry/otlp-grpc-exporter-base": ["@opentelemetry/otlp-grpc-exporter-base@0.200.0", "", { "dependencies": { "@grpc/grpc-js": "^1.7.1", "@opentelemetry/core": "2.0.0", "@opentelemetry/otlp-exporter-base": "0.200.0", "@opentelemetry/otlp-transformer": "0.200.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CK2S+bFgOZ66Bsu5hlDeOX6cvW5FVtVjFFbWuaJP0ELxJKBB6HlbLZQ2phqz/uLj1cWap5xJr/PsR3iGoB7Vqw=="],
 
     "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.200.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.200.0", "@opentelemetry/core": "2.0.0", "@opentelemetry/resources": "2.0.0", "@opentelemetry/sdk-logs": "0.200.0", "@opentelemetry/sdk-metrics": "2.0.0", "@opentelemetry/sdk-trace-base": "2.0.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-+9YDZbYybOnv7sWzebWOeK6gKyt2XE7iarSyBFkwwnP559pEevKOUD8NyDHhRjCSp13ybh9iVXlMfcj/DwF/yw=="],
 
@@ -1736,15 +1741,19 @@
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
-    "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
-
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
-    "@opentelemetry/exporter-logs-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
+    "@opentelemetry/exporter-logs-otlp-grpc/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
+
+    "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
+
+    "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/resources": ["@opentelemetry/resources@2.0.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg=="],
+
+    "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.0.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/resources": "2.0.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA=="],
 
     "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
 
@@ -1752,11 +1761,13 @@
 
     "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.0.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/resources": "2.0.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA=="],
 
-    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
+    "@opentelemetry/exporter-trace-otlp-grpc/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
 
-    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/resources": ["@opentelemetry/resources@2.0.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg=="],
+    "@opentelemetry/exporter-trace-otlp-grpc/@opentelemetry/resources": ["@opentelemetry/resources@2.0.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg=="],
 
     "@opentelemetry/otlp-exporter-base/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
+
+    "@opentelemetry/otlp-grpc-exporter-base/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
 
     "@opentelemetry/otlp-transformer/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
 
@@ -1815,6 +1826,8 @@
     "compress-commons/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
     "docker-modem/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "dockerode/@grpc/proto-loader": ["@grpc/proto-loader@0.7.15", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.2.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ=="],
 
     "dockerode/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 

--- a/docs/adr/0011-cedar-policy-authorization-schema.md
+++ b/docs/adr/0011-cedar-policy-authorization-schema.md
@@ -36,7 +36,7 @@ Authorization is evaluated in the auth service via the `permissions().authorizeA
 
 1. **No authorization**: No JWT validation, no Cedar checks on any endpoint.
 2. **Unprotected `updateConfig` RPC**: Any WebSocket client can reconfigure subgraphs.
-3. **No gateway-specific actions in Cedar**: Missing actions like `GATEWAY_CONFIG_UPDATE`.
+3. **No gateway-specific actions in Cedar**: Missing actions like `GATEWAY_UPDATE`.
 
 #### Auth Service (`apps/auth` + `packages/authorization`)
 
@@ -104,7 +104,7 @@ Update the Cedar schema with new actions, align Cedar policies with actual syste
 ### Phase 1: Schema, Policies, and Models
 
 1. **Cedar Schema** (`schema.schemacedar`):
-   - Add actions: `PEER_LIST`, `ROUTE_LIST`, `IBGP_LIST`, `GATEWAY_CONFIG_UPDATE`
+   - Add actions: `PEER_LIST`, `ROUTE_LIST`, `IBGP_LIST`, `GATEWAY_UPDATE`
    - Remove `CHECK_PERMISSIONS` (implementation detail, not a business action)
    - Normalize `TELEMETRY_EXPORTER` attributes to match other principals
    - Add `Gateway` resource type
@@ -112,12 +112,12 @@ Update the Cedar schema with new actions, align Cedar policies with actual syste
 2. **Cedar Policies** (`.cedar` files):
    - `node-custodian.cedar`: Add `PEER_LIST`
    - `data-custodian.cedar`: Add `ROUTE_LIST`
-   - `node.cedar`: Add `IBGP_LIST`, `GATEWAY_CONFIG_UPDATE`
+   - `node.cedar`: Add `IBGP_LIST`, `GATEWAY_UPDATE`
    - `admin.cedar`: No change (wildcard `action` already covers new actions)
    - `user.cedar`: Add `PEER_LIST`, `ROUTE_LIST` for read-only dashboard access
 
 3. **TypeScript Models** (`models.ts`):
-   - Add `PEER_LIST`, `ROUTE_LIST`, `IBGP_LIST`, `GATEWAY_CONFIG_UPDATE` to `Action` enum
+   - Add `PEER_LIST`, `ROUTE_LIST`, `IBGP_LIST`, `GATEWAY_UPDATE` to `Action` enum
    - Update `ROLE_PERMISSIONS` mapping
 
 ### Phase 2: Auth Service Hardening
@@ -137,7 +137,7 @@ Update the Cedar schema with new actions, align Cedar policies with actual syste
 
 ### Phase 4: Gateway and CLI
 
-- **Gateway**: Add JWT validation middleware for `updateConfig` RPC; check `GATEWAY_CONFIG_UPDATE` via auth service
+- **Gateway**: Add JWT validation middleware for `updateConfig` RPC; check `GATEWAY_UPDATE` via auth service
 - **CLI**: Propagate `--token` to orchestrator RPC calls; align client with orchestrator `PublicApi`
 
 ### Architecture
@@ -179,7 +179,7 @@ flowchart TB
 Authorization enforcement follows a **progressive API** pattern across all RPC servers (`AuthRpcServer`, `GatewayRpcServer`, and the orchestrator's `PublicApi`). Rather than performing a single coarse-grained authorization gate at connection time, each server exposes scoped sub-API entry points that return handler objects. Authorization is enforced at two levels:
 
 1. **Entry-point validation** -- The caller invokes a sub-API method (e.g., `tokens(token)`, `getNetworkClient(token)`, `getConfigClient(token)`) with their JWT. The server verifies the token is valid and, optionally, performs a broad capability check to fail fast before returning the handler set.
-2. **Per-operation Cedar checks** -- Each handler within the returned object individually evaluates its specific Cedar action (e.g., `TOKEN_CREATE`, `PEER_UPDATE`, `GATEWAY_CONFIG_UPDATE`) against the caller's principal. This ensures least-privilege even after the initial entry-point succeeds.
+2. **Per-operation Cedar checks** -- Each handler within the returned object individually evaluates its specific Cedar action (e.g., `TOKEN_CREATE`, `PEER_UPDATE`, `GATEWAY_UPDATE`) against the caller's principal. This ensures least-privilege even after the initial entry-point succeeds.
 
 This two-level pattern is enabled by [capnweb](https://www.npmjs.com/package/capnweb)'s `RpcTarget`, which supports returning nested handler objects over WebSocket connections. The progressive disclosure of capabilities means a principal that can list peers cannot silently escalate to deleting them -- each operation is independently authorized.
 
@@ -187,7 +187,7 @@ This two-level pattern is enabled by [capnweb](https://www.npmjs.com/package/cap
 | ------------ | ------------------ | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | Auth Service | `AuthRpcServer`    | `tokens(token)`, `certs(token)`, `validation(token)`, `permissions(token)`       | `TOKEN_CREATE`, `TOKEN_REVOKE`, `TOKEN_LIST`, `MANAGE`                                              |
 | Orchestrator | `PublicApi`        | `getNetworkClient(token)`, `getDataChannelClient(token)`, `getIBGPClient(token)` | `PEER_CREATE/UPDATE/DELETE/LIST`, `ROUTE_CREATE/DELETE/LIST`, `IBGP_CONNECT/DISCONNECT/UPDATE/LIST` |
-| Gateway      | `GatewayRpcServer` | `getConfigClient(token)`                                                         | `GATEWAY_CONFIG_UPDATE`                                                                             |
+| Gateway      | `GatewayPublicApi` | `getConfigClient(token)`                                                         | `GATEWAY_UPDATE`                                                                                    |
 
 ```mermaid
 sequenceDiagram
@@ -211,26 +211,26 @@ sequenceDiagram
 
 ### Action-to-Principal Authorization Matrix
 
-| Action                | ADMIN | NODE | NODE_CUSTODIAN | DATA_CUSTODIAN | USER | TELEMETRY_EXPORTER |
-| --------------------- | ----- | ---- | -------------- | -------------- | ---- | ------------------ |
-| LOGIN                 | x     |      |                |                | x    |                    |
-| MANAGE                | x     |      |                |                |      |                    |
-| IBGP_CONNECT          | x     | x    | x              |                |      |                    |
-| IBGP_DISCONNECT       | x     | x    | x              |                |      |                    |
-| IBGP_UPDATE           | x     | x    | x              |                |      |                    |
-| IBGP_LIST             | x     | x    | x              |                |      |                    |
-| PEER_CREATE           | x     |      | x              |                |      |                    |
-| PEER_UPDATE           | x     |      | x              |                |      |                    |
-| PEER_DELETE           | x     |      | x              |                |      |                    |
-| PEER_LIST             | x     |      | x              |                | x    |                    |
-| ROUTE_CREATE          | x     |      |                | x              |      |                    |
-| ROUTE_DELETE          | x     |      |                | x              |      |                    |
-| ROUTE_LIST            | x     |      |                | x              | x    |                    |
-| TOKEN_CREATE          | x     |      |                |                |      |                    |
-| TOKEN_REVOKE          | x     |      |                |                |      |                    |
-| TOKEN_LIST            | x     |      |                |                |      |                    |
-| TELEMETRY_EXPORT      | x     |      |                |                |      | x                  |
-| GATEWAY_CONFIG_UPDATE | x     | x    |                |                |      |                    |
+| Action           | ADMIN | NODE | NODE_CUSTODIAN | DATA_CUSTODIAN | USER | TELEMETRY_EXPORTER |
+| ---------------- | ----- | ---- | -------------- | -------------- | ---- | ------------------ |
+| LOGIN            | x     |      |                |                | x    |                    |
+| MANAGE           | x     |      |                |                |      |                    |
+| IBGP_CONNECT     | x     | x    | x              |                |      |                    |
+| IBGP_DISCONNECT  | x     | x    | x              |                |      |                    |
+| IBGP_UPDATE      | x     | x    | x              |                |      |                    |
+| IBGP_LIST        | x     | x    | x              |                |      |                    |
+| PEER_CREATE      | x     |      | x              |                |      |                    |
+| PEER_UPDATE      | x     |      | x              |                |      |                    |
+| PEER_DELETE      | x     |      | x              |                |      |                    |
+| PEER_LIST        | x     |      | x              |                | x    |                    |
+| ROUTE_CREATE     | x     |      |                | x              |      |                    |
+| ROUTE_DELETE     | x     |      |                | x              |      |                    |
+| ROUTE_LIST       | x     |      |                | x              | x    |                    |
+| TOKEN_CREATE     | x     |      |                |                |      |                    |
+| TOKEN_REVOKE     | x     |      |                |                |      |                    |
+| TOKEN_LIST       | x     |      |                |                |      |                    |
+| TELEMETRY_EXPORT | x     |      |                |                |      | x                  |
+| GATEWAY_UPDATE   | x     | x    |                |                |      |                    |
 
 ## Risks and Mitigations
 

--- a/packages/authorization/src/policy/src/definitions/admin.cedar
+++ b/packages/authorization/src/policy/src/definitions/admin.cedar
@@ -3,7 +3,10 @@ permit (
     action,
     resource
 )
-when {
-    (principal.trustedDomains.isEmpty() || principal.trustedDomains.contains(resource.domainId)) &&
-    (principal.trustedNodes.isEmpty() || principal.trustedNodes.contains(resource.nodeId))
+when
+{
+    (principal.trustedDomains.isEmpty() ||
+     principal.trustedDomains.contains(resource.domainId)) &&
+    (principal.trustedNodes.isEmpty() ||
+     principal.trustedNodes.contains(resource.nodeId))
 };

--- a/packages/authorization/src/policy/src/definitions/cedar.d.ts
+++ b/packages/authorization/src/policy/src/definitions/cedar.d.ts
@@ -2,3 +2,8 @@ declare module '*.cedar' {
   const content: string
   export default content
 }
+
+declare module '*.schemacedar' {
+  const content: string
+  export default content
+}

--- a/packages/authorization/src/policy/src/definitions/data-custodian.cedar
+++ b/packages/authorization/src/policy/src/definitions/data-custodian.cedar
@@ -2,7 +2,8 @@ permit (
     principal is CATALYST::DATA_CUSTODIAN,
     action in [
         CATALYST::Action::"ROUTE_CREATE",
-        CATALYST::Action::"ROUTE_DELETE"
+        CATALYST::Action::"ROUTE_DELETE",
+        CATALYST::Action::"ROUTE_LIST"
     ],
     resource
 )

--- a/packages/authorization/src/policy/src/definitions/index.ts
+++ b/packages/authorization/src/policy/src/definitions/index.ts
@@ -4,7 +4,7 @@ import dataCustodianPolicy from './data-custodian.cedar' with { type: 'text' }
 import type { Action, IBGPEntity, PeerEntity, Role, RouteEntity } from './models.js'
 import nodeCustodianPolicy from './node-custodian.cedar' with { type: 'text' }
 import nodePolicy from './node.cedar' with { type: 'text' }
-import CATALYST_SCHEMA from './schema.cedar' with { type: 'text' }
+import CATALYST_SCHEMA from './schema.schemacedar' with { type: 'text' }
 import telemetryExporterPolicy from './telemetry-exporter.cedar' with { type: 'text' }
 import userPolicy from './user.cedar' with { type: 'text' }
 
@@ -51,6 +51,7 @@ export type CatalystPolicyDomain = [
       Token: Record<string, unknown>
       AdminPanel: Record<string, unknown>
       Collector: Record<string, unknown>
+      Gateway: Record<string, unknown>
     }
   },
 ]

--- a/packages/authorization/src/policy/src/definitions/models.ts
+++ b/packages/authorization/src/policy/src/definitions/models.ts
@@ -78,33 +78,46 @@ export enum Action {
   IBGP_CONNECT = 'IBGP_CONNECT',
   IBGP_DISCONNECT = 'IBGP_DISCONNECT',
   IBGP_UPDATE = 'IBGP_UPDATE',
+  IBGP_LIST = 'IBGP_LIST',
   PEER_CREATE = 'PEER_CREATE',
   PEER_UPDATE = 'PEER_UPDATE',
   PEER_DELETE = 'PEER_DELETE',
+  PEER_LIST = 'PEER_LIST',
   ROUTE_CREATE = 'ROUTE_CREATE',
   ROUTE_DELETE = 'ROUTE_DELETE',
+  ROUTE_LIST = 'ROUTE_LIST',
   TOKEN_CREATE = 'TOKEN_CREATE',
   TOKEN_REVOKE = 'TOKEN_REVOKE',
   TOKEN_LIST = 'TOKEN_LIST',
   TELEMETRY_EXPORT = 'TELEMETRY_EXPORT',
+  GATEWAY_UPDATE = 'GATEWAY_UPDATE',
 }
 
 /**
  * Default role-to-action permissions mapping.
  * Used as a reference for policy generation and documentation.
+ * Must stay in sync with Cedar policies in the definitions/ directory.
  */
 export const ROLE_PERMISSIONS: Record<Role, Action[]> = {
   [Role.ADMIN]: Object.values(Action),
-  [Role.NODE]: [Action.IBGP_CONNECT, Action.IBGP_DISCONNECT, Action.IBGP_UPDATE],
+  [Role.NODE]: [
+    Action.IBGP_CONNECT,
+    Action.IBGP_DISCONNECT,
+    Action.IBGP_UPDATE,
+    Action.IBGP_LIST,
+    Action.GATEWAY_UPDATE,
+  ],
   [Role.NODE_CUSTODIAN]: [
     Action.PEER_CREATE,
     Action.PEER_UPDATE,
     Action.PEER_DELETE,
+    Action.PEER_LIST,
     Action.IBGP_CONNECT,
     Action.IBGP_DISCONNECT,
     Action.IBGP_UPDATE,
+    Action.IBGP_LIST,
   ],
-  [Role.DATA_CUSTODIAN]: [Action.ROUTE_CREATE, Action.ROUTE_DELETE],
-  [Role.USER]: [Action.LOGIN],
+  [Role.DATA_CUSTODIAN]: [Action.ROUTE_CREATE, Action.ROUTE_DELETE, Action.ROUTE_LIST],
+  [Role.USER]: [Action.LOGIN, Action.PEER_LIST, Action.ROUTE_LIST],
   [Role.TELEMETRY_EXPORTER]: [Action.TELEMETRY_EXPORT],
 }

--- a/packages/authorization/src/policy/src/definitions/node-custodian.cedar
+++ b/packages/authorization/src/policy/src/definitions/node-custodian.cedar
@@ -4,9 +4,11 @@ permit (
         CATALYST::Action::"PEER_CREATE",
         CATALYST::Action::"PEER_UPDATE",
         CATALYST::Action::"PEER_DELETE",
+        CATALYST::Action::"PEER_LIST",
         CATALYST::Action::"IBGP_CONNECT",
         CATALYST::Action::"IBGP_DISCONNECT",
-        CATALYST::Action::"IBGP_UPDATE"
+        CATALYST::Action::"IBGP_UPDATE",
+        CATALYST::Action::"IBGP_LIST"
     ],
     resource
 )

--- a/packages/authorization/src/policy/src/definitions/node.cedar
+++ b/packages/authorization/src/policy/src/definitions/node.cedar
@@ -1,20 +1,23 @@
 permit (
     principal is CATALYST::NODE,
-    action in [
-        CATALYST::Action::"IBGP_CONNECT",
-        CATALYST::Action::"IBGP_DISCONNECT",
-        CATALYST::Action::"IBGP_UPDATE"
-    ],
+    action in
+        [CATALYST::Action::"IBGP_CONNECT",
+         CATALYST::Action::"IBGP_DISCONNECT",
+         CATALYST::Action::"IBGP_UPDATE",
+         CATALYST::Action::"IBGP_LIST",
+         CATALYST::Action::"GATEWAY_UPDATE"],
     resource
 )
-when {
+when
+{
     principal.trustedDomains.contains(resource.domainId) &&
-    (principal.trustedNodes.isEmpty() || principal.trustedNodes.contains(resource.nodeId))
+    (principal.trustedNodes.isEmpty() ||
+     principal.trustedNodes.contains(resource.nodeId))
 };
 
 // Allow NODE principals to check permissions via the auth service
 permit (
     principal is CATALYST::NODE,
-    action == CATALYST::Action::"CHECK_PERMISSIONS",
+    action == CATALYST::Action::"MANAGE",
     resource is CATALYST::AdminPanel
 );

--- a/packages/authorization/src/policy/src/definitions/schema.schemacedar
+++ b/packages/authorization/src/policy/src/definitions/schema.schemacedar
@@ -38,7 +38,6 @@ namespace CATALYST {
         id: String,
         name: String,
         type: String,
-        role: String,
         trustedNodes: Set<String>,
         trustedDomains: Set<String>
     };
@@ -67,6 +66,10 @@ namespace CATALYST {
         nodeId: String,
         domainId: String
     };
+    entity Gateway {
+        nodeId: String,
+        domainId: String
+    };
 
     action LOGIN appliesTo {
         principal: [ADMIN, NODE, DATA_CUSTODIAN, NODE_CUSTODIAN, USER],
@@ -88,6 +91,11 @@ namespace CATALYST {
         resource: [IBGP, AdminPanel]
     };
 
+    action IBGP_LIST appliesTo {
+        principal: [ADMIN, NODE, NODE_CUSTODIAN],
+        resource: [IBGP, AdminPanel]
+    };
+
     action PEER_CREATE appliesTo {
         principal: [ADMIN, NODE_CUSTODIAN],
         resource: [Peer, AdminPanel]
@@ -103,6 +111,11 @@ namespace CATALYST {
         resource: [Peer, AdminPanel]
     };
 
+    action PEER_LIST appliesTo {
+        principal: [ADMIN, NODE_CUSTODIAN, USER],
+        resource: [Peer, AdminPanel]
+    };
+
     action ROUTE_CREATE appliesTo {
         principal: [ADMIN, DATA_CUSTODIAN],
         resource: [Route, AdminPanel]
@@ -110,6 +123,11 @@ namespace CATALYST {
 
     action ROUTE_DELETE appliesTo {
         principal: [ADMIN, DATA_CUSTODIAN],
+        resource: [Route, AdminPanel]
+    };
+
+    action ROUTE_LIST appliesTo {
+        principal: [ADMIN, DATA_CUSTODIAN, USER],
         resource: [Route, AdminPanel]
     };
 
@@ -128,11 +146,6 @@ namespace CATALYST {
         resource: Token
     };
 
-    action CHECK_PERMISSIONS appliesTo {
-        principal: NODE,
-        resource: AdminPanel
-    };
-
     action MANAGE appliesTo {
         principal: [ADMIN, NODE, DATA_CUSTODIAN, NODE_CUSTODIAN, USER],
         resource: AdminPanel
@@ -141,5 +154,10 @@ namespace CATALYST {
     action TELEMETRY_EXPORT appliesTo {
         principal: [ADMIN, TELEMETRY_EXPORTER],
         resource: [Collector]
+    };
+
+    action GATEWAY_UPDATE appliesTo {
+        principal: [ADMIN, NODE],
+        resource: [Gateway, AdminPanel]
     };
 }

--- a/packages/authorization/src/policy/src/definitions/user.cedar
+++ b/packages/authorization/src/policy/src/definitions/user.cedar
@@ -7,3 +7,17 @@ when {
     principal.trustedDomains.contains(resource.domainId) &&
     (principal.trustedNodes.isEmpty() || principal.trustedNodes.contains(resource.nodeId))
 };
+
+// Allow USER principals read-only access to list peers and routes
+permit (
+    principal is CATALYST::USER,
+    action in [
+        CATALYST::Action::"PEER_LIST",
+        CATALYST::Action::"ROUTE_LIST"
+    ],
+    resource
+)
+when {
+    principal.trustedDomains.contains(resource.domainId) &&
+    (principal.trustedNodes.isEmpty() || principal.trustedNodes.contains(resource.nodeId))
+};

--- a/packages/authorization/src/service/rpc/schema.ts
+++ b/packages/authorization/src/service/rpc/schema.ts
@@ -145,6 +145,22 @@ export const GetCurrentKeyIdResponseSchema = z.discriminatedUnion('success', [
 export type GetCurrentKeyIdResponse = z.infer<typeof GetCurrentKeyIdResponseSchema>
 
 /**
+ * Authenticate Response - pure JWT verification result (no Cedar policy evaluation)
+ */
+export const AuthenticateResponseSchema = z.discriminatedUnion('valid', [
+  z.object({
+    valid: z.literal(true),
+    payload: z.record(z.string(), z.unknown()),
+  }),
+  z.object({
+    valid: z.literal(false),
+    error: z.string(),
+  }),
+])
+
+export type AuthenticateResponse = z.infer<typeof AuthenticateResponseSchema>
+
+/**
  * progressive API handler interfaces
  */
 export interface TokenHandlers {

--- a/packages/authorization/tests/policy/telemetry-authorization.test.ts
+++ b/packages/authorization/tests/policy/telemetry-authorization.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'bun:test'
 import { AuthorizationEngine } from '../../src/policy/src/authorization-engine.js'
-import { EntityBuilderFactory } from '../../src/policy/src/entity-builder.js'
+import type { CatalystPolicyDomain } from '../../src/policy/src/definitions/index.js'
 import {
+  Action,
   ALL_POLICIES,
   CATALYST_SCHEMA,
   Role,
-  Action,
 } from '../../src/policy/src/definitions/index.js'
-import type { CatalystPolicyDomain } from '../../src/policy/src/definitions/index.js'
+import { EntityBuilderFactory } from '../../src/policy/src/entity-builder.js'
 
 describe('Telemetry Authorization', () => {
   const engine = new AuthorizationEngine<CatalystPolicyDomain>(CATALYST_SCHEMA, ALL_POLICIES)
@@ -53,7 +53,6 @@ describe('Telemetry Authorization', () => {
         id: 'telemetry-exporter',
         name: 'Telemetry Exporter',
         type: 'service',
-        role: 'TELEMETRY_EXPORTER',
         trustedNodes: [],
         trustedDomains: [],
       })
@@ -84,7 +83,6 @@ describe('Telemetry Authorization', () => {
         id: 'admin-1',
         name: 'Admin',
         type: 'user',
-        role: 'ADMIN',
         trustedNodes: [],
         trustedDomains: [],
       })
@@ -115,7 +113,6 @@ describe('Telemetry Authorization', () => {
         id: 'user-1',
         name: 'Regular User',
         type: 'user',
-        role: 'USER',
         trustedNodes: [],
         trustedDomains: [],
       })
@@ -144,7 +141,6 @@ describe('Telemetry Authorization', () => {
         id: 'telemetry-exporter',
         name: 'Telemetry Exporter',
         type: 'service',
-        role: 'TELEMETRY_EXPORTER',
         trustedNodes: [],
         trustedDomains: ['domain-1'],
       })
@@ -175,7 +171,6 @@ describe('Telemetry Authorization', () => {
         id: 'telemetry-exporter',
         name: 'Telemetry Exporter',
         type: 'service',
-        role: 'TELEMETRY_EXPORTER',
         trustedNodes: [],
         trustedDomains: ['other-domain'],
       })

--- a/packages/authorization/tests/service/rpc-progressive.test.ts
+++ b/packages/authorization/tests/service/rpc-progressive.test.ts
@@ -1,20 +1,20 @@
-import { describe, it, expect, beforeAll } from 'bun:test'
-import { AuthRpcServer } from '../../src/service/rpc/server.js'
-import {
-  type TokenHandlers,
-  type CertHandlers,
-  type ValidationHandlers,
-} from '../../src/service/rpc/schema.js'
+import { TelemetryBuilder } from '@catalyst/telemetry'
+import { beforeAll, describe, expect, it } from 'bun:test'
+import type { TokenRecord } from '../../src/jwt/index.js'
+import { JWTTokenFactory } from '../../src/jwt/jwt-token-factory.js'
+import { Principal } from '../../src/policy/src/definitions/models.js'
 import {
   ALL_POLICIES,
   AuthorizationEngine,
   CATALYST_SCHEMA,
   type CatalystPolicyDomain,
 } from '../../src/policy/src/index.js'
-import { JWTTokenFactory } from '../../src/jwt/jwt-token-factory.js'
-import { Principal } from '../../src/policy/src/definitions/models.js'
-import type { TokenRecord } from '../../src/jwt/index.js'
-import { TelemetryBuilder } from '@catalyst/telemetry'
+import {
+  type CertHandlers,
+  type TokenHandlers,
+  type ValidationHandlers,
+} from '../../src/service/rpc/schema.js'
+import { AuthRpcServer } from '../../src/service/rpc/server.js'
 
 describe('Auth Progressive API', () => {
   let tokenFactory: JWTTokenFactory
@@ -75,10 +75,20 @@ describe('Auth Progressive API', () => {
       expect(tokenHandlers.list).toBeDefined()
     })
 
-    it('should deny access to token handlers with non-admin token', async () => {
+    it('should deny per-operation access with non-admin token', async () => {
+      // tokens() now returns handlers for any valid token; authz is per-handler
       const result = await rpcServer.tokens(userToken)
-      expect(result).toHaveProperty('error')
-      expect((result as { error: string }).error).toContain('ADMIN principal required')
+      expect(result).not.toHaveProperty('error')
+      const handlers = result as TokenHandlers
+
+      // But calling create should fail with permission denied
+      expect(
+        handlers.create({
+          subject: 'test',
+          entity: { id: 't1', name: 'Test', type: 'user' },
+          principal: Principal.NODE,
+        })
+      ).rejects.toThrow()
     })
 
     it('should allow creating and revoking a token via token handlers', async () => {
@@ -156,8 +166,116 @@ describe('Auth Progressive API', () => {
     })
   })
 
+  describe('authenticate (authentication-only)', () => {
+    it('should return valid=true with payload for a valid token', async () => {
+      const result = await rpcServer.authenticate(adminToken)
+      expect(result.valid).toBe(true)
+      if (result.valid) {
+        expect(result.payload).toBeDefined()
+        expect(result.payload.sub).toBe('admin-user')
+        expect(result.payload.principal).toBe(Principal.ADMIN)
+      }
+    })
+
+    it('should return valid=true for a user token (no policy check)', async () => {
+      const result = await rpcServer.authenticate(userToken)
+      expect(result.valid).toBe(true)
+      if (result.valid) {
+        expect(result.payload).toBeDefined()
+        expect(result.payload.sub).toBe('regular-user')
+        expect(result.payload.principal).toBe(Principal.USER)
+      }
+    })
+
+    it('should return valid=false for an invalid token', async () => {
+      const result = await rpcServer.authenticate('invalid-token-string')
+      expect(result.valid).toBe(false)
+      if (!result.valid) {
+        expect(result.error).toBeDefined()
+      }
+    })
+
+    it('should return valid=false for a revoked token', async () => {
+      // Create and then revoke a token
+      const handlers = (await rpcServer.tokens(adminToken)) as TokenHandlers
+      const tempToken = await handlers.create({
+        subject: 'temp-user',
+        entity: { id: 'temp1', name: 'Temp', type: 'user' },
+        principal: Principal.USER,
+      })
+
+      // Verify it authenticates before revocation
+      const beforeRevoke = await rpcServer.authenticate(tempToken)
+      expect(beforeRevoke.valid).toBe(true)
+
+      // Revoke it
+      const tokens = await handlers.list({})
+      const jti = tokens.find((t: TokenRecord) => t.entityId === 'temp1')!.jti
+      await handlers.revoke({ jti })
+
+      // Now authenticate should fail
+      const afterRevoke = await rpcServer.authenticate(tempToken)
+      expect(afterRevoke.valid).toBe(false)
+    })
+
+    it('should NOT evaluate Cedar policies (any principal can authenticate)', async () => {
+      // A user with no special permissions should still authenticate successfully
+      // This proves authenticate does NOT check Cedar policies
+      const limitedToken = await tokenFactory.mint({
+        subject: 'limited-user',
+        entity: {
+          id: 'limited-user',
+          name: 'Limited',
+          type: 'user',
+          trustedDomains: ['other-domain'], // Different domain
+        },
+        principal: Principal.USER,
+      })
+
+      const result = await rpcServer.authenticate(limitedToken)
+      expect(result.valid).toBe(true)
+      // If this were going through Cedar, a domain mismatch would fail
+      // authenticate() only checks JWT validity
+    })
+  })
+
+  describe('permissions sub-api (authorization)', () => {
+    it('should authorize an action for admin principal', async () => {
+      const permissionsApi = await rpcServer.permissions(adminToken)
+      expect(permissionsApi).not.toHaveProperty('error')
+      if (!('error' in permissionsApi)) {
+        const result = await permissionsApi.authorizeAction({
+          action: 'PEER_CREATE',
+          nodeContext: { nodeId: 'test-node', domains: ['test-domain'] },
+        })
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.allowed).toBe(true)
+        }
+      }
+    })
+
+    it('should deny an action for user principal on admin-only operations', async () => {
+      const permissionsApi = await rpcServer.permissions(userToken)
+      expect(permissionsApi).not.toHaveProperty('error')
+      if (!('error' in permissionsApi)) {
+        const result = await permissionsApi.authorizeAction({
+          action: 'PEER_CREATE',
+          nodeContext: { nodeId: 'test-node', domains: ['test-domain'] },
+        })
+        // USER should not be able to create peers - either denied or system error
+        if (result.success) {
+          expect(result.allowed).toBe(false)
+        } else {
+          // Cedar may return permission_denied or system_error depending on schema
+          expect(['permission_denied', 'system_error']).toContain(result.errorType)
+        }
+      }
+    })
+  })
+
   describe('Isolation Boundaries', () => {
-    it('should deny access if domain mismatch', async () => {
+    it('should deny per-op access if domain mismatch', async () => {
       // Token for 'other-domain'
       const otherDomainToken = await tokenFactory.mint({
         subject: 'admin-user',
@@ -170,12 +288,22 @@ describe('Auth Progressive API', () => {
         principal: Principal.ADMIN,
       })
 
+      // tokens() returns handlers for any valid token
       const result = await rpcServer.tokens(otherDomainToken)
-      expect(result).toHaveProperty('error')
-      expect((result as { error: string }).error).toContain('ADMIN principal required')
+      expect(result).not.toHaveProperty('error')
+      const handlers = result as TokenHandlers
+
+      // But per-op check should fail due to domain mismatch
+      await expect(
+        handlers.create({
+          subject: 'test',
+          entity: { id: 't1', name: 'Test', type: 'user' },
+          principal: Principal.NODE,
+        })
+      ).rejects.toThrow()
     })
 
-    it('should deny access if node mismatch (when trustedNodes is set)', async () => {
+    it('should deny per-op access if node mismatch (when trustedNodes is set)', async () => {
       // Token restricted to 'other-node'
       const otherNodeToken = await tokenFactory.mint({
         subject: 'admin-user',
@@ -190,11 +318,14 @@ describe('Auth Progressive API', () => {
       })
 
       const result = await rpcServer.tokens(otherNodeToken)
-      expect(result).toHaveProperty('error')
-      expect((result as { error: string }).error).toContain('ADMIN principal required')
+      expect(result).not.toHaveProperty('error')
+      const handlers = result as TokenHandlers
+
+      // Per-op check should fail due to node mismatch
+      await expect(handlers.list({})).rejects.toThrow()
     })
 
-    it('should grant access if node matches (when trustedNodes is set)', async () => {
+    it('should grant per-op access if node matches (when trustedNodes is set)', async () => {
       // Token restricted to 'test-node'
       const matchedNodeToken = await tokenFactory.mint({
         subject: 'admin-user',
@@ -208,11 +339,13 @@ describe('Auth Progressive API', () => {
         principal: Principal.ADMIN,
       })
 
-      const handlers = await rpcServer.tokens(matchedNodeToken)
-      expect(handlers).not.toHaveProperty('error')
+      const handlers = (await rpcServer.tokens(matchedNodeToken)) as TokenHandlers
+      // Should succeed since node matches
+      const tokens = await handlers.list({})
+      expect(Array.isArray(tokens)).toBe(true)
     })
 
-    it('should grant access across multiple trusted domains', async () => {
+    it('should grant per-op access across multiple trusted domains', async () => {
       // Token trusted for both A and B
       const multiDomainToken = await tokenFactory.mint({
         subject: 'admin-user',
@@ -225,8 +358,10 @@ describe('Auth Progressive API', () => {
         principal: Principal.ADMIN,
       })
 
-      const handlers = await rpcServer.tokens(multiDomainToken)
-      expect(handlers).not.toHaveProperty('error')
+      const handlers = (await rpcServer.tokens(multiDomainToken)) as TokenHandlers
+      // Should succeed since test-domain is in trustedDomains
+      const tokens = await handlers.list({})
+      expect(Array.isArray(tokens)).toBe(true)
     })
   })
 })


### PR DESCRIPTION
### TL;DR

Implemented a progressive API pattern for authorization across the Catalyst platform, enhancing security by enforcing fine-grained access control at both entry-point and per-operation levels.

### What changed?

- Implemented a two-level authorization pattern:
  - Entry-point validation: Verifies JWT token validity when accessing API entry points
  - Per-operation Cedar checks: Each operation independently evaluates permissions
- Updated Gateway RPC server to use this pattern with a new `getConfigClient(token)` method
- Added new Cedar actions: `PEER_LIST`, `ROUTE_LIST`, `IBGP_LIST`, `GATEWAY_UPDATE`
- Enhanced Auth service with separate `authenticate()` and `authorizeToken()` methods
- Updated Orchestrator to follow the same pattern for its public API
- Fixed container tests to work with the new authorization model
- Updated telemetry token format to use `principal` instead of `roles`

### How to test?

1. Run the updated container tests:
   ```
   CATALYST_CONTAINER_TESTS_ENABLED=1 bun test apps/orchestrator/tests/orchestrator.gateway.container.test.ts
   ```

2. Test the Gateway RPC client:
   ```
   cd apps/gateway
   CATALYST_AUTH_TOKEN=your_token bun scripts/test-rpc.ts
   ```

3. Verify authorization works by using an invalid token and confirming operations are rejected

### Why make this change?

This change implements a more secure and consistent authorization model across the Catalyst platform. The progressive API pattern provides better security by:

1. Enforcing fine-grained access control at both connection and operation levels
2. Separating authentication (token validity) from authorization (permission checks)
3. Ensuring each operation is independently authorized, preventing privilege escalation
4. Standardizing the authorization approach across all services

This aligns with the Cedar policy authorization schema defined in ADR-0011 and provides a more robust security model for the entire platform.