### PR TITLE
fix(orchestrator): enforce mandatory peerToken and fix cross-node route sync

### DIFF
--- a/apps/cli/src/handlers/node-peer-handlers.ts
+++ b/apps/cli/src/handlers/node-peer-handlers.ts
@@ -30,6 +30,7 @@ export async function createPeerHandler(input: CreatePeerInput): Promise<CreateP
       name: input.name,
       endpoint: input.endpoint,
       domains: input.domains,
+      peerToken: input.peerToken,
     })
 
     if (result.success) {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,7 +1,6 @@
 import { Command } from 'commander'
 import { nodeCommands } from './commands/node/index.js'
 import { authCommands } from './commands/auth/index.js'
-import { graphqlCommands } from './commands/graphql/index.js'
 
 const program = new Command()
 
@@ -24,6 +23,5 @@ program
 
 program.addCommand(nodeCommands())
 program.addCommand(authCommands())
-program.addCommand(graphqlCommands())
 
 program.parse(process.argv)

--- a/apps/cli/tests/node/peer.container.test.ts
+++ b/apps/cli/tests/node/peer.container.test.ts
@@ -153,6 +153,7 @@ describe.skipIf(skipTests)('Peer Commands Container Tests', () => {
         name: 'test-peer.somebiz.local.io',
         endpoint: 'ws://test-peer:3000/rpc',
         domains: ['example.com'],
+        peerToken: systemToken,
         connectionStatus: 'disconnected',
       })
       expect(createResult.success).toBe(true)

--- a/apps/envoy/tests/cross-node-routing.container.test.ts
+++ b/apps/envoy/tests/cross-node-routing.container.test.ts
@@ -435,11 +435,13 @@ describe.skipIf(skipTests)('Cross-Node Routing: All-Container E2E with Real Envo
       name: 'node-a.somebiz.local.io',
       endpoint: 'ws://orch-a:3000/rpc',
       domains: ['somebiz.local.io'],
+      peerToken: systemToken,
     })
     await netA.addPeer({
       name: 'node-b.somebiz.local.io',
       endpoint: 'ws://orch-b:3000/rpc',
       domains: ['somebiz.local.io'],
+      peerToken: systemToken,
     })
 
     // Wait for BGP handshake

--- a/apps/envoy/tests/three-node-hop.container.test.ts
+++ b/apps/envoy/tests/three-node-hop.container.test.ts
@@ -374,11 +374,13 @@ async function setupThreeNodeCluster(protocol: string): Promise<ThreeNodeCluster
     name: 'node-a.somebiz.local.io',
     endpoint: 'ws://orch-a:3000/rpc',
     domains: ['somebiz.local.io'],
+    peerToken: systemToken,
   })
   await netA.addPeer({
     name: 'node-b.somebiz.local.io',
     endpoint: 'ws://orch-b:3000/rpc',
     domains: ['somebiz.local.io'],
+    peerToken: systemToken,
   })
 
   // Peer B <-> C: C accepts B, then B connects to C
@@ -386,11 +388,13 @@ async function setupThreeNodeCluster(protocol: string): Promise<ThreeNodeCluster
     name: 'node-b.somebiz.local.io',
     endpoint: 'ws://orch-b:3000/rpc',
     domains: ['somebiz.local.io'],
+    peerToken: systemToken,
   })
   await netB.addPeer({
     name: 'node-c.somebiz.local.io',
     endpoint: 'ws://orch-c:3000/rpc',
     domains: ['somebiz.local.io'],
+    peerToken: systemToken,
   })
 
   // Brief wait for BGP handshake before polling

--- a/apps/orchestrator/tests/orchestrator.container.test.ts
+++ b/apps/orchestrator/tests/orchestrator.container.test.ts
@@ -7,7 +7,6 @@ import {
   type StartedTestContainer,
 } from 'testcontainers'
 
-
 import path from 'path'
 import type { Readable } from 'node:stream'
 import { newWebSocketRpcSession, type RpcStub } from 'capnweb'
@@ -170,11 +169,13 @@ describe.skipIf(skipTests)('Orchestrator Container Tests (Next)', () => {
         name: 'node-a.somebiz.local.io',
         endpoint: 'ws://node-a:3000/rpc',
         domains: ['somebiz.local.io'],
+        peerToken: systemToken,
       })
       await netA.addPeer({
         name: 'node-b.somebiz.local.io',
         endpoint: 'ws://node-b:3000/rpc',
         domains: ['somebiz.local.io'],
+        peerToken: systemToken,
       })
 
       // Give it a moment for the handshake
@@ -228,11 +229,13 @@ describe.skipIf(skipTests)('Orchestrator Container Tests (Next)', () => {
         name: 'node-b.somebiz.local.io',
         endpoint: 'ws://node-b:3000/rpc',
         domains: ['somebiz.local.io'],
+        peerToken: systemToken,
       })
       await netB.addPeer({
         name: 'node-c.somebiz.local.io',
         endpoint: 'ws://node-c:3000/rpc',
         domains: ['somebiz.local.io'],
+        peerToken: systemToken,
       })
 
       // Give it a moment for the handshake

--- a/apps/orchestrator/tests/orchestrator.envoy.test.ts
+++ b/apps/orchestrator/tests/orchestrator.envoy.test.ts
@@ -124,6 +124,7 @@ describe('CatalystNodeBus > Envoy Integration', () => {
       name: 'node-b.somebiz.local.io',
       endpoint: 'http://node-b:3000',
       domains: ['somebiz.local.io'],
+      peerToken: 'token-for-b',
     }
 
     await bus.dispatch({ action: Actions.LocalPeerCreate, data: peerInfo })
@@ -173,6 +174,7 @@ describe('CatalystNodeBus > Envoy Integration', () => {
       name: 'node-b.somebiz.local.io',
       endpoint: 'http://node-b:3000',
       domains: ['somebiz.local.io'],
+      peerToken: 'token-for-b',
     }
 
     await bus.dispatch({ action: Actions.LocalPeerCreate, data: peerInfo })
@@ -315,11 +317,13 @@ describe('CatalystNodeBus > Envoy Integration', () => {
       endpoint: 'http://node-b:3000',
       domains: ['somebiz.local.io'],
       envoyAddress: 'envoy-proxy-b',
+      peerToken: 'token-for-b',
     }
     const peerC: PeerInfo = {
       name: 'node-c.somebiz.local.io',
       endpoint: 'http://node-c:3000',
       domains: ['somebiz.local.io'],
+      peerToken: 'token-for-c',
     }
 
     // Connect both peers
@@ -393,11 +397,13 @@ describe('CatalystNodeBus > Envoy Integration', () => {
       name: 'node-b.somebiz.local.io',
       endpoint: 'http://node-b:3000',
       domains: ['somebiz.local.io'],
+      peerToken: 'token-for-b',
     }
     const peerC: PeerInfo = {
       name: 'node-c.somebiz.local.io',
       endpoint: 'http://node-c:3000',
       domains: ['somebiz.local.io'],
+      peerToken: 'token-for-c',
     }
 
     await plainBus.dispatch({ action: Actions.LocalPeerCreate, data: peerB })
@@ -452,6 +458,7 @@ describe('CatalystNodeBus > Envoy Integration', () => {
       endpoint: 'http://node-b:3000',
       domains: ['somebiz.local.io'],
       envoyAddress: 'envoy-proxy-b',
+      peerToken: 'token-for-b',
     }
 
     await bus.dispatch({ action: Actions.LocalPeerCreate, data: peerB })
@@ -489,6 +496,7 @@ describe('CatalystNodeBus > Envoy Integration', () => {
       name: 'node-c.somebiz.local.io',
       endpoint: 'http://node-c:3000',
       domains: ['somebiz.local.io'],
+      peerToken: 'token-for-c',
     }
 
     await bus.dispatch({ action: Actions.LocalPeerCreate, data: peerC })
@@ -521,6 +529,7 @@ describe('CatalystNodeBus > Envoy Integration', () => {
       name: 'node-b.somebiz.local.io',
       endpoint: 'http://node-b:3000',
       domains: ['somebiz.local.io'],
+      peerToken: 'token-for-b',
     }
 
     await bus.dispatch({ action: Actions.LocalPeerCreate, data: peerInfo })
@@ -577,11 +586,13 @@ describe('CatalystNodeBus > Envoy Integration', () => {
       endpoint: 'http://node-b:3000',
       domains: ['somebiz.local.io'],
       envoyAddress: 'envoy-proxy-b',
+      peerToken: 'token-for-b',
     }
     const peerC: PeerInfo = {
       name: 'node-c.somebiz.local.io',
       endpoint: 'http://node-c:3000',
       domains: ['somebiz.local.io'],
+      peerToken: 'token-for-c',
     }
 
     await envoyBus.dispatch({ action: Actions.LocalPeerCreate, data: peerB })
@@ -634,11 +645,13 @@ describe('CatalystNodeBus > Envoy Integration', () => {
       endpoint: 'http://node-b:3000',
       domains: ['somebiz.local.io'],
       envoyAddress: 'envoy-proxy-b',
+      peerToken: 'token-for-b',
     }
     const peerC: PeerInfo = {
       name: 'node-c.somebiz.local.io',
       endpoint: 'http://node-c:3000',
       domains: ['somebiz.local.io'],
+      peerToken: 'token-for-c',
     }
 
     // Connect both peers

--- a/apps/orchestrator/tests/orchestrator.gateway.container.test.ts
+++ b/apps/orchestrator/tests/orchestrator.gateway.container.test.ts
@@ -201,11 +201,13 @@ describe.skipIf(skipTests)('Orchestrator Gateway Container Tests', () => {
           name: 'peer-a.somebiz.local.io',
           endpoint: 'ws://peer-a:3000/rpc',
           domains: ['somebiz.local.io'],
+          peerToken: auth.systemToken,
         })
         await netA.addPeer({
           name: 'peer-b.somebiz.local.io',
           endpoint: 'ws://peer-b:3000/rpc',
           domains: ['somebiz.local.io'],
+          peerToken: auth.systemToken,
         })
 
         // Give it a moment for the handshake

--- a/apps/orchestrator/tests/orchestrator.topology.test.ts
+++ b/apps/orchestrator/tests/orchestrator.topology.test.ts
@@ -14,16 +14,19 @@ describe('Orchestrator Topology Tests', () => {
     name: 'node-a.somebiz.local.io',
     endpoint: 'ws://node-a',
     domains: ['somebiz.local.io'],
+    peerToken: 'token-for-a',
   }
   const infoB: PeerInfo = {
     name: 'node-b.somebiz.local.io',
     endpoint: 'ws://node-b',
     domains: ['somebiz.local.io'],
+    peerToken: 'token-for-b',
   }
   const infoC: PeerInfo = {
     name: 'node-c.somebiz.local.io',
     endpoint: 'ws://node-c',
     domains: ['somebiz.local.io'],
+    peerToken: 'token-for-c',
   }
 
   beforeEach(() => {

--- a/apps/orchestrator/tests/peering.orchestrator.topology.container.test.ts
+++ b/apps/orchestrator/tests/peering.orchestrator.topology.container.test.ts
@@ -199,11 +199,13 @@ describe.skipIf(skipTests)('Orchestrator Peering Container Tests', () => {
           name: 'node-a.somebiz.local.io',
           endpoint: 'ws://shared-node-a:3000/rpc',
           domains: ['somebiz.local.io'],
+          peerToken: auth.systemToken,
         })
         await netA.addPeer({
           name: 'node-b.somebiz.local.io',
           endpoint: 'ws://shared-node-b:3000/rpc',
           domains: ['somebiz.local.io'],
+          peerToken: auth.systemToken,
         })
 
         // Wait for handshake

--- a/apps/orchestrator/tests/peering.orchestrator.topology.test.ts
+++ b/apps/orchestrator/tests/peering.orchestrator.topology.test.ts
@@ -12,11 +12,13 @@ describe('Orchestrator Peering Tests (Mocked Container Logic)', () => {
     name: 'node-a.somebiz.local.io',
     endpoint: 'ws://node-a',
     domains: ['somebiz.local.io'],
+    peerToken: 'token-for-a',
   }
   const infoB: PeerInfo = {
     name: 'node-b.somebiz.local.io',
     endpoint: 'ws://node-b',
     domains: ['somebiz.local.io'],
+    peerToken: 'token-for-b',
   }
 
   beforeEach(() => {
@@ -41,6 +43,52 @@ describe('Orchestrator Peering Tests (Mocked Container Logic)', () => {
       await (node as unknown as { lastNotificationPromise?: Promise<void> }).lastNotificationPromise
     }
   }
+
+  it('Routes registered before peering propagate bidirectionally', async () => {
+    // Regression: when routes exist before peering is established, the
+    // sync-on-connect code path in InternalProtocolOpen/Connected must
+    // push pre-existing routes to the new peer in both directions.
+    const apiA = nodeA.publicApi()
+    const apiB = nodeB.publicApi()
+
+    const netA = (
+      (await apiA.getNetworkClient('secret')) as { success: true; client: NetworkClient }
+    ).client
+    const netB = (
+      (await apiB.getNetworkClient('secret')) as { success: true; client: NetworkClient }
+    ).client
+
+    // 1. Register routes BEFORE peering
+    const dataA = (
+      (await apiA.getDataChannelClient('secret')) as { success: true; client: DataChannel }
+    ).client
+    const dataB = (
+      (await apiB.getDataChannelClient('secret')) as { success: true; client: DataChannel }
+    ).client
+
+    await dataA.addRoute({ name: 'books-a', protocol: 'http' as const, endpoint: 'http://a:8080' })
+    await dataB.addRoute({ name: 'books-b', protocol: 'http' as const, endpoint: 'http://b:8080' })
+
+    // 2. Establish peering (B adds A first, then A adds B)
+    await netB.addPeer(infoA)
+    await netA.addPeer(infoB)
+
+    await waitForNotification(nodeA)
+    await waitForNotification(nodeB)
+    await new Promise((r) => setTimeout(r, 100))
+
+    // 3. Both sides should have learned the other's route
+    const stateA = (nodeA as unknown as { state: RouteTable }).state
+    const stateB = (nodeB as unknown as { state: RouteTable }).state
+
+    const booksB_onA = stateA.internal.routes.find((r) => r.name === 'books-b')
+    expect(booksB_onA).toBeDefined()
+    expect(booksB_onA?.nodePath).toEqual(['node-b.somebiz.local.io'])
+
+    const booksA_onB = stateB.internal.routes.find((r) => r.name === 'books-a')
+    expect(booksA_onB).toBeDefined()
+    expect(booksA_onB?.nodePath).toEqual(['node-a.somebiz.local.io'])
+  })
 
   it('Simple Peering: A <-> B propagation', async () => {
     // 1. Establish Peering
@@ -97,5 +145,25 @@ describe('Orchestrator Peering Tests (Mocked Container Logic)', () => {
 
     expect(learnedRoute).toBeDefined()
     expect(learnedRoute?.nodePath).toEqual(['node-a.somebiz.local.io'])
+  })
+
+  it('addPeer rejects when peerToken is missing', async () => {
+    const apiA = nodeA.publicApi()
+    const netAResult = await apiA.getNetworkClient('secret')
+    expect(netAResult.success).toBe(true)
+
+    const netA = (netAResult as { success: true; client: NetworkClient }).client
+
+    const result = await netA.addPeer({
+      name: 'node-b.somebiz.local.io',
+      endpoint: 'ws://node-b',
+      domains: ['somebiz.local.io'],
+      // peerToken intentionally omitted
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toContain('peerToken is required')
+    }
   })
 })

--- a/apps/orchestrator/tests/transit.orchestrator.topology.container.test.ts
+++ b/apps/orchestrator/tests/transit.orchestrator.topology.container.test.ts
@@ -185,11 +185,13 @@ describe.skipIf(skipTests)('Orchestrator Transit Container Tests', () => {
           name: 'node-a.somebiz.local.io',
           endpoint: 'ws://node-a:3000/rpc',
           domains: ['somebiz.local.io'],
+          peerToken: auth.systemToken,
         })
         await netA.addPeer({
           name: 'node-b.somebiz.local.io',
           endpoint: 'ws://node-b:3000/rpc',
           domains: ['somebiz.local.io'],
+          peerToken: auth.systemToken,
         })
 
         // Wait for handshake
@@ -228,11 +230,13 @@ describe.skipIf(skipTests)('Orchestrator Transit Container Tests', () => {
           name: 'node-b.somebiz.local.io',
           endpoint: 'ws://node-b:3000/rpc',
           domains: ['somebiz.local.io'],
+          peerToken: auth.systemToken,
         })
         await netB.addPeer({
           name: 'node-c.somebiz.local.io',
           endpoint: 'ws://node-c:3000/rpc',
           domains: ['somebiz.local.io'],
+          peerToken: auth.systemToken,
         })
 
         // Wait for B-C handshake and sync

--- a/apps/orchestrator/tests/transit.orchestrator.topology.test.ts
+++ b/apps/orchestrator/tests/transit.orchestrator.topology.test.ts
@@ -13,16 +13,19 @@ describe('Orchestrator Transit Tests (Mocked Container Logic)', () => {
     name: 'node-a.somebiz.local.io',
     endpoint: 'ws://node-a',
     domains: ['somebiz.local.io'],
+    peerToken: 'token-for-a',
   }
   const infoB: PeerInfo = {
     name: 'node-b.somebiz.local.io',
     endpoint: 'ws://node-b',
     domains: ['somebiz.local.io'],
+    peerToken: 'token-for-b',
   }
   const infoC: PeerInfo = {
     name: 'node-c.somebiz.local.io',
     endpoint: 'ws://node-c',
     domains: ['somebiz.local.io'],
+    peerToken: 'token-for-c',
   }
 
   beforeEach(() => {

--- a/docker-compose/DEMO.md
+++ b/docker-compose/DEMO.md
@@ -1,0 +1,362 @@
+# 3-Stack Integration Demo
+
+Step-by-step walkthrough for building, booting, and testing the three-node
+Catalyst Router topology defined in `three-node.compose.yaml`.
+
+All commands assume you are running from the repository root.
+
+## Topology
+
+```
+Stack A                    Stack B                    Stack C
++-----------------+        +-----------------+        +-----------------+
+| auth-a   :5001  |        | auth-b   :5002  |        | auth-c   :5003  |
+| orch-a   :3001  |        | orch-b   :3002  |        | orch-c   :3003  |
+| envoy-a  :10001 |        | envoy-b  :10002 |        | envoy-c  :10003 |
+| books-a         |        | books-b         |        | curl-client     |
++-----------------+        +-----------------+        +-----------------+
+        |                         |                         |
+        +-------orchestrator-mesh-+-----------+-------------+
+        +-------envoy-mesh--------+-----------+-------------+
+```
+
+| Stack | Auth   | Orchestrator   | Envoy Proxy   | Downstream  |
+| ----- | ------ | -------------- | ------------- | ----------- |
+| A     | auth-a | orchestrator-a | envoy-proxy-a | books-a     |
+| B     | auth-b | orchestrator-b | envoy-proxy-b | books-b     |
+| C     | auth-c | orchestrator-c | envoy-proxy-c | curl-client |
+
+All three orchestrators share the domain `somebiz.local.io` and peer over the
+`orchestrator-mesh` network. Envoy proxies peer over the `envoy-mesh` network.
+
+Peering topology: **A <-> B <-> C** (B acts as transit; full mesh is not required).
+
+## Prerequisites
+
+- Docker Engine 24+ and Docker Compose v2
+- ~4 GB free RAM (14 containers)
+- Ports 3001-3003, 5001-5003, 9911-9913, 10001-10003, 10011-10012, 10021-10022, 10031-10032 available on the host
+- [Bun](https://bun.sh) installed (for running CLI commands)
+- Clone of this repository with dependencies installed (`bun install`)
+
+**Note:** Healthchecks in the compose file use `127.0.0.1` instead of
+`localhost` because Alpine resolves `localhost` to IPv6 `::1`, while Bun
+binds to IPv4 only.
+
+## Host Port Reference
+
+| Service            | Stack A | Stack B | Stack C |
+| ------------------ | ------- | ------- | ------- |
+| Auth               | 5001    | 5002    | 5003    |
+| Orchestrator       | 3001    | 3002    | 3003    |
+| Envoy Admin        | 9911    | 9912    | 9913    |
+| Envoy Proxy :10000 | 10001   | 10002   | 10003   |
+| Envoy Proxy :10001 | 10011   | 10021   | 10031   |
+| Envoy Proxy :10002 | 10012   | 10022   | 10032   |
+
+---
+
+## Step 1: Build
+
+Build all images. This runs a single `bun install` in the base stage and
+creates per-service targets (auth, orchestrator, envoy, books-api).
+
+```bash
+docker compose -f docker-compose/three-node.compose.yaml build
+```
+
+## Step 2: Start Auth Services
+
+Start only the three auth services. Each mints a System Admin Token on startup
+and logs it to stdout.
+
+```bash
+docker compose -f docker-compose/three-node.compose.yaml up -d auth-a auth-b auth-c
+```
+
+Wait for all three to become healthy before proceeding:
+
+```bash
+docker compose -f docker-compose/three-node.compose.yaml ps auth-a auth-b auth-c
+```
+
+All three should show `healthy` status.
+
+## Step 3: Extract and Export Tokens
+
+Extract the system tokens from the auth service logs and export them as
+environment variables. The orchestrators read these on startup to authenticate
+with their local auth service.
+
+```bash
+export SYSTEM_TOKEN_A=$(docker compose -f docker-compose/three-node.compose.yaml logs auth-a 2>&1 \
+  | grep -o 'System Admin Token minted: ey[^ ]*' | head -1 \
+  | sed 's/System Admin Token minted: //')
+
+export SYSTEM_TOKEN_B=$(docker compose -f docker-compose/three-node.compose.yaml logs auth-b 2>&1 \
+  | grep -o 'System Admin Token minted: ey[^ ]*' | head -1 \
+  | sed 's/System Admin Token minted: //')
+
+export SYSTEM_TOKEN_C=$(docker compose -f docker-compose/three-node.compose.yaml logs auth-c 2>&1 \
+  | grep -o 'System Admin Token minted: ey[^ ]*' | head -1 \
+  | sed 's/System Admin Token minted: //')
+```
+
+Verify the tokens were captured:
+
+```bash
+echo "Token A: ${SYSTEM_TOKEN_A:0:20}..."
+echo "Token B: ${SYSTEM_TOKEN_B:0:20}..."
+echo "Token C: ${SYSTEM_TOKEN_C:0:20}..."
+```
+
+Each line should show the first 20 characters of a JWT (starting with `eyJ`).
+If any token is empty, re-check that the corresponding auth service is healthy
+and re-run the export command.
+
+## Step 4: Start All Services
+
+With the tokens exported, bring up the full stack. The orchestrators use
+`SYSTEM_TOKEN_A`/`B`/`C` to mint their own NODE tokens via their local auth
+service.
+
+```bash
+docker compose -f docker-compose/three-node.compose.yaml up -d
+```
+
+Wait for every service to become healthy:
+
+```bash
+docker compose -f docker-compose/three-node.compose.yaml ps
+```
+
+The orchestrators start last because they depend on auth, envoy-svc,
+envoy-proxy, and books (or curl-client) being healthy first.
+
+## Step 5: Register Routes
+
+Register the books-api service as a local route on orchestrators A and B.
+The `books` hostname is a Docker network alias that resolves within each
+stack's data network.
+
+```bash
+bun run apps/cli/src/index.ts \
+  --orchestrator-url ws://localhost:3001/rpc \
+  --token "$SYSTEM_TOKEN_A" \
+  node route create books-a http://books:8080 --protocol http:graphql
+```
+
+```bash
+bun run apps/cli/src/index.ts \
+  --orchestrator-url ws://localhost:3002/rpc \
+  --token "$SYSTEM_TOKEN_B" \
+  node route create books-b http://books:8080 --protocol http:graphql
+```
+
+Verify on stack A:
+
+```bash
+bun run apps/cli/src/index.ts \
+  --orchestrator-url ws://localhost:3001/rpc \
+  --token "$SYSTEM_TOKEN_A" \
+  node route list
+```
+
+Expected output: a table showing `books-a` with source `local` and protocol
+`http:graphql`.
+
+## Step 6: Peer the Orchestrators
+
+Each stack has its own auth server, so peering requires **peer tokens** -- a
+token minted by the remote stack's auth service that the local node presents
+when connecting.
+
+Peering topology: **A <-> B <-> C** (B is the transit node).
+
+### 6a. Mint Peer Tokens
+
+Mint tokens on each auth server for the remote nodes that will connect:
+
+```bash
+# Auth-A mints a token for node-b (so node-b can authenticate when connecting to orch-a)
+PEER_TOKEN_B_ON_A=$(bun run apps/cli/src/index.ts \
+  --auth-url ws://localhost:5001/rpc \
+  --token "$SYSTEM_TOKEN_A" \
+  auth token mint node-b.somebiz.local.io \
+  --principal CATALYST::NODE --type service \
+  --trusted-domains somebiz.local.io --expires-in 7d 2>/dev/null | tail -1)
+
+# Auth-B mints a token for node-a (so node-a can authenticate when connecting to orch-b)
+PEER_TOKEN_A_ON_B=$(bun run apps/cli/src/index.ts \
+  --auth-url ws://localhost:5002/rpc \
+  --token "$SYSTEM_TOKEN_B" \
+  auth token mint node-a.somebiz.local.io \
+  --principal CATALYST::NODE --type service \
+  --trusted-domains somebiz.local.io --expires-in 7d 2>/dev/null | tail -1)
+
+# Auth-B mints a token for node-c
+PEER_TOKEN_C_ON_B=$(bun run apps/cli/src/index.ts \
+  --auth-url ws://localhost:5002/rpc \
+  --token "$SYSTEM_TOKEN_B" \
+  auth token mint node-c.somebiz.local.io \
+  --principal CATALYST::NODE --type service \
+  --trusted-domains somebiz.local.io --expires-in 7d 2>/dev/null | tail -1)
+
+# Auth-C mints a token for node-b
+PEER_TOKEN_B_ON_C=$(bun run apps/cli/src/index.ts \
+  --auth-url ws://localhost:5003/rpc \
+  --token "$SYSTEM_TOKEN_C" \
+  auth token mint node-b.somebiz.local.io \
+  --principal CATALYST::NODE --type service \
+  --trusted-domains somebiz.local.io --expires-in 7d 2>/dev/null | tail -1)
+```
+
+Verify the tokens:
+
+```bash
+echo "PEER_TOKEN_B_ON_A: ${PEER_TOKEN_B_ON_A:0:20}..."
+echo "PEER_TOKEN_A_ON_B: ${PEER_TOKEN_A_ON_B:0:20}..."
+echo "PEER_TOKEN_C_ON_B: ${PEER_TOKEN_C_ON_B:0:20}..."
+echo "PEER_TOKEN_B_ON_C: ${PEER_TOKEN_B_ON_C:0:20}..."
+```
+
+### 6b. Create Peer Connections
+
+Peer endpoints use Docker network aliases (`orch-a`, `orch-b`, `orch-c`) that
+resolve on the `orchestrator-mesh` network. Both sides of each peering
+relationship must be configured.
+
+```bash
+# A peers with B (A presents PEER_TOKEN_A_ON_B to authenticate with B's auth)
+bun run apps/cli/src/index.ts \
+  --orchestrator-url ws://localhost:3001/rpc \
+  --token "$SYSTEM_TOKEN_A" \
+  node peer create node-b.somebiz.local.io ws://orch-b:3000/rpc \
+  --domains somebiz.local.io \
+  --peer-token "$PEER_TOKEN_A_ON_B"
+
+# B peers with A (B presents PEER_TOKEN_B_ON_A to authenticate with A's auth)
+bun run apps/cli/src/index.ts \
+  --orchestrator-url ws://localhost:3002/rpc \
+  --token "$SYSTEM_TOKEN_B" \
+  node peer create node-a.somebiz.local.io ws://orch-a:3000/rpc \
+  --domains somebiz.local.io \
+  --peer-token "$PEER_TOKEN_B_ON_A"
+
+# B peers with C
+bun run apps/cli/src/index.ts \
+  --orchestrator-url ws://localhost:3002/rpc \
+  --token "$SYSTEM_TOKEN_B" \
+  node peer create node-c.somebiz.local.io ws://orch-c:3000/rpc \
+  --domains somebiz.local.io \
+  --peer-token "$PEER_TOKEN_B_ON_C"
+
+# C peers with B
+bun run apps/cli/src/index.ts \
+  --orchestrator-url ws://localhost:3003/rpc \
+  --token "$SYSTEM_TOKEN_C" \
+  node peer create node-b.somebiz.local.io ws://orch-b:3000/rpc \
+  --domains somebiz.local.io \
+  --peer-token "$PEER_TOKEN_C_ON_B"
+```
+
+Verify peering on node A:
+
+```bash
+bun run apps/cli/src/index.ts \
+  --orchestrator-url ws://localhost:3001/rpc \
+  --token "$SYSTEM_TOKEN_A" \
+  node peer list
+```
+
+Expected output: a table showing `node-b.somebiz.local.io` with `connected`
+status.
+
+## Step 7: Verify Route Propagation
+
+After peering, routes advertised on A and B should propagate through B to C.
+Check that orchestrator C (which has no local books service) sees both routes
+as `internal`:
+
+```bash
+bun run apps/cli/src/index.ts \
+  --orchestrator-url ws://localhost:3003/rpc \
+  --token "$SYSTEM_TOKEN_C" \
+  node route list
+```
+
+Expected output: a table showing `books-a` and `books-b` with source
+`internal`, learned from peer `node-b.somebiz.local.io`.
+
+## Step 8: Test End-to-End
+
+### From the curl-client container
+
+The curl-client sits on stack C's data network. It can reach envoy-proxy-c,
+which routes the request across the envoy-mesh to a books service on stack A
+or B.
+
+```bash
+docker compose -f docker-compose/three-node.compose.yaml exec curl-client \
+  curl -s http://envoy-proxy-c:10000/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ books { id title author } }"}'
+```
+
+### From the host
+
+Send a GraphQL query through envoy-proxy-c (host port 10003). This tests the
+same cross-node path from outside the Docker network:
+
+```bash
+curl -s http://localhost:10003/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ books { id title author } }"}'
+```
+
+Expected response from either command:
+
+```json
+{
+  "data": {
+    "books": [
+      { "id": "1", "title": "The Lord of the Rings", "author": "J.R.R. Tolkien" },
+      { "id": "2", "title": "Pride and Prejudice", "author": "Jane Austen" },
+      { "id": "3", "title": "The Hobbit", "author": "J.R.R. Tolkien" }
+    ]
+  }
+}
+```
+
+Stack C has no books service of its own -- if you get a response, cross-node
+routing is working.
+
+## Step 9: Verify Cross-Node Routing
+
+Use verbose output to confirm the request is being routed through Envoy across
+stacks:
+
+```bash
+docker compose -f docker-compose/three-node.compose.yaml exec curl-client \
+  curl -v http://envoy-proxy-c:10000/graphql \
+  -H "Host: books-a.somebiz.local.io" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ books { id title author } }"}'
+```
+
+The `-v` flag shows the upstream connection details. Look for response headers
+indicating the request was proxied through Envoy to stack A.
+
+## Step 10: Teardown
+
+Stop all containers, remove networks, and clean up volumes:
+
+```bash
+docker compose -f docker-compose/three-node.compose.yaml down -v
+```
+
+To also remove the built images:
+
+```bash
+docker compose -f docker-compose/three-node.compose.yaml down -v --rmi local
+```

--- a/docker-compose/Dockerfile.test
+++ b/docker-compose/Dockerfile.test
@@ -1,0 +1,83 @@
+# Multi-stage Dockerfile for the 3-stack integration test.
+#
+# Copies the entire monorepo, runs bun install once, then provides
+# per-service targets that only set WORKDIR, PORT, and CMD.
+#
+# Usage in docker-compose:
+#   build:
+#     context: ..
+#     dockerfile: docker-compose/Dockerfile.test
+#     target: auth
+
+FROM oven/bun:1.3.6-alpine AS base
+
+WORKDIR /app
+
+# Copy root workspace config + lockfile
+COPY package.json bun.lock ./
+
+# Copy ALL workspace package.json files for complete resolution
+COPY apps/auth/package.json apps/auth/package.json
+COPY apps/cli/package.json apps/cli/package.json
+COPY apps/envoy/package.json apps/envoy/package.json
+COPY apps/gateway/package.json apps/gateway/package.json
+COPY apps/node/package.json apps/node/package.json
+COPY apps/orchestrator/package.json apps/orchestrator/package.json
+COPY packages/authorization/package.json packages/authorization/package.json
+COPY packages/config/package.json packages/config/package.json
+COPY packages/routing/package.json packages/routing/package.json
+COPY packages/sdk/package.json packages/sdk/package.json
+COPY packages/service/package.json packages/service/package.json
+COPY packages/telemetry/package.json packages/telemetry/package.json
+COPY packages/types/package.json packages/types/package.json
+COPY examples/books-api/package.json examples/books-api/package.json
+COPY examples/movies-api/package.json examples/movies-api/package.json
+COPY examples/orders-api/package.json examples/orders-api/package.json
+COPY examples/product-api/package.json examples/product-api/package.json
+
+# Single bun install for the entire monorepo
+RUN bun install --omit=dev --ignore-scripts
+
+# Copy ALL source code
+COPY apps apps
+COPY packages packages
+COPY examples examples
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+# ── Service targets ──────────────────────────────────────────────────
+
+FROM base AS auth
+WORKDIR /app/apps/auth
+ENV PORT=5000
+EXPOSE 5000
+USER appuser
+CMD ["bun", "run", "src/server.ts"]
+
+FROM base AS orchestrator
+WORKDIR /app/apps/orchestrator
+ENV PORT=3000
+EXPOSE 3000
+USER appuser
+CMD ["bun", "run", "src/server.ts"]
+
+FROM base AS envoy
+WORKDIR /app/apps/envoy
+ENV PORT=3000
+EXPOSE 3000 18000
+USER appuser
+CMD ["bun", "run", "src/index.ts"]
+
+FROM base AS gateway
+WORKDIR /app/apps/gateway
+ENV PORT=4000
+EXPOSE 4000
+USER appuser
+CMD ["bun", "run", "src/index.ts"]
+
+FROM base AS books-api
+WORKDIR /app/examples/books-api
+ENV PORT=8080
+EXPOSE 8080
+USER appuser
+CMD ["bun", "run", "src/index.ts"]

--- a/docker-compose/envoy-bootstrap-a.yaml
+++ b/docker-compose/envoy-bootstrap-a.yaml
@@ -1,0 +1,47 @@
+# Envoy proxy bootstrap for Stack A.
+# Points ADS xDS at envoy-svc-a:18000 via STRICT_DNS.
+
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9901
+
+node:
+  id: catalyst-envoy-proxy-a
+  cluster: catalyst
+
+dynamic_resources:
+  lds_config:
+    resource_api_version: V3
+    ads: {}
+  cds_config:
+    resource_api_version: V3
+    ads: {}
+  ads_config:
+    api_type: GRPC
+    transport_api_version: V3
+    grpc_services:
+      - envoy_grpc:
+          cluster_name: xds_cluster
+
+static_resources:
+  clusters:
+    - name: xds_cluster
+      connect_timeout: 5s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: xds_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: envoy-svc-a
+                      port_value: 18000

--- a/docker-compose/envoy-bootstrap-b.yaml
+++ b/docker-compose/envoy-bootstrap-b.yaml
@@ -1,0 +1,47 @@
+# Envoy proxy bootstrap for Stack B.
+# Points ADS xDS at envoy-svc-b:18000 via STRICT_DNS.
+
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9901
+
+node:
+  id: catalyst-envoy-proxy-b
+  cluster: catalyst
+
+dynamic_resources:
+  lds_config:
+    resource_api_version: V3
+    ads: {}
+  cds_config:
+    resource_api_version: V3
+    ads: {}
+  ads_config:
+    api_type: GRPC
+    transport_api_version: V3
+    grpc_services:
+      - envoy_grpc:
+          cluster_name: xds_cluster
+
+static_resources:
+  clusters:
+    - name: xds_cluster
+      connect_timeout: 5s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: xds_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: envoy-svc-b
+                      port_value: 18000

--- a/docker-compose/envoy-bootstrap-c.yaml
+++ b/docker-compose/envoy-bootstrap-c.yaml
@@ -1,0 +1,47 @@
+# Envoy proxy bootstrap for Stack C.
+# Points ADS xDS at envoy-svc-c:18000 via STRICT_DNS.
+
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9901
+
+node:
+  id: catalyst-envoy-proxy-c
+  cluster: catalyst
+
+dynamic_resources:
+  lds_config:
+    resource_api_version: V3
+    ads: {}
+  cds_config:
+    resource_api_version: V3
+    ads: {}
+  ads_config:
+    api_type: GRPC
+    transport_api_version: V3
+    grpc_services:
+      - envoy_grpc:
+          cluster_name: xds_cluster
+
+static_resources:
+  clusters:
+    - name: xds_cluster
+      connect_timeout: 5s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: xds_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: envoy-svc-c
+                      port_value: 18000

--- a/docker-compose/three-node.compose.yaml
+++ b/docker-compose/three-node.compose.yaml
@@ -1,0 +1,460 @@
+# 3-Stack Integration Test — 14 containers, 8 networks
+#
+# Topology:
+#   Stack A: auth-a, orchestrator-a, envoy-svc-a, envoy-proxy-a, books-a
+#   Stack B: auth-b, orchestrator-b, envoy-svc-b, envoy-proxy-b, books-b
+#   Stack C: auth-c, orchestrator-c, envoy-svc-c, envoy-proxy-c, curl-client
+#
+# Networks:
+#   stack-{a,b,c}-control — auth + orchestrator + envoy-svc + envoy-proxy
+#   stack-{a,b,c}-data    — envoy-proxy + downstream (books / curl)
+#   orchestrator-mesh     — orchestrator-a, orchestrator-b, orchestrator-c
+#   envoy-mesh            — envoy-proxy-a, envoy-proxy-b, envoy-proxy-c
+#
+# Build:
+#   All Bun services share a single Dockerfile (docker-compose/Dockerfile.test)
+#   with per-service build targets. The base stage copies the entire monorepo
+#   and runs bun install once; service targets only set WORKDIR + CMD.
+#
+# Bootstrap:
+#   1. Start auth services first:
+#        docker compose -f three-node.compose.yaml up auth-a auth-b auth-c
+#   2. Extract system tokens from logs:
+#        docker compose -f three-node.compose.yaml logs auth-a | grep "System Admin Token minted:"
+#   3. Export tokens and start the rest:
+#        export SYSTEM_TOKEN_A=<token-a>
+#        export SYSTEM_TOKEN_B=<token-b>
+#        export SYSTEM_TOKEN_C=<token-c>
+#        docker compose -f three-node.compose.yaml up
+
+services:
+  # ===================================================================
+  # Stack A
+  # ===================================================================
+
+  auth-a:
+    build:
+      context: ..
+      dockerfile: docker-compose/Dockerfile.test
+      target: auth
+    ports:
+      - '5001:5000'
+    environment:
+      - PORT=5000
+      - CATALYST_NODE_ID=auth-a
+      - CATALYST_PEERING_ENDPOINT=ws://auth-a:5000/rpc
+      - CATALYST_BOOTSTRAP_TOKEN=bootstrap-a
+      - 'CATALYST_AUTH_KEYS_DB=:memory:'
+      - 'CATALYST_AUTH_TOKENS_DB=:memory:'
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:5000/health']
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    networks:
+      stack-a-control:
+        aliases:
+          - auth
+
+  envoy-svc-a:
+    build:
+      context: ..
+      dockerfile: docker-compose/Dockerfile.test
+      target: envoy
+    environment:
+      - PORT=3000
+      - CATALYST_NODE_ID=envoy-svc-a
+      - CATALYST_DOMAINS=somebiz.local.io
+      - CATALYST_ENVOY_XDS_PORT=18000
+      - CATALYST_ENVOY_BIND_ADDRESS=0.0.0.0
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:3000/health']
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    networks:
+      - stack-a-control
+
+  envoy-proxy-a:
+    build:
+      context: ..
+      dockerfile: apps/envoy/Dockerfile.envoy-proxy
+    ports:
+      - '9911:9901'
+      - '10001:10000'
+      - '10011:10001'
+      - '10012:10002'
+    volumes:
+      - ./envoy-bootstrap-a.yaml:/etc/envoy/envoy.yaml:ro
+    command: ['-c', '/etc/envoy/envoy.yaml', '--log-level', 'info']
+    healthcheck:
+      test: ['CMD', 'curl', '-sf', 'http://127.0.0.1:9901/server_info']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      envoy-svc-a:
+        condition: service_healthy
+    networks:
+      - stack-a-control
+      - stack-a-data
+      - envoy-mesh
+
+  books-a:
+    build:
+      context: ..
+      dockerfile: docker-compose/Dockerfile.test
+      target: books-api
+    environment:
+      - PORT=8080
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:8080/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      stack-a-data:
+        aliases:
+          - books
+
+  orchestrator-a:
+    build:
+      context: ..
+      dockerfile: docker-compose/Dockerfile.test
+      target: orchestrator
+    ports:
+      - '3001:3000'
+    environment:
+      - PORT=3000
+      - CATALYST_NODE_ID=node-a.somebiz.local.io
+      - CATALYST_PEERING_ENDPOINT=ws://orch-a:3000/rpc
+      - CATALYST_DOMAINS=somebiz.local.io
+      - CATALYST_AUTH_ENDPOINT=ws://auth:5000/rpc
+      - CATALYST_SYSTEM_TOKEN=${SYSTEM_TOKEN_A}
+      - CATALYST_ENVOY_ENDPOINT=ws://envoy-svc-a:3000/api
+      - 'CATALYST_ENVOY_PORT_RANGE=[10000,10001,10002]'
+      - CATALYST_ENVOY_ADDRESS=envoy-proxy-a
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:3000/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      auth-a:
+        condition: service_healthy
+      envoy-svc-a:
+        condition: service_healthy
+      envoy-proxy-a:
+        condition: service_healthy
+      books-a:
+        condition: service_healthy
+    networks:
+      stack-a-control:
+        aliases:
+          - orch-a
+      orchestrator-mesh:
+        aliases:
+          - orch-a
+
+  # ===================================================================
+  # Stack B
+  # ===================================================================
+
+  auth-b:
+    build:
+      context: ..
+      dockerfile: docker-compose/Dockerfile.test
+      target: auth
+    ports:
+      - '5002:5000'
+    environment:
+      - PORT=5000
+      - CATALYST_NODE_ID=auth-b
+      - CATALYST_PEERING_ENDPOINT=ws://auth-b:5000/rpc
+      - CATALYST_BOOTSTRAP_TOKEN=bootstrap-b
+      - 'CATALYST_AUTH_KEYS_DB=:memory:'
+      - 'CATALYST_AUTH_TOKENS_DB=:memory:'
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:5000/health']
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    networks:
+      stack-b-control:
+        aliases:
+          - auth
+
+  envoy-svc-b:
+    build:
+      context: ..
+      dockerfile: docker-compose/Dockerfile.test
+      target: envoy
+    environment:
+      - PORT=3000
+      - CATALYST_NODE_ID=envoy-svc-b
+      - CATALYST_DOMAINS=somebiz.local.io
+      - CATALYST_ENVOY_XDS_PORT=18000
+      - CATALYST_ENVOY_BIND_ADDRESS=0.0.0.0
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:3000/health']
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    networks:
+      - stack-b-control
+
+  envoy-proxy-b:
+    build:
+      context: ..
+      dockerfile: apps/envoy/Dockerfile.envoy-proxy
+    ports:
+      - '9912:9901'
+      - '10002:10000'
+      - '10021:10001'
+      - '10022:10002'
+    volumes:
+      - ./envoy-bootstrap-b.yaml:/etc/envoy/envoy.yaml:ro
+    command: ['-c', '/etc/envoy/envoy.yaml', '--log-level', 'info']
+    healthcheck:
+      test: ['CMD', 'curl', '-sf', 'http://127.0.0.1:9901/server_info']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      envoy-svc-b:
+        condition: service_healthy
+    networks:
+      - stack-b-control
+      - stack-b-data
+      - envoy-mesh
+
+  books-b:
+    build:
+      context: ..
+      dockerfile: docker-compose/Dockerfile.test
+      target: books-api
+    environment:
+      - PORT=8080
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:8080/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      stack-b-data:
+        aliases:
+          - books
+
+  orchestrator-b:
+    build:
+      context: ..
+      dockerfile: docker-compose/Dockerfile.test
+      target: orchestrator
+    ports:
+      - '3002:3000'
+    environment:
+      - PORT=3000
+      - CATALYST_NODE_ID=node-b.somebiz.local.io
+      - CATALYST_PEERING_ENDPOINT=ws://orch-b:3000/rpc
+      - CATALYST_DOMAINS=somebiz.local.io
+      - CATALYST_AUTH_ENDPOINT=ws://auth:5000/rpc
+      - CATALYST_SYSTEM_TOKEN=${SYSTEM_TOKEN_B}
+      - CATALYST_ENVOY_ENDPOINT=ws://envoy-svc-b:3000/api
+      - 'CATALYST_ENVOY_PORT_RANGE=[10000,10001,10002]'
+      - CATALYST_ENVOY_ADDRESS=envoy-proxy-b
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:3000/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      auth-b:
+        condition: service_healthy
+      envoy-svc-b:
+        condition: service_healthy
+      envoy-proxy-b:
+        condition: service_healthy
+      books-b:
+        condition: service_healthy
+    networks:
+      stack-b-control:
+        aliases:
+          - orch-b
+      orchestrator-mesh:
+        aliases:
+          - orch-b
+
+  # ===================================================================
+  # Stack C
+  # ===================================================================
+
+  auth-c:
+    build:
+      context: ..
+      dockerfile: docker-compose/Dockerfile.test
+      target: auth
+    ports:
+      - '5003:5000'
+    environment:
+      - PORT=5000
+      - CATALYST_NODE_ID=auth-c
+      - CATALYST_PEERING_ENDPOINT=ws://auth-c:5000/rpc
+      - CATALYST_BOOTSTRAP_TOKEN=bootstrap-c
+      - 'CATALYST_AUTH_KEYS_DB=:memory:'
+      - 'CATALYST_AUTH_TOKENS_DB=:memory:'
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:5000/health']
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    networks:
+      stack-c-control:
+        aliases:
+          - auth
+
+  envoy-svc-c:
+    build:
+      context: ..
+      dockerfile: docker-compose/Dockerfile.test
+      target: envoy
+    environment:
+      - PORT=3000
+      - CATALYST_NODE_ID=envoy-svc-c
+      - CATALYST_DOMAINS=somebiz.local.io
+      - CATALYST_ENVOY_XDS_PORT=18000
+      - CATALYST_ENVOY_BIND_ADDRESS=0.0.0.0
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:3000/health']
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    networks:
+      - stack-c-control
+
+  envoy-proxy-c:
+    build:
+      context: ..
+      dockerfile: apps/envoy/Dockerfile.envoy-proxy
+    ports:
+      - '9913:9901'
+      - '10003:10000'
+      - '10031:10001'
+      - '10032:10002'
+    volumes:
+      - ./envoy-bootstrap-c.yaml:/etc/envoy/envoy.yaml:ro
+    command: ['-c', '/etc/envoy/envoy.yaml', '--log-level', 'info']
+    healthcheck:
+      test: ['CMD', 'curl', '-sf', 'http://127.0.0.1:9901/server_info']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      envoy-svc-c:
+        condition: service_healthy
+    networks:
+      - stack-c-control
+      - stack-c-data
+      - envoy-mesh
+
+  orchestrator-c:
+    build:
+      context: ..
+      dockerfile: docker-compose/Dockerfile.test
+      target: orchestrator
+    ports:
+      - '3003:3000'
+    environment:
+      - PORT=3000
+      - CATALYST_NODE_ID=node-c.somebiz.local.io
+      - CATALYST_PEERING_ENDPOINT=ws://orch-c:3000/rpc
+      - CATALYST_DOMAINS=somebiz.local.io
+      - CATALYST_AUTH_ENDPOINT=ws://auth:5000/rpc
+      - CATALYST_SYSTEM_TOKEN=${SYSTEM_TOKEN_C}
+      - CATALYST_ENVOY_ENDPOINT=ws://envoy-svc-c:3000/api
+      - 'CATALYST_ENVOY_PORT_RANGE=[10000,10001,10002]'
+      - CATALYST_ENVOY_ADDRESS=envoy-proxy-c
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:3000/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      auth-c:
+        condition: service_healthy
+      envoy-svc-c:
+        condition: service_healthy
+      envoy-proxy-c:
+        condition: service_healthy
+    networks:
+      stack-c-control:
+        aliases:
+          - orch-c
+      orchestrator-mesh:
+        aliases:
+          - orch-c
+
+  curl-client:
+    image: curlimages/curl:8.11.1
+    command: ['sleep', 'infinity']
+    depends_on:
+      orchestrator-a:
+        condition: service_healthy
+      orchestrator-b:
+        condition: service_healthy
+      orchestrator-c:
+        condition: service_healthy
+    networks:
+      - stack-c-data
+
+# =====================================================================
+# Networks
+# =====================================================================
+
+networks:
+  # Per-stack control planes: auth <-> orchestrator <-> envoy-svc <-> envoy-proxy
+  stack-a-control:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.1.0/28
+  stack-b-control:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.2.0/28
+  stack-c-control:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.3.0/28
+
+  # Per-stack data planes: envoy-proxy <-> downstream service
+  stack-a-data:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.1.16/28
+  stack-b-data:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.2.16/28
+  stack-c-data:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.3.16/28
+
+  # Cross-stack mesh: orchestrator peering
+  orchestrator-mesh:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.10.0/28
+
+  # Cross-stack mesh: envoy data plane
+  envoy-mesh:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.11.0/28


### PR DESCRIPTION
The InternalProtocolOpen handler was using the remote node's config
(which lacks a local peerToken) with a fallback to this.nodeToken
(minted by the wrong auth). This caused one-directional route
propagation when nodes use separate auth services.

- Look up the local peer record's stored peerToken in InternalProtocolOpen
- Make peerToken mandatory in LocalPeerCreate with validation
- Remove all || this.nodeToken || '' fallback chains (8 locations)
- Add CRITICAL error logging when peerToken is missing at any sync point
- Add regression test for routes registered before peering
- Add rejection test for missing peerToken
- Update all test files to include peerToken in addPeer calls
- Add 3-node Docker Compose demo infrastructure (A <-> B <-> C)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>