### PR TITLE
fix(envoy): set codec_type HTTP2 on gRPC listeners

### DIFF
--- a/apps/envoy/src/xds/proto-encoding.ts
+++ b/apps/envoy/src/xds/proto-encoding.ts
@@ -396,10 +396,14 @@ export function encodeListener(listener: XdsListener): {
       filters: fc.filters.map((f) => {
         // The typed_config has an '@type' field — encode the inner HCM message
         const { '@type': _typeUrl, ...hcmFields } = f.typed_config
+        const codecTypeMap: Record<string, number> = { AUTO: 0, HTTP1: 1, HTTP2: 2 }
         const hcmProto: Record<string, unknown> = {
           stat_prefix: hcmFields.stat_prefix,
           route_config: hcmFields.route_config,
           http_filters: [{ name: 'envoy.filters.http.router', typed_config: routerAny }],
+        }
+        if (hcmFields.codec_type) {
+          hcmProto.codec_type = codecTypeMap[hcmFields.codec_type] ?? 0
         }
         if (hcmFields.upgrade_configs) {
           hcmProto.upgrade_configs = hcmFields.upgrade_configs


### PR DESCRIPTION
The HttpConnectionManager codec_type defaults to AUTO which auto-detects
HTTP/1.1 vs HTTP/2 based on ALPN or connection preface. For gRPC
listeners this means Envoy accepts HTTP/1.1 connections that then fail
with confusing errors when they attempt gRPC framing over an HTTP/1.1
connection.

Added codec_type to the ListenerProtocolOptions interface and set it to
HTTP2 for http:grpc protocol channels. Updated buildHttpConnectionManager
to emit the field when set, and updated encodeListener in proto-encoding
to map the string enum to its protobuf int value (AUTO=0, HTTP1=1,
HTTP2=2).