### PR TITLE
fix(routing): constrain DataChannel name to DNS-label-safe characters

### DIFF
--- a/packages/routing/src/datachannel.ts
+++ b/packages/routing/src/datachannel.ts
@@ -10,7 +10,11 @@ export const DataChannelProtocolEnum = z.enum([
 export type DataChannelProtocol = z.infer<typeof DataChannelProtocolEnum>
 
 export const DataChannelDefinitionSchema = z.object({
-  name: z.string(),
+  name: z
+    .string()
+    .min(1)
+    .max(253)
+    .regex(/^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$/i),
   endpoint: z.url().optional(),
   protocol: DataChannelProtocolEnum,
   region: z.string().optional(),


### PR DESCRIPTION
The name field was an unconstrained z.string(), but it is interpolated
directly into Envoy resource names (ingress_${name}, local_${name},
egress_${name}_via_${peer}). Names containing slashes, null bytes,
spaces, or extremely long strings could produce invalid Envoy configs,
confuse stat prefix parsing, or create resource name collisions.

Added min(1), max(253), and a regex constraint allowing only
alphanumeric characters, hyphens, dots, and underscores with
alphanumeric start/end — matching DNS label conventions and all
existing channel name usage patterns in the codebase.