### PR TITLE
refactor(domain): update all domain consumers from array to single string

### DIFF
--- a/apps/cli/src/commands/node/peer.ts
+++ b/apps/cli/src/commands/node/peer.ts
@@ -15,7 +15,7 @@ export function peerCommands(): Command {
     .description('Create a new peer connection')
     .argument('<name>', 'Peer name (FQDN)')
     .argument('<endpoint>', 'WebSocket endpoint (e.g., ws://localhost:3000/rpc)')
-    .option('--domains <domains>', 'Comma-separated list of domains')
+    .option('--domain <domain>', 'Organization domain for the peer')
     .option('--peer-token <token>', 'Token for authenticating with peer')
     .option('--token <token>', 'Auth token for this operation')
     .action(async (name, endpoint, options, cmd) => {
@@ -23,7 +23,7 @@ export function peerCommands(): Command {
       const validation = CreatePeerInputSchema.safeParse({
         name,
         endpoint,
-        domains: options.domains?.split(',').map((d: string) => d.trim()) || [],
+        domain: options.domain || '',
         peerToken: options.peerToken,
         token: options.token || globals.token || process.env.CATALYST_AUTH_TOKEN,
         orchestratorUrl: globals.orchestratorUrl,
@@ -77,7 +77,7 @@ export function peerCommands(): Command {
             result.data.peers.map((p) => ({
               Name: p.name,
               Endpoint: p.endpoint,
-              Domains: p.domains?.join(', ') || '-',
+              Domain: p.domain || '-',
               Status: p.connectionStatus || 'unknown',
             }))
           )

--- a/apps/cli/src/handlers/node-peer-handlers.test.ts
+++ b/apps/cli/src/handlers/node-peer-handlers.test.ts
@@ -7,13 +7,13 @@ describe('Node Peer Handlers', () => {
       const input: CreatePeerInput = {
         name: 'test-peer.example.com',
         endpoint: 'ws://test:3000/rpc',
-        domains: ['example.com'],
+        domain: 'example.com',
         orchestratorUrl: 'ws://localhost:3000/rpc',
         logLevel: 'info',
       }
       expect(input.name).toBe('test-peer.example.com')
       expect(input.endpoint).toBe('ws://test:3000/rpc')
-      expect(input.domains).toEqual(['example.com'])
+      expect(input.domain).toBe('example.com')
     })
 
     it('should have DeletePeerInput type with required fields', () => {
@@ -60,7 +60,7 @@ describe('Node Peer Handlers', () => {
           peers: Array<{
             name: string
             endpoint: string
-            domains: string[]
+            domain: string
             connectionStatus: string
           }>
         }
@@ -71,7 +71,7 @@ describe('Node Peer Handlers', () => {
             {
               name: 'peer-a',
               endpoint: 'ws://peer-a:3000/rpc',
-              domains: ['example.com'],
+              domain: 'example.com',
               connectionStatus: 'connected',
             },
           ],

--- a/apps/cli/src/handlers/node-peer-handlers.ts
+++ b/apps/cli/src/handlers/node-peer-handlers.ts
@@ -28,7 +28,7 @@ export async function createPeerHandler(input: CreatePeerInput): Promise<CreateP
       data: {
         name: input.name,
         endpoint: input.endpoint,
-        domains: input.domains,
+        domain: input.domain,
         peerToken: input.peerToken,
       },
     })

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -27,7 +27,7 @@ export type ListServicesInput = z.infer<typeof ListServicesInputSchema>
 export const CreatePeerInputSchema = BaseCliConfigSchema.extend({
   name: z.string().min(1),
   endpoint: z.string().url(),
-  domains: z.array(z.string()).default([]),
+  domain: z.string().default(''),
   peerToken: z.string().optional(),
   token: z.string().optional(),
 })

--- a/apps/envoy/tests/service.test.ts
+++ b/apps/envoy/tests/service.test.ts
@@ -52,7 +52,7 @@ function createMinimalConfig(overrides: Partial<CatalystConfig> = {}): CatalystC
   return {
     node: {
       name: 'test-node',
-      domains: ['test.local'],
+      domain: 'test.local',
     },
     port: 3000,
     ...overrides,

--- a/apps/orchestrator/src/orchestrator.ts
+++ b/apps/orchestrator/src/orchestrator.ts
@@ -109,7 +109,7 @@ export class ConnectionPool {
 interface AuthServicePermissionsHandlers {
   authorizeAction(request: {
     action: string
-    nodeContext: { nodeId: string; domains: string[] }
+    nodeContext: { nodeId: string; domain: string }
   }): Promise<
     | { success: true; allowed: boolean }
     | {
@@ -174,14 +174,10 @@ export class CatalystNodeBus extends RpcTarget {
   }
 
   private validateNodeConfig() {
-    const { name, domains } = this.config.node
-    if (!name.endsWith('.somebiz.local.io')) {
-      throw new Error(`Invalid node name: ${name}. Must end with .somebiz.local.io`)
-    }
-    const domainMatch = domains.some((d) => name.endsWith(`.${d}`))
-    if (!domainMatch && domains.length > 0) {
+    const { name, domain } = this.config.node
+    if (domain && !name.endsWith(`.${domain}`)) {
       throw new Error(
-        `Node name ${name} does not match any configured domains: ${domains.join(', ')}`
+        `Node name ${name} does not match configured domain: ${domain}. Expected format: {nodeId}.${domain}`
       )
     }
   }
@@ -213,7 +209,7 @@ export class CatalystNodeBus extends RpcTarget {
         action,
         nodeContext: {
           nodeId: this.config.node.name,
-          domains: this.config.node.domains,
+          domain: this.config.node.domain,
         },
       })
 
@@ -291,7 +287,7 @@ export class CatalystNodeBus extends RpcTarget {
               {
                 name: action.data.name,
                 endpoint: action.data.endpoint,
-                domains: action.data.domains,
+                domain: action.data.domain,
                 peerToken: action.data.peerToken,
                 connectionStatus: 'initializing' as const,
                 lastConnected: undefined,
@@ -318,7 +314,7 @@ export class CatalystNodeBus extends RpcTarget {
                 ? {
                     ...p,
                     endpoint: action.data.endpoint,
-                    domains: action.data.domains,
+                    domain: action.data.domain,
                     peerToken: action.data.peerToken,
                     connectionStatus: 'initializing',
                     lastConnected: undefined,

--- a/apps/orchestrator/src/service.ts
+++ b/apps/orchestrator/src/service.ts
@@ -136,7 +136,7 @@ export class OrchestratorService extends CatalystService {
           type: 'service',
           nodeId: this.config.node.name,
           trustedNodes: [], // Empty for now - could be populated from peer config
-          trustedDomains: this.config.node.domains, // Domains this node trusts
+          trustedDomains: this.config.node.domain ? [this.config.node.domain] : [],
         },
         principal: Principal.NODE,
         expiresIn: '7d', // Node token valid for 7 days

--- a/apps/orchestrator/tests/auth-test-helpers.ts
+++ b/apps/orchestrator/tests/auth-test-helpers.ts
@@ -125,14 +125,14 @@ export function extractSystemTokenFromLogs(logs: string[]): string {
  * @param authEndpoint - WebSocket endpoint of the auth service
  * @param systemToken - System admin token for the auth service
  * @param peerName - Name of the peer node that will use this token
- * @param domains - Domains the peer token should be valid for
+ * @param domain - Organization domain the peer token should be valid for
  * @returns Peer token string
  */
 export async function mintPeerToken(
   authEndpoint: string,
   systemToken: string,
   peerName: string,
-  domains: string[]
+  domain: string
 ): Promise<string> {
   console.log(`Minting peer token for ${peerName} from ${authEndpoint}...`)
   const authClient = newWebSocketRpcSession<AuthServiceApi>(authEndpoint)
@@ -148,7 +148,7 @@ export async function mintPeerToken(
       id: peerName,
       name: peerName,
       type: 'service',
-      trustedDomains: domains,
+      trustedDomains: domain ? [domain] : [],
       trustedNodes: [], // Empty = trust all nodes
     },
     principal: Principal.NODE,

--- a/packages/authorization/src/service/rpc/schema.ts
+++ b/packages/authorization/src/service/rpc/schema.ts
@@ -206,7 +206,7 @@ export const PermissionsApiRequestSchema = z.string() // token
 
 export const NodeContextSchema = z.object({
   nodeId: z.string(),
-  domains: z.array(z.string()),
+  domain: z.string(),
 })
 
 export type NodeContext = z.infer<typeof NodeContextSchema>

--- a/packages/authorization/src/service/rpc/server.ts
+++ b/packages/authorization/src/service/rpc/server.ts
@@ -242,7 +242,7 @@ export class AuthRpcServer extends RpcTarget {
         builder.entity(principal.uid.type, principal.uid.id).setAttributes(principal.attrs)
         builder.entity('CATALYST::AdminPanel', 'admin-panel').setAttributes({
           nodeId: request.nodeContext.nodeId,
-          domainId: request.nodeContext.domains[0] || '', // Use first domain
+          domainId: request.nodeContext.domain,
         })
 
         const entities = builder.build()

--- a/packages/authorization/src/service/service.ts
+++ b/packages/authorization/src/service/service.ts
@@ -67,7 +67,7 @@ export class AuthService extends CatalystService {
         id: 'system',
         name: 'System Admin',
         type: 'service',
-        trustedDomains: this.config.node.domains,
+        trustedDomains: this.config.node.domain ? [this.config.node.domain] : [],
         trustedNodes: [],
       },
       principal: Principal.ADMIN,
@@ -82,7 +82,7 @@ export class AuthService extends CatalystService {
       this.telemetry,
       policyService,
       this.config.node.name,
-      this.config.node.domains[0] || ''
+      this.config.node.domain
     )
     this._rpcServer.setSystemToken(this._systemToken)
 


### PR DESCRIPTION
Update all code that referenced `config.node.domains` (array) to use
`config.node.domain` (single string). This includes authorization
service, orchestrator, CLI types/handlers/commands, RPC schema, and
test helpers.

Also replaces the hardcoded `somebiz.local.io` validation in
`validateNodeConfig()` with configurable FQDN validation against
the configured domain.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>