### PR TITLE
fix(envoy): bind admin interface to 127.0.0.1 in bootstrap configs

### DIFF
--- a/apps/envoy/envoy-bootstrap.yaml
+++ b/apps/envoy/envoy-bootstrap.yaml
@@ -14,7 +14,7 @@
 admin:
   address:
     socket_address:
-      address: 0.0.0.0
+      address: 127.0.0.1
       port_value: 9901
 
 node:

--- a/docker-compose/envoy-bootstrap.yaml
+++ b/docker-compose/envoy-bootstrap.yaml
@@ -8,7 +8,7 @@
 admin:
   address:
     socket_address:
-      address: 0.0.0.0
+      address: 127.0.0.1
       port_value: 9901
 
 node:


### PR DESCRIPTION
Both bootstrap configs (bare-metal and Docker Compose) bound the Envoy
admin interface to 0.0.0.0:9901, exposing sensitive endpoints like
/config_dump, /quitquitquit, and /drain_listeners to the network.
An attacker with network access could dump the full proxy config or
shut down the proxy entirely.

Changed both to bind to 127.0.0.1 so the admin interface is only
accessible from the local machine. Docker port mapping can be used
to explicitly expose admin access when needed.