### PR TITLE
fix(envoy): warn about unauthenticated RPC endpoint on startup

### DIFF
--- a/apps/envoy/src/service.ts
+++ b/apps/envoy/src/service.ts
@@ -27,6 +27,8 @@ export class EnvoyService extends CatalystService {
     const rpcApp = createRpcHandler(instrumentedRpc)
 
     this.handler.get('/', (c) => c.text('Catalyst Envoy Service is running.'))
+    this.telemetry.logger
+      .warn`RPC endpoint /api has no authentication — restrict network access in production`
     this.handler.route('/api', rpcApp)
 
     // Start the xDS gRPC ADS server if an xDS port is configured


### PR DESCRIPTION
The Envoy service mounts its RPC WebSocket handler at /api with no
authentication middleware. Any caller who can reach the endpoint can
invoke updateRoutes to push arbitrary xDS snapshots, potentially
redirecting traffic or modifying cluster configs.

Added a startup warning to make this security gap visible in logs.
Network-level restrictions (firewall rules, service mesh policies)
should be used to limit access until proper auth middleware is
implemented.