### PR TITLE
fix(envoy): pin Envoy Docker image to v1.32.13 for reproducible builds

### DIFF
--- a/apps/envoy/Dockerfile.envoy-proxy
+++ b/apps/envoy/Dockerfile.envoy-proxy
@@ -1,2 +1,2 @@
-FROM envoyproxy/envoy:v1.32-latest
+FROM envoyproxy/envoy:v1.32.13
 RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends curl && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The Dockerfile used envoyproxy/envoy:v1.32-latest, a mutable tag that
resolves to different images over time as patch releases are published.
Two identical CI builds on different days could pull different Envoy
versions with different behavior, making issues hard to reproduce.

Pinned to v1.32.13, the latest stable patch in the v1.32 line which
includes security fixes for CVEs in curl, gRPC, kafka, and wasmtime
dependencies.