### PR TITLE
refactor(orchestrator): extract RIB with unified plan/commit pipeline

### DIFF
--- a/apps/orchestrator/src/orchestrator.ts
+++ b/apps/orchestrator/src/orchestrator.ts
@@ -4,7 +4,6 @@ import {
   type DataChannelDefinition,
   type InternalRoute,
   type PeerInfo,
-  type PeerRecord,
   type RouteTable,
 } from '@catalyst/routing'
 export type { PeerInfo, InternalRoute }
@@ -270,7 +269,7 @@ export class CatalystNodeBus extends RpcTarget {
     if (!envoyEndpoint || !this.portAllocator) return
 
     // Only react to route-affecting actions
-    const routeActions = [
+    const routeActions: ReadonlyArray<Action['action']> = [
       Actions.LocalRouteCreate,
       Actions.LocalRouteDelete,
       Actions.InternalProtocolUpdate,

--- a/apps/orchestrator/src/rib.ts
+++ b/apps/orchestrator/src/rib.ts
@@ -113,7 +113,7 @@ export class RoutingInformationBase {
   private allocatePorts(action: Action, newState: RouteTable, prevState: RouteTable): void {
     if (!this.portAllocator) return
 
-    const routeActions = [
+    const routeActions: ReadonlyArray<Action['action']> = [
       Actions.LocalRouteCreate,
       Actions.LocalRouteDelete,
       Actions.InternalProtocolUpdate,
@@ -147,7 +147,7 @@ export class RoutingInformationBase {
 
     // Allocate egress ports for internal routes
     for (const route of newState.internal.routes) {
-      const egressKey = `egress_${route.name}_via_${route.peerName}`
+      const egressKey = `egress_${route.name}_via_${route.peer.name}`
       const result = this.portAllocator.allocate(egressKey)
       if (result.success) {
         if (!route.envoyPort) {
@@ -161,9 +161,9 @@ export class RoutingInformationBase {
     // Release egress ports for closed peer connections
     if (action.action === Actions.InternalProtocolClose) {
       const closedPeer = action.data.peerInfo.name
-      const removedRoutes = prevState.internal.routes.filter((r) => r.peerName === closedPeer)
+      const removedRoutes = prevState.internal.routes.filter((r) => r.peer.name === closedPeer)
       for (const route of removedRoutes) {
-        this.portAllocator.release(`egress_${route.name}_via_${route.peerName}`)
+        this.portAllocator.release(`egress_${route.name}_via_${route.peer.name}`)
       }
     }
   }
@@ -251,7 +251,9 @@ export class RoutingInformationBase {
             ...state,
             internal: {
               ...state.internal,
-              routes: state.internal.routes.filter((r) => r.peerName !== action.data.peerInfo.name),
+              routes: state.internal.routes.filter(
+                (r) => r.peer.name !== action.data.peerInfo.name
+              ),
               peers: peerList.filter((p) => p.name !== action.data.peerInfo.name),
             },
           }
@@ -342,17 +344,16 @@ export class RoutingInformationBase {
 
             // Remove existing if any (upsert)
             currentInternalRoutes = currentInternalRoutes.filter(
-              (r) => !(r.name === u.route.name && r.peerName === sourcePeerName)
+              (r) => !(r.name === u.route.name && r.peer.name === sourcePeerName)
             )
             currentInternalRoutes.push({
               ...u.route,
-              peerName: sourcePeerName,
               peer: peerInfo,
               nodePath: nodePath,
             })
           } else if (u.action === 'remove') {
             currentInternalRoutes = currentInternalRoutes.filter(
-              (r) => r.name !== u.route.name || r.peerName !== sourcePeerName
+              (r) => r.name !== u.route.name || r.peer.name !== sourcePeerName
             )
           }
         }
@@ -391,7 +392,7 @@ export class RoutingInformationBase {
           .map((r) => {
             let route = r as DataChannelDefinition
             if (this.config.envoyConfig && this.portAllocator) {
-              const egressKey = `egress_${r.name}_via_${r.peerName}`
+              const egressKey = `egress_${r.name}_via_${r.peer.name}`
               const localPort = this.portAllocator.getPort(egressKey)
               if (localPort) {
                 route = { ...r, envoyPort: localPort }
@@ -559,7 +560,7 @@ export class RoutingInformationBase {
     prevState: RouteTable,
     newState: RouteTable
   ): Propagation[] {
-    const removedRoutes = prevState.internal.routes.filter((r) => r.peerName === peerName)
+    const removedRoutes = prevState.internal.routes.filter((r) => r.peer.name === peerName)
     if (removedRoutes.length === 0) return []
 
     this.logger.info`Propagating withdrawal of ${removedRoutes.length} routes from ${peerName}`

--- a/apps/orchestrator/tests/rib.test.ts
+++ b/apps/orchestrator/tests/rib.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { Actions, type PeerInfo } from '@catalyst/routing'
 import { RoutingInformationBase, type Plan } from '../src/rib.js'
 import type { OrchestratorConfig } from '../src/types.js'
 
-const NODE: PeerInfo = {
+const NODE = {
   name: 'node-a.somebiz.local.io',
   endpoint: 'http://node-a:3000',
   domains: ['somebiz.local.io'],
-}
+} satisfies PeerInfo
 
 const PEER_B: PeerInfo = {
   name: 'node-b.somebiz.local.io',
@@ -308,7 +308,7 @@ describe('RoutingInformationBase', () => {
       const routes = rib.getState().internal.routes
       expect(routes).toHaveLength(1)
       expect(routes[0].name).toBe('svc-b')
-      expect(routes[0].peerName).toBe(PEER_B.name)
+      expect(routes[0].peer.name).toBe(PEER_B.name)
       expect(routes[0].nodePath).toEqual([PEER_B.name])
     })
 


### PR DESCRIPTION
## Summary

**The big move.** Extracts all routing logic from the orchestrator into a `RoutingInformationBase` class with a unified `plan()`/`commit()` pipeline. This eliminates the artificial split between state mutation (`handleAction`) and BGP propagation (`handleBGPNotify`) — the source of most complexity in the orchestrator.

**Before:** `handleAction()` (~150 lines) mutates state, then `handleBGPNotify()` (~260 lines, 9 switch cases) re-derives what changed by inspecting the action type, re-reading state, and duplicating routing logic (loop detection, path filtering, envoyPort rewriting).

**After:** The RIB's `plan()` computes both the state delta and propagation targets in one pass — no duplication, no re-derivation. This matches how real BGP implementations work (BIRD, FRR, GoBGP): one pipeline from input to propagation.

**Pipeline:**
```
plan(action)  → pure, synchronous: new state + propagation targets
commit(plan)  → synchronous: applies state, returns CommitResult
handlePostCommit → fire-and-forget: fanOut to peers + Envoy + GraphQL
```

**Critical design decision:** `commit()` is synchronous (state-only). Transport fan-out happens as fire-and-forget in `handlePostCommit` to avoid cross-node deadlocks. If `commit()` awaited `transport.fanOut()`, the remote peer's response would dispatch back to this node, deadlocking the ActionQueue.

**Changes:**
- `apps/orchestrator/src/rib.ts` → new file (~720 lines). `RoutingInformationBase` with `plan()`, `commit()`, `getState()`, `getRouteMetadata()`
- `apps/orchestrator/src/orchestrator.ts` → replaces `handleAction` + `handleBGPNotify` with `rib.plan()` + `rib.commit()` (-563 lines)
- `apps/orchestrator/tests/rib.test.ts` → 34 unit tests for plan/commit

## Context

Part 5 of 8 in the orchestrator refactor stack. See `docs/architecture-proposal-orchestrator-refactor.md` § "RIB (Routing Information Base)" for full design.

**Backward compatibility:** Uses the same `RouteTable` shape, same loop detection, same envoyPort rewriting. `publicApi()` produces the same interface. No new BGP semantics yet.

## Test plan

- [x] New: 34 RIB unit tests (plan purity, all action types, loop prevention, propagation targeting, commit state application, peer lifecycle)
- [x] All 20 existing orchestrator tests pass unchanged
- [x] All topology and container integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)