### PR TITLE
chore: update docs and instructions

### DIFF
--- a/apps/rpi-config/src/instructions.ts
+++ b/apps/rpi-config/src/instructions.ts
@@ -34,12 +34,16 @@ export function printInstructions(
 ${prerequisite}
   To build the image:
 
+    # Option A — Docker (macOS / any host)
+    ./builds/rpi/build-docker.sh --source-dir ${absDir} ${configPath}
+
+    # Option B — Native arm64 Debian host
     ./builds/rpi/build.sh --source-dir ${absDir} ${configPath}
 
   To flash the image:
 
     sudo rpi-imager --cli \\
-      ./work/image-${opts.imageName}/${opts.imageName}.img \\
-      /dev/mmcblk0
+      ${absDir}/build/image-${opts.imageName}/${opts.imageName}.img \\
+      /dev/sdX
 `)
 }


### PR DESCRIPTION
### TL;DR

Added Docker support for building Raspberry Pi images, allowing cross-platform image generation without requiring a native arm64 Debian host.

### What changed?

- Added documentation for building Raspberry Pi images using Docker Desktop
- Updated the README to present two build options:
  - Option A: Docker-based build that works on macOS/Windows/Linux
  - Option B: Native build on arm64 Debian host (previous method)
- Updated the build instructions output to include the Docker build option
- Fixed the path in the flash instructions to correctly point to the build output directory

### How to test?

1. Generate a configuration:
```bash
bun run rpi:config -- --non-interactive --password "pass" --peering-secret "s" -o dist/rpi
```

2. Build using Docker:
```bash
bun build --compile --target=bun-linux-arm64 --outfile dist/rpi/bin/catalyst-node apps/node/src/index.ts
./builds/rpi/build-docker.sh --source-dir dist/rpi dist/rpi/config.yaml
```

3. Verify the image is created in the `dist/rpi/build/` directory

### Why make this change?

This change significantly improves developer experience by removing the requirement for a physical Raspberry Pi or arm64 Debian host to build images. Developers can now build Raspberry Pi images directly from their development machines using Docker, which works across all major platforms. This is especially beneficial for macOS users with Apple Silicon, where the container runs natively without emulation.