### PR TITLE
fix(envoy): isolate watcher callback failures in snapshot cache

### DIFF
--- a/apps/envoy/src/xds/snapshot-cache.ts
+++ b/apps/envoy/src/xds/snapshot-cache.ts
@@ -42,7 +42,13 @@ export function createSnapshotCache(): SnapshotCache {
     setSnapshot(snapshot: XdsSnapshot): void {
       current = snapshot
       for (const callback of watchers) {
-        callback(snapshot)
+        try {
+          callback(snapshot)
+        } catch {
+          // Isolate watcher failures so remaining watchers still receive
+          // the update. Without this, a single throwing callback would
+          // break the notification chain for all subsequent watchers.
+        }
       }
     },
 


### PR DESCRIPTION
The setSnapshot method iterates watchers with a plain for-of loop and
calls each callback synchronously. If any watcher throws (e.g. a gRPC
stream write fails), the exception propagates out of setSnapshot and
skips all remaining watchers in the Set. In a multi-stream scenario
this means one broken ADS connection prevents all other connected
Envoy proxies from receiving the snapshot update.

Wrapped each callback invocation in try/catch to ensure every watcher
receives the notification regardless of individual failures.