### PR TITLE
fix(envoy): add missing testcontainers dep and correct HCM upgrade_configs field number

### DIFF
--- a/apps/envoy/package.json
+++ b/apps/envoy/package.json
@@ -24,6 +24,7 @@
     "@catalyst/authorization": "catalog:",
     "@catalyst/orchestrator-service": "catalog:",
     "@types/bun": "catalog:dev",
+    "testcontainers": "catalog:testing",
     "typescript": "catalog:dev"
   }
 }

--- a/apps/envoy/src/xds/proto-encoding.ts
+++ b/apps/envoy/src/xds/proto-encoding.ts
@@ -233,7 +233,7 @@ function buildProtoRoot(): protobuf.Root {
       .add(
         new protobuf.Field(
           'upgrade_configs',
-          6,
+          23,
           'envoy.extensions.filters.network.http_connection_manager.v3.UpgradeConfig',
           'repeated'
         )

--- a/apps/orchestrator/tests/peering.orchestrator.topology.container.test.ts
+++ b/apps/orchestrator/tests/peering.orchestrator.topology.container.test.ts
@@ -107,8 +107,8 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
         return container
       }
 
-      nodeA = await startNode('node-a.somebiz.local.io', 'node-a')
-      nodeB = await startNode('node-b.somebiz.local.io', 'node-b')
+      nodeA = await startNode('node-a.somebiz.local.io', 'shared-node-a')
+      nodeB = await startNode('node-b.somebiz.local.io', 'shared-node-b')
 
       console.log('All nodes started.')
     }, TIMEOUT)
@@ -197,12 +197,12 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
         // Setup B to accept A first, then A connects to B
         await netB.addPeer({
           name: 'node-a.somebiz.local.io',
-          endpoint: 'ws://node-a:3000/rpc',
+          endpoint: 'ws://shared-node-a:3000/rpc',
           domains: ['somebiz.local.io'],
         })
         await netA.addPeer({
           name: 'node-b.somebiz.local.io',
-          endpoint: 'ws://node-b:3000/rpc',
+          endpoint: 'ws://shared-node-b:3000/rpc',
           domains: ['somebiz.local.io'],
         })
 
@@ -316,13 +316,13 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
 
       nodeA = await startNode(
         'node-a.somebiz.local.io',
-        'node-a',
+        'sep-node-a',
         authA.endpoint,
         authA.systemToken
       )
       nodeB = await startNode(
         'node-b.somebiz.local.io',
-        'node-b',
+        'sep-node-b',
         authB.endpoint,
         authB.systemToken
       )
@@ -428,14 +428,14 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
         // B→A uses token minted by Auth-A
         await netB.addPeer({
           name: 'node-a.somebiz.local.io',
-          endpoint: 'ws://node-a:3000/rpc',
+          endpoint: 'ws://sep-node-a:3000/rpc',
           domains: ['somebiz.local.io'],
           peerToken: peerTokenBtoA,
         })
         // A→B uses token minted by Auth-B
         await netA.addPeer({
           name: 'node-b.somebiz.local.io',
-          endpoint: 'ws://node-b:3000/rpc',
+          endpoint: 'ws://sep-node-b:3000/rpc',
           domains: ['somebiz.local.io'],
           peerToken: peerTokenAtoB,
         })

--- a/bun.lock
+++ b/bun.lock
@@ -38,24 +38,6 @@
         "vitest": "^1.2.1",
       },
     },
-    "apps/catalyst-zenoh-bridge": {
-      "name": "@catalyst/zenoh-bridge",
-      "version": "0.0.1",
-      "dependencies": {
-        "@catalyst/config": "catalog:",
-        "@catalyst/routing": "catalog:",
-        "@catalyst/service": "catalog:",
-        "@catalyst/telemetry": "catalog:",
-        "@hono/capnweb": "catalog:",
-        "capnweb": "catalog:",
-        "hono": "catalog:",
-        "zod": "catalog:",
-      },
-      "devDependencies": {
-        "@types/bun": "catalog:dev",
-        "typescript": "catalog:dev",
-      },
-    },
     "apps/cli": {
       "name": "@catalyst/cli",
       "version": "0.0.0",
@@ -104,6 +86,7 @@
         "@catalyst/authorization": "catalog:",
         "@catalyst/orchestrator-service": "catalog:",
         "@types/bun": "catalog:dev",
+        "testcontainers": "catalog:testing",
         "typescript": "catalog:dev",
       },
     },
@@ -542,8 +525,6 @@
     "@catalyst/telemetry": ["@catalyst/telemetry@workspace:packages/telemetry"],
 
     "@catalyst/types": ["@catalyst/types@workspace:packages/types"],
-
-    "@catalyst/zenoh-bridge": ["@catalyst/zenoh-bridge@workspace:apps/catalyst-zenoh-bridge"],
 
     "@cedar-policy/cedar-wasm": ["@cedar-policy/cedar-wasm@4.8.2", "", {}, "sha512-S37Kd4wP/IMZN3pdKEcsV8av7jMj4AKRovxzJEYZNTEYq0Wj4fno3dsw8xHHDXqT0dkQGTNUBuQNF8CTvOgE/Q=="],
 


### PR DESCRIPTION
- Add testcontainers to apps/envoy devDependencies so container tests can
  resolve the import
- Fix proto field number for upgrade_configs from 6 to 23 in
  HttpConnectionManager definition. Field 6 in the real Envoy proto is
  add_user_agent (BoolValue), causing Envoy to NACK listener configs that
  include WebSocket upgrade support.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>