### PR TITLE
fix(envoy): add deprecation warning for legacy envoyPort derivation path

### DIFF
--- a/apps/envoy/src/rpc/server.ts
+++ b/apps/envoy/src/rpc/server.ts
@@ -106,7 +106,12 @@ export class EnvoyRpcServer extends RpcTarget {
       if (result.data.portAllocations) {
         portAllocations = { ...result.data.portAllocations }
       } else {
-        // Backward compat: derive from route.envoyPort (2-node mode)
+        // Backward compat: derive from route.envoyPort (2-node mode).
+        // This conflates local listener ports with remote upstream ports,
+        // which only works when ports are symmetric (direct 2-node links).
+        // Multi-hop routing requires explicit portAllocations.
+        this.logger
+          .warn`No portAllocations in route config — using legacy envoyPort derivation (2-node only)`
         portAllocations = {}
         for (const route of this.config.local) {
           if (route.envoyPort) {


### PR DESCRIPTION
The backward-compat path that derives portAllocations from
route.envoyPort conflates local listener ports with remote upstream
ports. This only works for direct 2-node links where ports are
symmetric. In multi-hop transit routing, the local egress listener port
(allocated by this node) differs from route.envoyPort (the upstream
peer's listening port used for the remote cluster).

Added a warning log when the fallback path is used, making it visible
that the orchestrator should provide explicit portAllocations. The
explicit path correctly separates local listener ports from upstream
remote ports via the orchestrator's port allocator.