### PR TITLE
feat(envoy): add multi-hop transit routing support

### DIFF
--- a/apps/envoy/src/xds/resources.ts
+++ b/apps/envoy/src/xds/resources.ts
@@ -145,6 +145,7 @@ export function buildEgressListener(opts: {
   channelName: string
   peerName: string
   port: number
+  bindAddress?: string
 }): XdsListener {
   const name = `egress_${opts.channelName}_via_${opts.peerName}`
   const clusterName = `remote_${opts.channelName}_via_${opts.peerName}`
@@ -153,7 +154,7 @@ export function buildEgressListener(opts: {
     name,
     address: {
       socket_address: {
-        address: '127.0.0.1',
+        address: opts.bindAddress ?? '0.0.0.0',
         port_value: opts.port,
       },
     },
@@ -321,6 +322,7 @@ export function buildXdsSnapshot(input: BuildXdsSnapshotInput): XdsSnapshot {
         channelName: route.name,
         peerName: route.peerName,
         port: egressPort,
+        bindAddress: input.bindAddress,
       })
     )
 

--- a/apps/envoy/tests/resources.test.ts
+++ b/apps/envoy/tests/resources.test.ts
@@ -83,11 +83,23 @@ describe('buildEgressListener', () => {
     expect(listener.name).toBe('egress_books-api_via_node-a')
   })
 
-  it('binds to 127.0.0.1 (localhost only)', () => {
+  it('defaults bind address to 0.0.0.0', () => {
     const listener = buildEgressListener({
       channelName: 'books-api',
       peerName: 'node-a',
       port: 10001,
+    })
+    const addr = listener.address.socket_address
+    expect(addr.address).toBe('0.0.0.0')
+    expect(addr.port_value).toBe(10001)
+  })
+
+  it('uses custom bind address when provided', () => {
+    const listener = buildEgressListener({
+      channelName: 'books-api',
+      peerName: 'node-a',
+      port: 10001,
+      bindAddress: '127.0.0.1',
     })
     const addr = listener.address.socket_address
     expect(addr.address).toBe('127.0.0.1')
@@ -504,7 +516,7 @@ describe('buildXdsSnapshot', () => {
     })
 
     const addr = snapshot.listeners[0].address.socket_address
-    expect(addr.address).toBe('127.0.0.1')
+    expect(addr.address).toBe('0.0.0.0')
     expect(addr.port_value).toBe(10001)
   })
 


### PR DESCRIPTION
Enable intermediate nodes to proxy traffic between non-adjacent nodes
in the mesh. Key changes:

- Change egress listener bind from 127.0.0.1 to 0.0.0.0 so transit
  nodes serve both local clients and downstream nodes (single ingress
  per transit route, all services must authenticate)

- Rewrite envoyPort in BGP re-advertisement across all 3 propagation
  paths (InternalProtocolUpdate, InternalProtocolOpen, Connected) using
  the port allocator's locally allocated egress port

- Always allocate egress ports for internal routes regardless of
  whether upstream set envoyPort, separating local listener port from
  remote cluster target port

- Send explicit portAllocations map from orchestrator to envoy service,
  enabling the envoy RPC server to use local ports for listeners while
  preserving upstream ports for remote clusters

- Add 5 unit tests covering: envoyPort rewrite in re-advertisement,
  no rewrite without envoy config, full sync rewrite on peer connect,
  envoyAddress propagation via PeerInfo, and remove action passthrough

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>