### PR TITLE
refactor(zod): migrate enum and schema patterns to zod v4 idioms

### DIFF
--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -6,10 +6,9 @@ export type CliResult<T> = { success: true; data?: T } | { success: false; error
 
 export const BaseCliConfigSchema = z.object({
   orchestratorUrl: z
-    .string()
     .url()
     .default(process.env.CATALYST_ORCHESTRATOR_URL || 'ws://localhost:3000/rpc'),
-  logLevel: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
+  logLevel: z.enum(['debug', 'info', 'warn', 'error'] as const).default('info'),
 })
 export type BaseCliConfig = z.infer<typeof BaseCliConfigSchema>
 
@@ -17,7 +16,7 @@ export const AddServiceInputSchema = DataChannelDefinitionSchema.pick({
   name: true,
   endpoint: true,
   protocol: true,
-}).merge(BaseCliConfigSchema)
+}).extend(BaseCliConfigSchema.shape)
 
 export type AddServiceInput = z.infer<typeof AddServiceInputSchema>
 
@@ -49,7 +48,9 @@ export type ListPeersInput = z.infer<typeof ListPeersInputSchema>
 export const CreateRouteInputSchema = BaseCliConfigSchema.extend({
   name: z.string().min(1),
   endpoint: z.string().url(),
-  protocol: z.enum(['http', 'http:graphql', 'http:gql', 'http:grpc']).default('http:graphql'),
+  protocol: z
+    .enum(['http', 'http:graphql', 'http:gql', 'http:grpc'] as const)
+    .default('http:graphql'),
   region: z.string().optional(),
   tags: z.array(z.string()).optional(),
   token: z.string().optional(),
@@ -72,7 +73,7 @@ export const MintTokenInputSchema = z.object({
   subject: z.string().min(1),
   principal: z.enum(Principal),
   name: z.string().min(1),
-  type: z.enum(['user', 'service']).default('user'),
+  type: z.enum(['user', 'service'] as const).default('user'),
   expiresIn: z.string().optional(),
   nodeId: z.string().optional(),
   trustedDomains: z.array(z.string()).optional(),

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,24 @@
         "vitest": "^1.2.1",
       },
     },
+    "apps/catalyst-zenoh-bridge": {
+      "name": "@catalyst/zenoh-bridge",
+      "version": "0.0.1",
+      "dependencies": {
+        "@catalyst/config": "catalog:",
+        "@catalyst/routing": "catalog:",
+        "@catalyst/service": "catalog:",
+        "@catalyst/telemetry": "catalog:",
+        "@hono/capnweb": "catalog:",
+        "capnweb": "catalog:",
+        "hono": "catalog:",
+        "zod": "catalog:",
+      },
+      "devDependencies": {
+        "@types/bun": "catalog:dev",
+        "typescript": "catalog:dev",
+      },
+    },
     "apps/cli": {
       "name": "@catalyst/cli",
       "version": "0.0.0",
@@ -497,6 +515,8 @@
     "@catalyst/telemetry": ["@catalyst/telemetry@workspace:packages/telemetry"],
 
     "@catalyst/types": ["@catalyst/types@workspace:packages/types"],
+
+    "@catalyst/zenoh-bridge": ["@catalyst/zenoh-bridge@workspace:apps/catalyst-zenoh-bridge"],
 
     "@cedar-policy/cedar-wasm": ["@cedar-policy/cedar-wasm@4.8.2", "", {}, "sha512-S37Kd4wP/IMZN3pdKEcsV8av7jMj4AKRovxzJEYZNTEYq0Wj4fno3dsw8xHHDXqT0dkQGTNUBuQNF8CTvOgE/Q=="],
 

--- a/packages/authorization/src/jwt/index.ts
+++ b/packages/authorization/src/jwt/index.ts
@@ -8,7 +8,7 @@ import type { PolicyEntity as CedarEntity } from '../policy/src/types.js'
 /**
  * Entity types that can own a token
  */
-export const EntityTypeEnum = z.enum(['user', 'service'])
+export const EntityTypeEnum = z.enum(['user', 'service'] as const)
 export type EntityType = z.infer<typeof EntityTypeEnum>
 
 /**

--- a/packages/authorization/tests/policy/integration/agnostic-usage.test.ts
+++ b/packages/authorization/tests/policy/integration/agnostic-usage.test.ts
@@ -6,7 +6,12 @@ import { GenericZodModel } from '../../../src/policy/src/providers/GenericZodMod
 describe('Model-Agnostic Usage Integration', () => {
   // --- Scenario 1: Orchestrator Route Integration (Mocked Schema) ---
   // This mimics importing DataChannelDefinitionSchema from 'orchestrator'
-  const MockDataChannelProtocolEnum = z.enum(['http', 'http:graphql', 'http:gql', 'http:grpc'])
+  const MockDataChannelProtocolEnum = z.enum([
+    'http',
+    'http:graphql',
+    'http:gql',
+    'http:grpc',
+  ] as const)
   const MockDataChannelDefinitionSchema = z.object({
     name: z.string(),
     endpoint: z.string().url().optional(),

--- a/packages/routing/src/datachannel.ts
+++ b/packages/routing/src/datachannel.ts
@@ -1,11 +1,16 @@
 import { z } from 'zod'
 // Local re-definition to decouple from V1
-export const DataChannelProtocolEnum = z.enum(['http', 'http:graphql', 'http:gql', 'http:grpc'])
+export const DataChannelProtocolEnum = z.enum([
+  'http',
+  'http:graphql',
+  'http:gql',
+  'http:grpc',
+] as const)
 export type DataChannelProtocol = z.infer<typeof DataChannelProtocolEnum>
 
 export const DataChannelDefinitionSchema = z.object({
   name: z.string(),
-  endpoint: z.string().url().optional(),
+  endpoint: z.url().optional(),
   protocol: DataChannelProtocolEnum,
   region: z.string().optional(),
   tags: z.array(z.string()).optional(),

--- a/packages/routing/src/internal/actions.ts
+++ b/packages/routing/src/internal/actions.ts
@@ -13,7 +13,7 @@ export const internalProtocolConnectedAction = z.literal(Actions.InternalProtoco
 export const UpdateMessageSchema = z.object({
   updates: z.array(
     z.object({
-      action: z.enum(['add', 'remove']),
+      action: z.enum(['add', 'remove'] as const),
       route: DataChannelDefinitionSchema,
       nodePath: z.array(z.string()).optional(),
     })

--- a/packages/routing/src/state.ts
+++ b/packages/routing/src/state.ts
@@ -7,7 +7,7 @@ export const PeerInfoSchema = NodeConfigSchema
 
 export type PeerInfo = z.infer<typeof PeerInfoSchema>
 
-export const PeerConnectionStatusEnum = z.enum(['initializing', 'connected', 'closed'])
+export const PeerConnectionStatusEnum = z.enum(['initializing', 'connected', 'closed'] as const)
 export type PeerConnectionStatus = z.infer<typeof PeerConnectionStatusEnum>
 
 export const PeerRecordSchema = PeerInfoSchema.extend({


### PR DESCRIPTION
Add 'as const' to z.enum() arrays for proper type inference,
replace z.string().url() with z.url(), and use .extend() over
.merge() for schema composition.