### PR TITLE
chore: update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,5 @@
 .vscode
 .cursor
 .husky
+.claude
+*.md


### PR DESCRIPTION
### TL;DR

Updated `.dockerignore` to exclude Markdown files and Claude-related directories.

### What changed?

Added two new entries to the `.dockerignore` file:
- `.claude` directory
- `*.md` (all Markdown files)

### How to test?

1. Build a Docker image using `docker build .`
2. Verify that any Markdown files and the `.claude` directory are not included in the build context
3. Check that the Docker build completes successfully

### Why make this change?

Excluding Markdown files and Claude-related directories from the Docker build context reduces the size of the build context and prevents unnecessary files from being sent to the Docker daemon. This improves build performance and keeps the Docker image focused only on the files needed for the application to run.