### PR TITLE
fix(envoy): replace overly broad IPv6 regex with net.isIP()

### DIFF
--- a/apps/envoy/src/xds/resources.ts
+++ b/apps/envoy/src/xds/resources.ts
@@ -97,11 +97,10 @@ const DnsLookupFamily = {
 // IP detection — determines STATIC vs STRICT_DNS cluster type
 // ---------------------------------------------------------------------------
 
-const IPV4_RE = /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)$/
-const IPV6_RE = /^[0-9a-fA-F:]+$/
+import { isIP } from 'node:net'
 
 function isIpAddress(address: string): boolean {
-  return IPV4_RE.test(address) || IPV6_RE.test(address)
+  return isIP(address) !== 0
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The IPv6 regex /^[0-9a-fA-F:]+$/ matched any string composed of hex
characters, causing hostnames like "cafe", "dead", or "abc" to be
misclassified as IP addresses. This set the cluster type to STATIC
instead of STRICT_DNS, making Envoy unable to resolve the hostname.

Replace with node:net isIP() which delegates to libc inet_pton() and
correctly handles all IPv4/IPv6 formats without false positives on
hostnames.