### PR TITLE
fix(node): fix Dockerfile permissions for default database paths

### DIFF
--- a/apps/node/Dockerfile
+++ b/apps/node/Dockerfile
@@ -77,10 +77,13 @@ WORKDIR /app/apps/node
 RUN mkdir -p /app/data
 
 ENV PORT=3000
+ENV CATALYST_AUTH_KEYS_DB=/app/data/keys.db
+ENV CATALYST_AUTH_TOKENS_DB=/app/data/tokens.db
 EXPOSE 3000
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
-RUN chown -R appuser:appgroup /app/data
+# Chown both the data directory AND the working directory
+RUN chown -R appuser:appgroup /app/data /app/apps/node
 USER appuser
 
 CMD ["bun", "run", "src/index.ts"]


### PR DESCRIPTION
Set ENV defaults for CATALYST_AUTH_KEYS_DB and CATALYST_AUTH_TOKENS_DB
to /app/data/ so the non-root appuser can write SQLite databases.
Also chown /app/apps/node so user-defined relative paths work too.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>