### PR TITLE
fix(envoy): warn when ADS gRPC server binds insecure on non-loopback

### DIFF
--- a/apps/envoy/src/xds/control-plane.ts
+++ b/apps/envoy/src/xds/control-plane.ts
@@ -82,6 +82,10 @@ export class XdsControlPlane {
             return
           }
           this.started = true
+          if (this.bindAddress !== '127.0.0.1' && this.bindAddress !== '::1') {
+            this.logger
+              .warn`xDS ADS server using insecure credentials on ${this.bindAddress}:${boundPort} — xDS traffic is unencrypted`
+          }
           this.logger.info`xDS ADS server listening on ${this.bindAddress}:${boundPort}`
           resolve()
         }


### PR DESCRIPTION
The ADS server uses ServerCredentials.createInsecure() for all binds,
meaning xDS traffic (cluster configs, listener definitions, routing
rules) is sent in plaintext. When bound to a non-loopback address this
exposes the control plane to network-level interception or tampering.

Added a warning log when the bind address is not 127.0.0.1 or ::1 to
make the security posture visible in production logs. A full mTLS
implementation is deferred as a larger change.