### PR TITLE
fix(envoy): replay snapshot on ADS connect and fix HCM upgrade_configs field number

### DIFF
--- a/apps/envoy/src/xds/control-plane.ts
+++ b/apps/envoy/src/xds/control-plane.ts
@@ -120,7 +120,7 @@ export class XdsControlPlane {
     const subscribedTypes = new Set<string>()
     const sentVersions = new Map<string, string>()
     const ackedVersions = new Map<string, string>()
-    let latestSnapshot: XdsSnapshot | undefined = this.cache.getSnapshot()
+    let latestSnapshot: XdsSnapshot | undefined
 
     /** Send snapshot resources for subscribed types that haven't been sent at this version. */
     const sendSubscribed = (): void => {
@@ -128,7 +128,10 @@ export class XdsControlPlane {
       this.sendSnapshotForTypes(call, latestSnapshot, subscribedTypes, sentVersions)
     }
 
-    // Watch for snapshot changes — send updates for subscribed types
+    // Watch for snapshot changes — send updates for subscribed types.
+    // The cache uses BehaviorSubject semantics: if a snapshot already exists,
+    // the callback fires immediately with the current value, so late-connecting
+    // streams always receive the latest config.
     const unwatch = this.cache.watch((snapshot) => {
       latestSnapshot = snapshot
       sendSubscribed()

--- a/apps/envoy/src/xds/proto-encoding.ts
+++ b/apps/envoy/src/xds/proto-encoding.ts
@@ -199,7 +199,7 @@ function buildProtoRoot(): protobuf.Root {
       .add(
         new protobuf.Field(
           'upgrade_configs',
-          6,
+          23,
           'envoy.extensions.filters.network.http_connection_manager.v3.UpgradeConfig',
           'repeated'
         )

--- a/apps/envoy/src/xds/snapshot-cache.ts
+++ b/apps/envoy/src/xds/snapshot-cache.ts
@@ -52,6 +52,11 @@ export function createSnapshotCache(): SnapshotCache {
 
     watch(callback: (snapshot: XdsSnapshot) => void): () => void {
       watchers.add(callback)
+      // Immediately replay the current snapshot to new watchers (BehaviorSubject pattern).
+      // This ensures late-connecting ADS streams receive the latest config.
+      if (current) {
+        callback(current)
+      }
       return () => {
         watchers.delete(callback)
       }

--- a/apps/envoy/tests/snapshot-cache.test.ts
+++ b/apps/envoy/tests/snapshot-cache.test.ts
@@ -99,6 +99,26 @@ describe('SnapshotCache', () => {
       expect(cb2).toHaveBeenCalledTimes(1)
     })
 
+    it('immediately replays current snapshot to new watchers', () => {
+      const cache = createSnapshotCache()
+      const snapshot = makeSnapshot('1')
+      cache.setSnapshot(snapshot)
+
+      const callback = mock(() => {})
+      cache.watch(callback)
+
+      expect(callback).toHaveBeenCalledTimes(1)
+      expect(callback).toHaveBeenCalledWith(snapshot)
+    })
+
+    it('does not replay when no snapshot exists', () => {
+      const cache = createSnapshotCache()
+      const callback = mock(() => {})
+      cache.watch(callback)
+
+      expect(callback).toHaveBeenCalledTimes(0)
+    })
+
     it('double unsubscribe is a no-op', () => {
       const cache = createSnapshotCache()
       const callback = mock(() => {})


### PR DESCRIPTION
Two bugs causing envoy-proxy container test flakiness:

1. ADS reconnect race: snapshot cache watch() now uses BehaviorSubject
   semantics — immediately fires callback with current snapshot on
   registration. Late-connecting Envoy proxies always receive the latest
   config. Removed manual getSnapshot() calls and fragile 500ms sleep.

2. LDS NACK: HttpConnectionManager upgrade_configs was encoded at proto
   field 6 (add_user_agent) instead of field 23. This caused Envoy to
   reject all listeners for http:graphql and http:gql routes that set
   WebSocket upgrade support.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>