### PR TITLE
fix(envoy): validate portAllocations values as valid TCP port numbers

### DIFF
--- a/apps/envoy/src/rpc/server.ts
+++ b/apps/envoy/src/rpc/server.ts
@@ -31,7 +31,7 @@ export const InternalRouteSchema = DataChannelDefinitionSchema.extend({
 export const RouteConfigSchema = z.object({
   local: z.array(DataChannelDefinitionSchema),
   internal: z.array(InternalRouteSchema),
-  portAllocations: z.record(z.string(), z.number()).optional(),
+  portAllocations: z.record(z.string(), z.number().int().min(1).max(65535)).optional(),
 })
 
 export type RouteConfig = z.infer<typeof RouteConfigSchema>


### PR DESCRIPTION
The portAllocations schema used z.number() which accepts any JavaScript
number including floats, negatives, zero, and values above 65535. These
invalid values would pass validation but produce Envoy configs that fail
at bind time with cryptic socket errors.

Changed to z.number().int().min(1).max(65535) to reject invalid port
values at the schema boundary with a clear Zod validation error,
preventing bad data from propagating to the xDS snapshot builder.