### PR TITLE
docs: update BGP protocol docs with degraded state and state machine

### DIFF
--- a/BGP_PROTOCOL.md
+++ b/BGP_PROTOCOL.md
@@ -37,7 +37,8 @@ Sent immediately upon connection establishment to negotiate parameters and capab
 - **AS Number**: The logical AS ID of the sender.
 - **Hold Time**: Max time (in seconds) between KEEPALIVEs/UPDATEs.
   - The session Hold Time is negotiated to the lower of the two peers' values.
-  - Default is **180 seconds**.
+  - Default is **180 seconds** (configurable via `CATALYST_HOLD_TIME`).
+  - Minimum is **3 seconds** per BGP spec.
   - If negotiated to 0, Keepalives are disabled.
 - **BGP Identifier**: Unique ID of the sending node.
 - **Capabilities**: Supported features (e.g., specific service types).
@@ -72,6 +73,65 @@ Sent when an error is detected. The connection is closed immediately after.
 - **Error Code**: Category of error (e.g., Message Header Error, OPEN Message Error).
 - **Error Subcode**: Specific error detail.
 - **Data**: Optional debugging data.
+
+## Peer Connection State Machine
+
+Peers transition through the following connection states. The state machine distinguishes between auto-recoverable failures (`degraded`) and fatal errors (`closed`).
+
+```mermaid
+stateDiagram-v2
+    [*] --> initializing : LocalPeerCreate
+
+    initializing --> connected : InternalProtocolConnected
+    initializing --> initializing : Tick (reconnection attempt fails)
+
+    connected --> degraded : InternalProtocolClose (code=4, HOLD_TIMER_EXPIRED)
+    connected --> closed : InternalProtocolClose (code!=4, fatal error)
+
+    degraded --> connected : InternalProtocolConnected (auto-reconnect succeeds)
+    degraded --> degraded : Tick (reconnection attempt fails)
+
+    closed --> [*] : LocalPeerDelete (manual removal only)
+    degraded --> [*] : LocalPeerDelete
+    initializing --> [*] : LocalPeerDelete
+    connected --> [*] : LocalPeerDelete
+```
+
+### State Descriptions
+
+| State          | Description                                                                              | Auto-Reconnect? |
+| -------------- | ---------------------------------------------------------------------------------------- | --------------- |
+| `initializing` | Peer added, connection not yet established                                               | Yes             |
+| `connected`    | Active session, exchanging keepalives and routes                                         | N/A             |
+| `degraded`     | Hold timer expired, routes withdrawn, awaiting reconnection                              | Yes             |
+| `closed`       | Fatal error (protocol error, auth failure, manual close), requires operator intervention | No              |
+
+### Key Distinctions
+
+- **`degraded` vs `closed`**: The `degraded` state represents transient failures (network partition, temporary node restart). The tick handler will automatically attempt reconnection. The `closed` state represents permanent or human-initiated failures that require manual intervention via `LocalPeerDelete` + `LocalPeerCreate`.
+- **`LocalPeerDelete` is the only way to fully remove a peer** from the peer list. `InternalProtocolClose` transitions the peer to `degraded` or `closed` but keeps the peer record for reconnection or inspection.
+
+## Hold Time Negotiation
+
+During the OPEN exchange, each peer sends its configured hold time. The session hold time is negotiated to `min(local, remote)` per BGP spec. This negotiated value is stored per-peer on the `PeerRecord.holdTime` field and used for all subsequent keepalive and expiry calculations.
+
+```mermaid
+sequenceDiagram
+    participant A as Node A (holdTime=180s)
+    participant B as Node B (holdTime=60s)
+
+    A->>B: open(peerInfo, holdTime=180)
+    Note right of B: InternalProtocolOpen<br/>negotiated = min(180, 60) = 60s<br/>Store holdTime=60 on A's peer record
+    B-->>A: { success: true, holdTime: 60 }
+    Note left of A: InternalProtocolConnected<br/>negotiated = min(180, 60) = 60s<br/>Store holdTime=60 on B's peer record
+
+    Note over A, B: Both peers use 60s hold time
+```
+
+The negotiated hold time determines:
+
+- **Expiry threshold**: `holdTime` seconds without any message triggers `InternalProtocolClose` with code 4
+- **Keepalive threshold**: `holdTime / 3` seconds triggers proactive keepalive sending
 
 ## Message Flow Diagrams
 
@@ -115,6 +175,82 @@ sequenceDiagram
     end
 
     Note right of A: If no msg received in 60s,<br/>Close Session
+```
+
+## Keep-Alive Implementation
+
+The orchestrator uses a tick-based architecture for all keep-alive and peer lifecycle management. A periodic timer dispatches an `InternalProtocolTick` action through the event bus every 20 seconds. All keep-alive logic -- hold timer checks, keepalive sending, and reconnection -- runs through the standard action/notify pipeline on each tick.
+
+### Hold Timer Expiry
+
+On each tick, connected peers are scanned. If a peer's `lastMessageReceived` exceeds the negotiated per-peer hold time (default 180 seconds), the peer is considered dead:
+
+1. An `InternalProtocolClose` is dispatched with error code 4 (`HOLD_TIMER_EXPIRED`).
+2. All routes learned from the expired peer are withdrawn and propagated to remaining peers.
+3. The peer is marked as `degraded` (not `closed` -- see Peer Connection State Machine above).
+
+### Keepalive Sending
+
+If a connected peer's `lastMessageReceived` exceeds `holdTime / 3` but has not yet expired, a keepalive message is sent via `IBGPClient.keepalive()`. This resets the peer's `lastMessageReceived` on the remote side, preventing hold timer expiry.
+
+### Automatic Reconnection
+
+Peers with status `degraded` or `initializing` are retried on each tick. When a reconnection attempt succeeds, an `InternalProtocolConnected` action is dispatched, which:
+
+1. Transitions the peer back to `connected`
+2. Negotiates a new hold time with the remote peer
+3. Re-syncs all local and internal routes to the recovered peer
+
+Peers with status `closed` are **not** auto-reconnected. They require manual intervention.
+
+### Peer Lifecycle
+
+`InternalProtocolClose` marks a peer as `degraded` (hold timer expired) or `closed` (fatal error) instead of removing it from the peer list. Only `LocalPeerDelete` fully removes a peer. This distinction enables automatic reconnection -- a peer that goes offline temporarily will be retried until it comes back or is explicitly deleted by an operator.
+
+### Configuration
+
+| Parameter     | Default    | Env Var              | Description                                          |
+| ------------- | ---------- | -------------------- | ---------------------------------------------------- |
+| `holdTime`    | 180s       | `CATALYST_HOLD_TIME` | Max seconds without a message before expiry (min 3s) |
+| Tick interval | 20s        | --                   | Frequency of the internal keep-alive tick            |
+| Keepalive     | holdTime/3 | --                   | Threshold for sending proactive keepalives           |
+
+The hold time is configurable at three levels (highest precedence first):
+
+1. **Per-peer negotiated**: `min(local, remote)` during OPEN exchange
+2. **Constructor override**: `holdTime` option passed to `CatalystNodeBus`
+3. **Config file**: `orchestrator.holdTime` in `CatalystConfig`
+4. **Default**: 180 seconds
+
+### Hold Timer Expiry and Reconnection Flow
+
+```mermaid
+sequenceDiagram
+    participant A as Node A
+    participant B as Node B (goes offline)
+
+    Note over A, B: Peers connected, exchanging keepalives
+
+    B->>B: Goes offline
+
+    Note over A: Tick fires, no message from B in holdTime
+    A->>A: InternalProtocolClose (HOLD_TIMER_EXPIRED)
+    A->>A: Withdraw routes from B
+    A->>A: Mark B as 'degraded'
+
+    Note over A: Subsequent ticks attempt reconnection
+    loop Every tick (20s)
+        A--xB: Reconnection attempt (fails)
+    end
+
+    B->>B: Comes back online
+
+    Note over A: Next tick succeeds
+    A->>B: open(A, holdTime)
+    B->>A: { holdTime }
+    A->>A: InternalProtocolConnected
+    A->>A: Negotiate holdTime, mark B as 'connected'
+    A->>B: Route sync (UPDATE)
 ```
 
 ### 3. Service Advertisement and Withdrawal (UPDATE)
@@ -162,6 +298,38 @@ sequenceDiagram
     A->>A: Close TCP Connection
 ```
 
+## Dispatch Concurrency
+
+The `CatalystNodeBus.dispatch()` method uses a Compare-And-Swap (CAS) pattern with exponential backoff to handle concurrent state mutations. This is necessary because the fire-and-forget notify phase can dispatch new actions while another dispatch is in progress.
+
+### Problem
+
+When dispatch A completes its `handleAction` phase and enters `handleNotify`, it may fire-and-forget a new dispatch B (e.g., propagating route updates). If dispatch B reads state, mutates it, and commits before dispatch A commits, dispatch A would overwrite B's changes with stale state.
+
+### Solution
+
+After `handleAction` returns, dispatch checks if `this.state` has changed since it was read (`prevState`). If it has, the dispatch retries with fresh state using exponential backoff:
+
+- Retry 1: 10ms delay
+- Retry 2: 20ms delay
+- Retry 3: 40ms delay
+
+After 3 retries, the dispatch proceeds regardless to avoid infinite loops. The exponential backoff gives concurrent dispatches time to settle before retrying.
+
+## Action-to-State Mapping
+
+| Action                            | State Mutation                                  | Hold Timer Effect                |
+| --------------------------------- | ----------------------------------------------- | -------------------------------- |
+| `InternalProtocolOpen`            | Peer -> `connected`, negotiate holdTime         | Starts (lastMessageReceived set) |
+| `InternalProtocolConnected`       | Peer -> `connected`, negotiate holdTime         | Starts (lastMessageReceived set) |
+| `InternalProtocolKeepalive`       | Update `lastMessageReceived`                    | Resets                           |
+| `InternalProtocolUpdate`          | Add/remove routes, update `lastMessageReceived` | Resets                           |
+| `InternalProtocolClose` (code=4)  | Peer -> `degraded`, withdraw routes             | Stops                            |
+| `InternalProtocolClose` (code!=4) | Peer -> `closed`, withdraw routes               | Stops                            |
+| `InternalProtocolTick`            | No-op (logic in notify phase)                   | Checks expiry, sends keepalives  |
+| `LocalPeerCreate`                 | Add peer as `initializing`                      | --                               |
+| `LocalPeerDelete`                 | Remove peer entirely                            | Stops                            |
+
 ## Data Structures
 
 ### Service Route
@@ -174,5 +342,20 @@ interface ServiceRoute {
   attributes: Record<string, any>
   signature: string // Cryptographic signature by the origin
   timestamp: number // Unix timestamp of route creation (Replay Protection)
+}
+```
+
+### PeerRecord
+
+```typescript
+interface PeerRecord {
+  name: string // Peer FQDN
+  domains: string[]
+  endpoint: string
+  peerToken?: string
+  connectionStatus: 'initializing' | 'connected' | 'degraded' | 'closed'
+  lastConnected?: Date
+  lastMessageReceived?: Date // Timestamp of last received message (any type)
+  holdTime?: number // Negotiated hold time in seconds
 }
 ```


### PR DESCRIPTION
## Summary

- Add mermaid state machine diagram for peer connection states (`initializing → connected → degraded/closed`)
- Document `degraded` vs `closed` state distinction and auto-reconnect behavior
- Add hold time negotiation section with sequence diagram
- Document CAS dispatch concurrency pattern with exponential backoff
- Add action-to-state mapping table and updated PeerRecord schema
- Add `CATALYST_HOLD_TIME` env var and config precedence documentation
- Remove outdated `KEEPALIVE_DESIGN.md` (superseded by `BGP_PROTOCOL.md`)

## Test plan

- [x] Documentation only — no code changes
- [x] Mermaid diagrams render correctly in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)