### PR TITLE
fix(envoy): remove unused resetProtoRoot export

### DIFF
--- a/apps/envoy/src/xds/proto-encoding.ts
+++ b/apps/envoy/src/xds/proto-encoding.ts
@@ -74,11 +74,6 @@ export function getProtoRoot(): protobuf.Root {
   return _root
 }
 
-/** Reset the cached root (for testing only). */
-export function resetProtoRoot(): void {
-  _root = undefined
-}
-
 function buildProtoRoot(): protobuf.Root {
   const root = new protobuf.Root()
 


### PR DESCRIPTION
resetProtoRoot() was exported to allow tests to clear the cached
protobuf type hierarchy, but no test ever calls it. Leaving it exported
creates a risk surface where runtime code could inadvertently clear the
cache during active encoding operations. Removed the dead code.