### PR TITLE
fix(envoy): validate IPv4 octets are 0-255 in isIpAddress check

### DIFF
--- a/apps/envoy/src/xds/resources.ts
+++ b/apps/envoy/src/xds/resources.ts
@@ -63,7 +63,7 @@ let versionCounter = 0
 // IP detection — determines STATIC vs STRICT_DNS cluster type
 // ---------------------------------------------------------------------------
 
-const IPV4_RE = /^\d{1,3}(\.\d{1,3}){3}$/
+const IPV4_RE = /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)$/
 const IPV6_RE = /^[0-9a-fA-F:]+$/
 
 function isIpAddress(address: string): boolean {

--- a/apps/envoy/tests/resources.test.ts
+++ b/apps/envoy/tests/resources.test.ts
@@ -208,6 +208,46 @@ describe('buildRemoteCluster', () => {
     expect(cluster.type).toBe('STATIC')
   })
 
+  it('uses STRICT_DNS for invalid IPv4 with out-of-range octets', () => {
+    const cluster = buildRemoteCluster({
+      channelName: 'books-api',
+      peerName: 'node-a',
+      peerAddress: '999.999.999.999',
+      peerPort: 8001,
+    })
+    expect(cluster.type).toBe('STRICT_DNS')
+  })
+
+  it('uses STRICT_DNS for partially invalid IPv4 octets', () => {
+    const cluster = buildRemoteCluster({
+      channelName: 'books-api',
+      peerName: 'node-a',
+      peerAddress: '256.0.0.1',
+      peerPort: 8001,
+    })
+    expect(cluster.type).toBe('STRICT_DNS')
+  })
+
+  it('uses STATIC for valid boundary IPv4 (255.255.255.255)', () => {
+    const cluster = buildRemoteCluster({
+      channelName: 'books-api',
+      peerName: 'node-a',
+      peerAddress: '255.255.255.255',
+      peerPort: 8001,
+    })
+    expect(cluster.type).toBe('STATIC')
+  })
+
+  it('uses STATIC for valid IPv4 (0.0.0.0)', () => {
+    const cluster = buildRemoteCluster({
+      channelName: 'books-api',
+      peerName: 'node-a',
+      peerAddress: '0.0.0.0',
+      peerPort: 8001,
+    })
+    expect(cluster.type).toBe('STATIC')
+  })
+
   it('recognizes IPv6 addresses as STATIC', () => {
     const cluster = buildRemoteCluster({
       channelName: 'books-api',


### PR DESCRIPTION
The previous regex /^\d{1,3}(\.\d{1,3}){3}$/ only checked format but
not octet range, incorrectly classifying addresses like 999.999.999.999
as valid IPs. This caused STATIC cluster type instead of STRICT_DNS for
invalid addresses. Use proper octet-validating regex.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>