### PR TITLE
feat(rpi-autologin): added new autologin and journalctl log stream as default behaviour

### DIFF
--- a/apps/rpi-config/src/config-builder.ts
+++ b/apps/rpi-config/src/config-builder.ts
@@ -61,6 +61,11 @@ export function buildConfig(opts: ResolvedOptions): RpiImageGenConfig {
     }
   }
 
+  // --- Console autologin + journal stream (optional) ---
+  if (opts.autologin !== false) {
+    config.layer.console = 'catalyst-console'
+  }
+
   // --- Catalyst node config ---
   config.catalyst = {
     ...(opts.mode === 'docker' && opts.registry

--- a/apps/rpi-config/src/index.ts
+++ b/apps/rpi-config/src/index.ts
@@ -62,6 +62,8 @@ program
   .addOption(new Option('--cloudflared-token <token>', 'Cloudflare Tunnel token'))
   .addOption(new Option('--no-cloudflared', 'Skip cloudflared'))
 
+  .addOption(new Option('--no-autologin', 'Skip console autologin + journal stream'))
+
   .addOption(new Option('--image-name <name>', 'Output image name').default(DEFAULTS.imageName))
   .addOption(
     new Option('--boot-part-size <size>', 'Boot partition size').default(DEFAULTS.bootPartSize)

--- a/apps/rpi-config/src/instructions.ts
+++ b/apps/rpi-config/src/instructions.ts
@@ -53,5 +53,15 @@ ${prerequisite}
     sudo rpi-imager --cli \\
       ${absDir}/build/image-${opts.imageName}/${opts.imageName}.img \\
       /dev/sdX
-`)
+${
+  opts.autologin !== false
+    ? `
+  Console:
+
+    Autologin is enabled on tty1. The physical console will automatically
+    log in as "${opts.username}" and stream the systemd journal.
+    Press Ctrl+C on the console to drop to an interactive shell.
+`
+    : ''
+}`)
 }

--- a/apps/rpi-config/src/prompts.ts
+++ b/apps/rpi-config/src/prompts.ts
@@ -141,6 +141,18 @@ export async function promptMissing(opts: Record<string, unknown>): Promise<Reso
     })
   }
 
+  // --- Console autologin ---
+  section('Console')
+  if (resolved.autologin !== false) {
+    const wantAutologin = await confirm({
+      message: 'Enable autologin with journal streaming on console?',
+      default: true,
+    })
+    if (!wantAutologin) {
+      resolved.autologin = false
+    }
+  }
+
   // --- Cloudflared ---
   section('Remote Access')
   if (resolved.cloudflared !== false && !resolved.cloudflaredToken) {

--- a/apps/rpi-config/src/types.ts
+++ b/apps/rpi-config/src/types.ts
@@ -23,6 +23,7 @@ export interface ResolvedOptions {
   otelVersion: string
   cloudflaredToken?: string
   cloudflared?: boolean
+  autologin?: boolean
   imageName: string
   bootPartSize: string
   rootPartSize: string

--- a/apps/rpi-config/src/yaml-writer.ts
+++ b/apps/rpi-config/src/yaml-writer.ts
@@ -48,6 +48,7 @@ const INLINE_COMMENTS: Record<string, Record<string, string | ((val: string) => 
     app: 'Catalyst Node composite server',
     container: 'Docker CE engine (built-in layer)',
     wifi: 'WiFi (wpa_supplicant + systemd-networkd)',
+    console: 'Console autologin + journal stream',
     tunnel: 'Cloudflare Tunnel for remote SSH',
   },
   wifi: {

--- a/builds/rpi/layer/catalyst-console.yaml
+++ b/builds/rpi/layer/catalyst-console.yaml
@@ -1,0 +1,37 @@
+# METABEGIN
+# X-Env-Layer-Name: catalyst-console
+# X-Env-Layer-Category: sys
+# X-Env-Layer-Desc: Autologin on tty1 and live systemd journal stream.
+#  Automatically logs in the configured user on the physical console
+#  and follows all journal entries so you can monitor services at a glance.
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Requires: systemd-min,rpi-user-credentials
+#
+# X-Env-VarRequires: IGconf_device_user1
+# X-Env-VarRequires-Valid: string
+# METAEND
+---
+mmdebstrap:
+  customize-hooks:
+    # Enable autologin on tty1 for the configured user
+    - |-
+      mkdir -p "$1/etc/systemd/system/getty@tty1.service.d"
+      cat > "$1/etc/systemd/system/getty@tty1.service.d/autologin.conf" <<ALEOF
+      [Service]
+      ExecStart=
+      ExecStart=-/sbin/agetty --autologin $IGconf_device_user1 --noclear %I \$TERM
+      ALEOF
+    # Stream systemd journal on tty1 login
+    - |-
+      HOME_DIR="$1/home/$IGconf_device_user1"
+      mkdir -p "$HOME_DIR"
+      cat >> "$HOME_DIR/.bash_profile" <<'BPEOF'
+
+      # --- Catalyst Console: live journal stream on tty1 ---
+      if [ "$(tty)" = "/dev/tty1" ]; then
+        printf '\n\033[1m=== Catalyst Node — Journal Stream ===\033[0m\n'
+        printf 'Press Ctrl+C for an interactive shell.\n\n'
+        journalctl -f --no-hostname -o short-precise
+      fi
+      BPEOF
+      chown -R 1000:1000 "$HOME_DIR/.bash_profile"


### PR DESCRIPTION
### TL;DR

Added console autologin with journal streaming for Raspberry Pi images.

### What changed?

- Added a new `catalyst-console` layer that enables autologin on tty1 for the configured user
- When logged in on the physical console, the system automatically streams the systemd journal
- Added a `--no-autologin` CLI option to disable this feature if desired
- Updated the configuration builder to include the console layer when autologin is enabled
- Enhanced the post-build instructions to inform users about the console autologin feature
- Added the layer definition both as embedded content and as a standalone YAML file

### How to test?

1. Build a Raspberry Pi image with the default settings (autologin enabled)
2. Flash the image to an SD card and boot a Raspberry Pi with a monitor connected
3. Verify that the console automatically logs in and displays the systemd journal stream
4. Press Ctrl+C to drop to an interactive shell
5. Build another image with `--no-autologin` and verify that automatic login doesn't occur

### Why make this change?

This feature improves the user experience for physical Raspberry Pi deployments by providing immediate visibility into system status without requiring manual login. The journal stream allows users to monitor services at a glance, which is particularly useful during initial setup and troubleshooting. The ability to press Ctrl+C to get an interactive shell maintains flexibility for users who need to interact with the system directly.