### PR TITLE
fix(envoy): nest ExplicitHttpConfig inside HttpProtocolOptions type

### DIFF
--- a/apps/envoy/src/xds/proto-encoding.ts
+++ b/apps/envoy/src/xds/proto-encoding.ts
@@ -237,27 +237,20 @@ function buildProtoRoot(): protobuf.Root {
   // envoy.config.core.v3.Http2ProtocolOptions (empty — defaults are fine)
   root.define('envoy.config.core.v3').add(new protobuf.Type('Http2ProtocolOptions'))
 
-  // envoy.extensions.upstreams.http.v3.HttpProtocolOptions.ExplicitHttpConfig
-  root
-    .define('envoy.extensions.upstreams.http.v3.HttpProtocolOptions')
-    .add(
-      new protobuf.Type('ExplicitHttpConfig').add(
-        new protobuf.Field('http2_protocol_options', 2, 'envoy.config.core.v3.Http2ProtocolOptions')
-      )
-    )
-
   // envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-  root
-    .define('envoy.extensions.upstreams.http.v3')
-    .add(
-      new protobuf.Type('HttpProtocolOptions').add(
-        new protobuf.Field(
-          'explicit_http_config',
-          3,
-          'envoy.extensions.upstreams.http.v3.HttpProtocolOptions.ExplicitHttpConfig'
-        )
-      )
+  const HttpProtocolOptions = new protobuf.Type('HttpProtocolOptions')
+  const ExplicitHttpConfig = new protobuf.Type('ExplicitHttpConfig').add(
+    new protobuf.Field('http2_protocol_options', 2, 'envoy.config.core.v3.Http2ProtocolOptions')
+  )
+  HttpProtocolOptions.add(ExplicitHttpConfig)
+  HttpProtocolOptions.add(
+    new protobuf.Field(
+      'explicit_http_config',
+      3,
+      'envoy.extensions.upstreams.http.v3.HttpProtocolOptions.ExplicitHttpConfig'
     )
+  )
+  root.define('envoy.extensions.upstreams.http.v3').add(HttpProtocolOptions)
 
   // envoy.config.cluster.v3.Cluster
   root.define('envoy.config.cluster.v3').add(


### PR DESCRIPTION
Previously ExplicitHttpConfig was defined in a namespace called
HttpProtocolOptions, then a separate HttpProtocolOptions Type was
created. This produced two distinct entities instead of a proper nested
message. Envoy expects ExplicitHttpConfig as a nested message inside
HttpProtocolOptions for typed_extension_protocol_options decoding.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>