### PR TITLE
feat(docker): add envoy service and proxy to compose files

### DIFF
--- a/docker-compose/docker.compose.yaml
+++ b/docker-compose/docker.compose.yaml
@@ -50,6 +50,8 @@ services:
       - CATALYST_DOMAINS=somebiz.local.io
       - CATALYST_PEERING_SECRET=valid-secret
       - CATALYST_GQL_GATEWAY_ENDPOINT=ws://gateway:4000/api
+      - CATALYST_ENVOY_ENDPOINT=ws://envoy-service:3000/api
+      - CATALYST_ENVOY_PORT_RANGE=[10000, [10001, 10100]]
       - OTEL_SERVICE_NAME=orchestrator
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
     healthcheck:
@@ -61,6 +63,8 @@ services:
       auth:
         condition: service_healthy
       gateway:
+        condition: service_healthy
+      envoy-service:
         condition: service_healthy
 
   gateway:
@@ -113,3 +117,53 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  # --- Envoy data plane ---
+
+  envoy-service:
+    build:
+      context: ..
+      dockerfile: apps/envoy/Dockerfile
+    ports:
+      - '3010:3000'
+      - '18000:18000'
+    environment:
+      - PORT=3000
+      - CATALYST_NODE_ID=envoy-service
+      - CATALYST_ENVOY_XDS_PORT=18000
+      - CATALYST_ENVOY_BIND_ADDRESS=0.0.0.0
+      - OTEL_SERVICE_NAME=envoy-service
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:3000/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      otel-collector:
+        condition: service_healthy
+
+  envoy-proxy:
+    image: envoyproxy/envoy:v1.32-latest
+    ports:
+      - '10000:10000'
+      - '9901:9901'
+    volumes:
+      - ./envoy-bootstrap.yaml:/etc/envoy/envoy.yaml:ro
+    command: ['-c', '/etc/envoy/envoy.yaml', '--log-level', 'info']
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'wget',
+          '--no-verbose',
+          '--tries=1',
+          '--spider',
+          'http://localhost:9901/server_info',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      envoy-service:
+        condition: service_healthy

--- a/docker-compose/envoy-bootstrap.yaml
+++ b/docker-compose/envoy-bootstrap.yaml
@@ -1,0 +1,51 @@
+# Envoy proxy bootstrap for Docker Compose.
+#
+# Points the ADS xDS cluster at the envoy-service container using STRICT_DNS.
+# HTTP/2 is required for the gRPC ADS connection.
+#
+# Usage: mounted as /etc/envoy/envoy.yaml in the envoy-proxy container.
+
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9901
+
+node:
+  id: catalyst-envoy-proxy
+  cluster: catalyst
+
+dynamic_resources:
+  lds_config:
+    resource_api_version: V3
+    ads: {}
+  cds_config:
+    resource_api_version: V3
+    ads: {}
+  ads_config:
+    api_type: GRPC
+    transport_api_version: V3
+    grpc_services:
+      - envoy_grpc:
+          cluster_name: xds_cluster
+
+static_resources:
+  clusters:
+    - name: xds_cluster
+      connect_timeout: 5s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: xds_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: envoy-service
+                      port_value: 18000

--- a/docker-compose/example.m0p2.compose.yaml
+++ b/docker-compose/example.m0p2.compose.yaml
@@ -28,6 +28,8 @@ services:
       - CATALYST_GQL_GATEWAY_ENDPOINT=ws://gateway:4000/api
       - CATALYST_AUTH_ENDPOINT=ws://auth:5000/rpc
       - CATALYST_SYSTEM_TOKEN=${CATALYST_SYSTEM_TOKEN}
+      - CATALYST_ENVOY_ENDPOINT=ws://envoy-service:3000/api
+      - CATALYST_ENVOY_PORT_RANGE=[10000, [10001, 10100]]
       - PORT=3000
     healthcheck:
       test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:3000/health']
@@ -38,6 +40,8 @@ services:
       auth:
         condition: service_healthy
       gateway:
+        condition: service_healthy
+      envoy-service:
         condition: service_healthy
 
   gateway:
@@ -86,6 +90,49 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  envoy-service:
+    build:
+      context: ..
+      dockerfile: apps/envoy/Dockerfile
+    ports:
+      - '3010:3000'
+      - '18000:18000'
+    environment:
+      - PORT=3000
+      - CATALYST_NODE_ID=envoy-service
+      - CATALYST_ENVOY_XDS_PORT=18000
+      - CATALYST_ENVOY_BIND_ADDRESS=0.0.0.0
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:3000/health']
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  envoy-proxy:
+    image: envoyproxy/envoy:v1.32-latest
+    ports:
+      - '10000:10000'
+      - '9901:9901'
+    volumes:
+      - ./envoy-bootstrap.yaml:/etc/envoy/envoy.yaml:ro
+    command: ['-c', '/etc/envoy/envoy.yaml', '--log-level', 'info']
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'wget',
+          '--no-verbose',
+          '--tries=1',
+          '--spider',
+          'http://localhost:9901/server_info',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      envoy-service:
+        condition: service_healthy
 
 volumes:
   auth-data:

--- a/docker-compose/two-node.compose.yaml
+++ b/docker-compose/two-node.compose.yaml
@@ -87,6 +87,8 @@ services:
       - CATALYST_DOMAINS=somebiz.local.io
       - CATALYST_PEERING_SECRET=valid-secret
       - CATALYST_GQL_GATEWAY_ENDPOINT=ws://gateway-a:4000/api
+      - CATALYST_ENVOY_ENDPOINT=ws://envoy-service:3000/api
+      - CATALYST_ENVOY_PORT_RANGE=[10000, [10001, 10050]]
       - OTEL_SERVICE_NAME=orchestrator-node-a
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
     healthcheck:
@@ -102,6 +104,8 @@ services:
       auth:
         condition: service_healthy
       gateway-a:
+        condition: service_healthy
+      envoy-service:
         condition: service_healthy
 
   # --- Node B: gateway-b + movies ---
@@ -154,6 +158,8 @@ services:
       - CATALYST_DOMAINS=somebiz.local.io
       - CATALYST_PEERING_SECRET=valid-secret
       - CATALYST_GQL_GATEWAY_ENDPOINT=ws://gateway-b:4000/api
+      - CATALYST_ENVOY_ENDPOINT=ws://envoy-service:3000/api
+      - CATALYST_ENVOY_PORT_RANGE=[[10051, 10100]]
       - OTEL_SERVICE_NAME=orchestrator-node-b
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
     healthcheck:
@@ -169,4 +175,56 @@ services:
       auth:
         condition: service_healthy
       gateway-b:
+        condition: service_healthy
+      envoy-service:
+        condition: service_healthy
+
+  # --- Envoy data plane ---
+
+  envoy-service:
+    build:
+      context: ..
+      dockerfile: apps/envoy/Dockerfile
+    ports:
+      - '3010:3000'
+      - '18000:18000'
+    environment:
+      - PORT=3000
+      - CATALYST_NODE_ID=envoy-service
+      - CATALYST_ENVOY_XDS_PORT=18000
+      - CATALYST_ENVOY_BIND_ADDRESS=0.0.0.0
+      - OTEL_SERVICE_NAME=envoy-service
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:3000/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      otel-collector:
+        condition: service_healthy
+
+  envoy-proxy:
+    image: envoyproxy/envoy:v1.32-latest
+    ports:
+      - '10000:10000'
+      - '9901:9901'
+    volumes:
+      - ./envoy-bootstrap.yaml:/etc/envoy/envoy.yaml:ro
+    command: ['-c', '/etc/envoy/envoy.yaml', '--log-level', 'info']
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'wget',
+          '--no-verbose',
+          '--tries=1',
+          '--spider',
+          'http://localhost:9901/server_info',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      envoy-service:
         condition: service_healthy


### PR DESCRIPTION
Adds envoy-service (xDS control plane) and envoy-proxy (data plane)
containers to all three docker-compose files. Creates a compose-specific
bootstrap YAML using STRICT_DNS to resolve the envoy-service container.

- envoy-service: built from apps/envoy/Dockerfile, exposes config + xDS
- envoy-proxy: envoyproxy/envoy:v1.32-latest with mounted bootstrap
- Orchestrator nodes wired with CATALYST_ENVOY_ENDPOINT and PORT_RANGE
- Health checks on all new services

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>