### PR TITLE
feat(envoy): add TCP passthrough proxy for raw protocol support (Zenoh)

### DIFF
--- a/apps/cli/src/commands/node/route.ts
+++ b/apps/cli/src/commands/node/route.ts
@@ -21,7 +21,7 @@ export function routeCommands(): Command {
     .argument('<endpoint>', 'Service endpoint URL')
     .option(
       '-p, --protocol <protocol>',
-      'Protocol (http, http:graphql, http:gql, http:grpc)',
+      'Protocol (http, http:graphql, http:gql, http:grpc, tcp)',
       'http:graphql'
     )
     .option('--region <region>', 'Region tag')

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -49,7 +49,7 @@ export const CreateRouteInputSchema = BaseCliConfigSchema.extend({
   name: z.string().min(1),
   endpoint: z.string().url(),
   protocol: z
-    .enum(['http', 'http:graphql', 'http:gql', 'http:grpc'] as const)
+    .enum(['http', 'http:graphql', 'http:gql', 'http:grpc', 'tcp'] as const)
     .default('http:graphql'),
   region: z.string().optional(),
   tags: z.array(z.string()).optional(),

--- a/apps/envoy/src/xds/control-plane.ts
+++ b/apps/envoy/src/xds/control-plane.ts
@@ -6,10 +6,12 @@ import {
   LISTENER_TYPE_URL,
   CLUSTER_TYPE_URL,
   encodeListener,
+  encodeTcpProxyListener,
   encodeCluster,
   encodeDiscoveryResponse,
   decodeDiscoveryRequest,
 } from './proto-encoding.js'
+import { isTcpProxyListener } from './resources.js'
 
 // ---------------------------------------------------------------------------
 // ADS service definition for @grpc/grpc-js
@@ -204,7 +206,9 @@ export class XdsControlPlane {
       subscribedTypes.has(LISTENER_TYPE_URL) &&
       sentVersions.get(LISTENER_TYPE_URL) !== snapshot.version
     ) {
-      const ldsResources = snapshot.listeners.map((l) => encodeListener(l))
+      const ldsResources = snapshot.listeners.map((l) =>
+        isTcpProxyListener(l) ? encodeTcpProxyListener(l) : encodeListener(l)
+      )
       const ldsResponse = encodeDiscoveryResponse({
         version_info: snapshot.version,
         resources: ldsResources,

--- a/apps/envoy/src/xds/proto-encoding.ts
+++ b/apps/envoy/src/xds/proto-encoding.ts
@@ -1,5 +1,5 @@
 import protobuf from 'protobufjs'
-import type { XdsListener, XdsCluster } from './resources.js'
+import type { XdsListener, XdsTcpProxyListener, XdsCluster } from './resources.js'
 
 // ---------------------------------------------------------------------------
 // Type URLs used for google.protobuf.Any wrapping
@@ -10,6 +10,8 @@ export const CLUSTER_TYPE_URL = 'type.googleapis.com/envoy.config.cluster.v3.Clu
 const HCM_TYPE_URL =
   'type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager'
 const ROUTER_TYPE_URL = 'type.googleapis.com/envoy.extensions.filters.http.router.v3.Router'
+export const TCP_PROXY_TYPE_URL =
+  'type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy'
 const HTTP_PROTOCOL_OPTIONS_TYPE_URL =
   'type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions'
 
@@ -206,6 +208,15 @@ function buildProtoRoot(): protobuf.Root {
       )
   )
 
+  // envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+  root
+    .define('envoy.extensions.filters.network.tcp_proxy.v3')
+    .add(
+      new protobuf.Type('TcpProxy')
+        .add(new protobuf.Field('stat_prefix', 1, 'string'))
+        .add(new protobuf.Field('cluster', 2, 'string'))
+    )
+
   // envoy.config.listener.v3.Filter
   root
     .define('envoy.config.listener.v3')
@@ -367,6 +378,56 @@ export function encodeListener(listener: XdsListener): {
         }
       }),
     })),
+  }
+
+  const ListenerType = root.lookupType('envoy.config.listener.v3.Listener')
+  const msg = ListenerType.fromObject(protoListener)
+  return {
+    type_url: LISTENER_TYPE_URL,
+    value: ListenerType.encode(msg).finish(),
+  }
+}
+
+/**
+ * Encode a TCP proxy listener into protobuf bytes suitable for
+ * wrapping in a DiscoveryResponse.resources Any field.
+ */
+export function encodeTcpProxyListener(listener: XdsTcpProxyListener): {
+  type_url: string
+  value: Uint8Array
+} {
+  const root = getProtoRoot()
+
+  const tcpProxyProto = {
+    stat_prefix: listener.filter_chains[0].filters[0].typed_config.stat_prefix,
+    cluster: listener.filter_chains[0].filters[0].typed_config.cluster,
+  }
+
+  const tcpProxyAny = encodeAsAny(
+    root,
+    'envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy',
+    TCP_PROXY_TYPE_URL,
+    tcpProxyProto
+  )
+
+  const protoListener = {
+    name: listener.name,
+    address: {
+      socket_address: {
+        address: listener.address.socket_address.address,
+        port_value: listener.address.socket_address.port_value,
+      },
+    },
+    filter_chains: [
+      {
+        filters: [
+          {
+            name: 'envoy.filters.network.tcp_proxy',
+            typed_config: tcpProxyAny,
+          },
+        ],
+      },
+    ],
   }
 
   const ListenerType = root.lookupType('envoy.config.listener.v3.Listener')

--- a/apps/envoy/src/xds/snapshot-cache.ts
+++ b/apps/envoy/src/xds/snapshot-cache.ts
@@ -1,4 +1,4 @@
-import type { XdsListener, XdsCluster } from './resources.js'
+import type { XdsListener, XdsTcpProxyListener, XdsCluster } from './resources.js'
 
 /**
  * xDS snapshot — a complete set of Envoy resources at a given version.
@@ -10,8 +10,8 @@ import type { XdsListener, XdsCluster } from './resources.js'
 export interface XdsSnapshot {
   /** Monotonic version string. */
   version: string
-  /** All LDS resources (ingress + egress listeners). */
-  listeners: XdsListener[]
+  /** All LDS resources (ingress + egress listeners, both HCM and TCP proxy). */
+  listeners: Array<XdsListener | XdsTcpProxyListener>
   /** All CDS resources (local + remote clusters). */
   clusters: XdsCluster[]
 }

--- a/packages/authorization/src/policy/src/definitions/models.ts
+++ b/packages/authorization/src/policy/src/definitions/models.ts
@@ -24,7 +24,7 @@ export type PeerEntity = {
 
 export type RouteEntity = {
   name: string
-  protocol: 'http' | 'http:graphql' | 'http:gql' | 'http:grpc'
+  protocol: 'http' | 'http:graphql' | 'http:gql' | 'http:grpc' | 'tcp'
   endpoint?: string | undefined
   region?: string | undefined
   tags?: string[] | undefined

--- a/packages/authorization/tests/policy/integration/agnostic-usage.test.ts
+++ b/packages/authorization/tests/policy/integration/agnostic-usage.test.ts
@@ -11,6 +11,7 @@ describe('Model-Agnostic Usage Integration', () => {
     'http:graphql',
     'http:gql',
     'http:grpc',
+    'tcp',
   ] as const)
   const MockDataChannelDefinitionSchema = z.object({
     name: z.string(),

--- a/packages/routing/src/datachannel.ts
+++ b/packages/routing/src/datachannel.ts
@@ -5,6 +5,7 @@ export const DataChannelProtocolEnum = z.enum([
   'http:graphql',
   'http:gql',
   'http:grpc',
+  'tcp',
 ] as const)
 export type DataChannelProtocol = z.infer<typeof DataChannelProtocolEnum>
 

--- a/packages/routing/tests/datachannel.test.ts
+++ b/packages/routing/tests/datachannel.test.ts
@@ -32,7 +32,7 @@ describe('DataChannelDefinitionSchema', () => {
     })
 
     it('parses all valid protocol types', () => {
-      for (const protocol of ['http', 'http:graphql', 'http:gql', 'http:grpc']) {
+      for (const protocol of ['http', 'http:graphql', 'http:gql', 'http:grpc', 'tcp']) {
         const result = DataChannelDefinitionSchema.safeParse({
           name: 'test',
           protocol,
@@ -44,7 +44,7 @@ describe('DataChannelDefinitionSchema', () => {
     it('rejects invalid protocol', () => {
       const result = DataChannelDefinitionSchema.safeParse({
         name: 'test',
-        protocol: 'tcp',
+        protocol: 'ftp',
       })
       expect(result.success).toBe(false)
     })


### PR DESCRIPTION
Add 'tcp' protocol to DataChannelProtocolEnum for L4 TCP passthrough
proxying through Envoy, enabling protocols like Zenoh that don't use HTTP.

- New XdsTcpProxyListener type with envoy.filters.network.tcp_proxy filter
- buildTcpProxyIngressListener/buildTcpProxyEgressListener resource builders
- isTcpProxyListener type guard for dispatch in control plane
- TcpProxy proto type (stat_prefix + cluster) in proto-encoding
- encodeTcpProxyListener for protobuf serialization
- buildXdsSnapshot branches on protocol: tcp → L4 proxy, others → HCM
- control-plane dispatches between HCM and TCP proxy encoders
- Updated DataChannelProtocolEnum, CLI types, authorization models
- 17 new tests for TCP proxy builders, encoding, and snapshot integration

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>