### PR TITLE
fix(envoy): validate re-hydrated ports are within configured range

### DIFF
--- a/apps/envoy/src/port-allocator.ts
+++ b/apps/envoy/src/port-allocator.ts
@@ -53,9 +53,10 @@ export function createPortAllocator(
   const available = new Set<number>(pool)
   const allocations = new Map<string, number>()
 
-  // Re-hydrate existing allocations
+  // Re-hydrate existing allocations — only accept ports within the configured range
   if (existing) {
     for (const [name, port] of existing) {
+      if (!available.has(port)) continue
       allocations.set(name, port)
       available.delete(port)
     }


### PR DESCRIPTION
Skip ports outside the configured portRange during re-hydration instead
of blindly tracking them. Previously, releasing an out-of-range
re-hydrated port would add it to the available pool, violating the port
range contract.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>