### PR TITLE
test(envoy): add container test for envoy service Dockerfile

### DIFF
--- a/apps/envoy/tests/envoy-service.container.test.ts
+++ b/apps/envoy/tests/envoy-service.container.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import { GenericContainer, Wait, type StartedTestContainer } from 'testcontainers'
+import * as grpc from '@grpc/grpc-js'
+import path from 'path'
+import { getProtoRoot } from '../src/xds/proto-encoding.js'
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const CONTAINER_RUNTIME = process.env.CONTAINER_RUNTIME || 'docker'
+const repoRoot = path.resolve(__dirname, '../../..')
+const envoyServiceImage = 'catalyst-envoy-service:container-test'
+
+/** Default ports for the envoy service inside the container. */
+const CONFIG_PORT = 3000
+const XDS_PORT = 18000
+
+/** Timeout for Docker setup (builds, container starts). */
+const SETUP_TIMEOUT = 300_000 // 5 minutes
+
+/** Timeout for individual test cases. */
+const TEST_TIMEOUT = 30_000 // 30 seconds
+
+// ---------------------------------------------------------------------------
+// Docker availability check
+// ---------------------------------------------------------------------------
+
+const isDockerRunning = (): boolean => {
+  try {
+    return Bun.spawnSync(['docker', 'info']).exitCode === 0
+  } catch {
+    return false
+  }
+}
+
+const skipTests = !isDockerRunning()
+if (skipTests) {
+  console.warn('Skipping envoy service container tests: Docker not running')
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+/**
+ * Envoy service Dockerfile container test.
+ *
+ * Builds the envoy service Docker image and verifies:
+ * 1. The container starts and the health endpoint responds
+ * 2. The xDS gRPC port is accessible and accepts connections
+ */
+describe.skipIf(skipTests)('Envoy Service Container: Dockerfile Validation', () => {
+  let container: StartedTestContainer
+  let healthPort: number
+  let xdsPort: number
+
+  beforeAll(async () => {
+    // Build the envoy service image
+    console.log('[setup] Building envoy service image...')
+    const build = Bun.spawn(
+      [CONTAINER_RUNTIME, 'build', '-t', envoyServiceImage, '-f', 'apps/envoy/Dockerfile', '.'],
+      { cwd: repoRoot, stdout: 'ignore', stderr: 'inherit' }
+    )
+    const buildExit = await build.exited
+    if (buildExit !== 0) throw new Error('Failed to build envoy service image')
+
+    // Start the container with both ports exposed
+    console.log('[setup] Starting envoy service container...')
+    container = await new GenericContainer(envoyServiceImage)
+      .withExposedPorts(CONFIG_PORT, XDS_PORT)
+      .withEnvironment({
+        PORT: String(CONFIG_PORT),
+        CATALYST_NODE_ID: 'envoy-container-test',
+        CATALYST_ENVOY_XDS_PORT: String(XDS_PORT),
+        CATALYST_ENVOY_BIND_ADDRESS: '0.0.0.0',
+      })
+      .withWaitStrategy(Wait.forHttp('/health', CONFIG_PORT))
+      .withStartupTimeout(120_000)
+      .start()
+
+    healthPort = container.getMappedPort(CONFIG_PORT)
+    xdsPort = container.getMappedPort(XDS_PORT)
+    console.log(`[setup] Envoy service ready (health=:${healthPort}, xds=:${xdsPort})`)
+  }, SETUP_TIMEOUT)
+
+  afterAll(async () => {
+    await container?.stop().catch(() => {})
+  }, SETUP_TIMEOUT)
+
+  it(
+    'health endpoint returns 200 with service info',
+    async () => {
+      const res = await fetch(`http://localhost:${healthPort}/health`)
+      expect(res.ok).toBe(true)
+
+      const body = (await res.json()) as { status: string; services?: string[] }
+      expect(body.status).toBe('ok')
+      expect(body.services).toContain('envoy')
+    },
+    TEST_TIMEOUT
+  )
+
+  it(
+    'root endpoint returns service banner',
+    async () => {
+      const res = await fetch(`http://localhost:${healthPort}/`)
+      expect(res.ok).toBe(true)
+
+      const text = await res.text()
+      expect(text).toContain('Catalyst Envoy Service')
+    },
+    TEST_TIMEOUT
+  )
+
+  it(
+    'xDS gRPC port accepts connections',
+    async () => {
+      // Attempt a gRPC connection to the ADS endpoint. We send a
+      // DiscoveryRequest and verify the stream opens without error.
+      const ADS_SERVICE_PATH =
+        '/envoy.service.discovery.v3.AggregatedDiscoveryService/StreamAggregatedResources'
+
+      const client = new grpc.Client(`localhost:${xdsPort}`, grpc.credentials.createInsecure())
+
+      const root = getProtoRoot()
+      const RequestType = root.lookupType('envoy.service.discovery.v3.DiscoveryRequest')
+
+      const stream = client.makeBidiStreamRequest(
+        ADS_SERVICE_PATH,
+        (v: Buffer) => v,
+        (v: Buffer) => v
+      )
+
+      try {
+        // The stream should open successfully (no immediate error)
+        const connected = await new Promise<boolean>((resolve) => {
+          const timeout = setTimeout(() => resolve(true), 3000)
+
+          stream.on('error', (err: grpc.ServiceError) => {
+            clearTimeout(timeout)
+            // UNAVAILABLE means the port is open but not serving yet — still
+            // proves the port is bound and accepting connections. Any other
+            // error (UNIMPLEMENTED, etc.) is also fine for this test — we
+            // just want to confirm the port is accessible.
+            if (err.code === grpc.status.UNAVAILABLE) {
+              resolve(false)
+            } else {
+              // Connection was established (server responded with something)
+              resolve(true)
+            }
+          })
+
+          // Send a CDS subscription request
+          const CLUSTER_TYPE_URL = 'type.googleapis.com/envoy.config.cluster.v3.Cluster'
+          const req = RequestType.fromObject({ type_url: CLUSTER_TYPE_URL })
+          stream.write(Buffer.from(RequestType.encode(req).finish()))
+        })
+
+        // Whether we got data or a timeout, the port was reachable
+        expect(connected).toBe(true)
+      } finally {
+        stream.end()
+        client.close()
+      }
+    },
+    TEST_TIMEOUT
+  )
+})


### PR DESCRIPTION
Adds envoy-service.container.test.ts that validates:
- Docker image builds from apps/envoy/Dockerfile
- Health endpoint responds with service info
- Root endpoint returns service banner
- xDS gRPC port accepts connections

Written test-first before the Dockerfile exists.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>