### PR TITLE
feat(orchestrator): negotiate hold time during OPEN exchange

### DIFF
--- a/packages/routing/src/internal/actions.ts
+++ b/packages/routing/src/internal/actions.ts
@@ -24,6 +24,7 @@ export const InternalProtocolOpenMessageSchema = z.object({
   action: z.literal(Actions.InternalProtocolOpen),
   data: z.object({
     peerInfo: PeerInfoSchema,
+    holdTime: z.number().optional(),
   }),
 })
 
@@ -48,6 +49,7 @@ export const InternalProtocolConnectedMessageSchema = z.object({
   action: z.literal(Actions.InternalProtocolConnected),
   data: z.object({
     peerInfo: PeerInfoSchema,
+    holdTime: z.number().optional(),
   }),
 })
 


### PR DESCRIPTION
## Summary
- Add `holdTime` field to `InternalProtocolOpenMessageSchema` and `InternalProtocolConnectedMessageSchema`
- Negotiate hold time as `min(local, remote)` per BGP spec during OPEN exchange
- Store negotiated hold time per-peer on `PeerRecord.holdTime`
- Tick handler uses per-peer hold time for expiry and keepalive thresholds
- `IBGPClient.open()` sends local holdTime and returns remote holdTime

## Test plan
- [x] New test: "hold time negotiation uses min(local, remote)" — verifies both peers negotiate correctly
- [x] All 20 non-container orchestrator tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)