### PR TITLE
fix(build-docker): working version of rpi image building

### DIFF
--- a/builds/rpi/Dockerfile.build
+++ b/builds/rpi/Dockerfile.build
@@ -22,6 +22,18 @@ FROM debian:bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# ---------- Configure apt resilience ----------
+# mmdebstrap inherits the host apt configuration, so these settings apply to
+# both the Docker image build AND the chroot bootstrap (where transient mirror
+# issues like hash-sum mismatches from CDN sync races are common).
+RUN mkdir -p /etc/apt/apt.conf.d && \
+    printf '%s\n' \
+      'Acquire::Retries "3";' \
+      'Acquire::http::No-Cache "true";' \
+      'Acquire::https::No-Cache "true";' \
+      'Acquire::http::Pipeline-Depth "0";' \
+      > /etc/apt/apt.conf.d/80retries
+
 # ---------- Install all rpi-image-gen dependencies ----------
 # Sourced from rpi-image-gen/depends manifest. We install everything upfront
 # so install_deps.sh doesn't need to run at build time (avoids binfmt_misc


### PR DESCRIPTION
### TL;DR

Add retry logic and apt resilience configuration to handle transient mirror issues during Raspberry Pi image builds.

### What changed?

- Added apt configuration in `Dockerfile.build` to improve resilience:
  - Set `Acquire::Retries` to 3
  - Disabled caching with `No-Cache` settings
  - Disabled pipelining with `Pipeline-Depth 0`

- Enhanced `build-docker.sh` with retry logic:
  - Added a maximum of 3 retry attempts for builds
  - Added apt index refresh between retry attempts
  - Improved error messages to indicate potential mirror sync issues
  - Added guidance for "Hash Sum mismatch" errors

### How to test?

Run the Raspberry Pi image build process and verify it can recover from transient apt mirror issues. You can simulate failures by temporarily modifying apt sources or network conditions.

### Why make this change?

The Raspberry Pi apt mirrors (particularly archive.raspberrypi.com) frequently experience CDN sync races that cause hash-sum mismatches. These transient issues were causing builds to fail unnecessarily. The added retry logic and apt configuration makes the build process more resilient to these common mirror problems, reducing build failures and improving developer experience.