### PR TITLE
fix(envoy): document Set insertion-order port allocation behavior

### DIFF
--- a/apps/envoy/src/port-allocator.ts
+++ b/apps/envoy/src/port-allocator.ts
@@ -70,7 +70,9 @@ export function createPortAllocator(
         return { success: true, port: existing }
       }
 
-      // Find next available port
+      // Take the first available port. Set iteration follows insertion order
+      // (ES2015 spec), so fresh ports come first and released ports go to the
+      // back — giving FIFO-like reuse that spreads port usage evenly.
       const next = available.values().next()
       if (next.done) {
         return { success: false, error: 'No ports available' }


### PR DESCRIPTION
The port allocator uses Set.values().next() to pick the next port, which
relies on ES2015 Set insertion-order iteration. After release(), ports
are re-added at the end of the Set via available.add(). This creates
FIFO-like reuse where fresh ports are used first and released ports go
to the back, spreading usage evenly across the range.

Added a comment documenting this implicit contract so future maintainers
don't accidentally break the allocation order by switching to a
different data structure.