### PR TITLE
fix(rpi): harden image layers, improve wifi and build

### DIFF
--- a/apps/rpi-config/README.md
+++ b/apps/rpi-config/README.md
@@ -247,6 +247,12 @@ The binary is written to `dist/rpi-config/catalyst-rpi-config`.
 | `--cloudflared-token <token>` | Cloudflare Tunnel token (omit to skip) | --      |
 | `--no-cloudflared`            | Explicitly skip cloudflared            | --      |
 
+### Console
+
+| Flag             | Description                               | Default |
+| ---------------- | ----------------------------------------- | ------- |
+| `--no-autologin` | Skip console autologin and journal stream | --      |
+
 ### Image Layout
 
 | Flag                      | Description         | Default                           |
@@ -293,6 +299,7 @@ When run without `--dry-run`, the CLI writes this structure:
 │   ├── catalyst-otel.yaml       # (native mode)
 │   ├── catalyst-node.yaml       # (native mode)
 │   ├── catalyst-docker-stack.yaml # (docker mode)
+│   ├── catalyst-console.yaml     # (if autologin enabled — default)
 │   ├── catalyst-wifi.yaml       # (if WiFi enabled)
 │   └── catalyst-cloudflared.yaml # (if cloudflared enabled)
 └── bin/

--- a/apps/rpi-config/src/index.ts
+++ b/apps/rpi-config/src/index.ts
@@ -26,10 +26,10 @@ program
   .addOption(new Option('--device <layer>', 'Device layer').default(DEFAULTS.device))
   .addOption(new Option('--hostname <name>', 'System hostname').default(DEFAULTS.hostname))
   .addOption(new Option('--username <user>', 'Login username').default(DEFAULTS.username))
-  .addOption(new Option('--password <pass>', 'Login password'))
+  .addOption(new Option('--password <pass>', 'Login password').env('CATALYST_PASSWORD'))
 
   .addOption(new Option('--wifi-ssid <ssid>', 'WiFi SSID'))
-  .addOption(new Option('--wifi-password <pass>', 'WiFi password'))
+  .addOption(new Option('--wifi-password <pass>', 'WiFi password').env('CATALYST_WIFI_PASSWORD'))
   .addOption(new Option('--wifi-country <code>', 'WiFi country code').default(DEFAULTS.wifiCountry))
   .addOption(new Option('--no-wifi', 'Skip WiFi'))
 
@@ -59,7 +59,11 @@ program
     new Option('--otel-version <ver>', 'OTEL Collector version').default(DEFAULTS.otelVersion)
   )
 
-  .addOption(new Option('--cloudflared-token <token>', 'Cloudflare Tunnel token'))
+  .addOption(
+    new Option('--cloudflared-token <token>', 'Cloudflare Tunnel token').env(
+      'CATALYST_CF_TUNNEL_TOKEN'
+    )
+  )
   .addOption(new Option('--no-cloudflared', 'Skip cloudflared'))
 
   .addOption(new Option('--no-autologin', 'Skip console autologin + journal stream'))

--- a/apps/rpi-config/src/prompts.ts
+++ b/apps/rpi-config/src/prompts.ts
@@ -78,7 +78,9 @@ export async function promptMissing(opts: Record<string, unknown>): Promise<Reso
     const wantWifi = await confirm({ message: 'Configure WiFi?', default: true })
     if (wantWifi) {
       resolved.wifiSsid = await input({ message: 'WiFi SSID:' })
-      resolved.wifiPassword = await password({ message: 'WiFi password:', mask: '*' })
+      resolved.wifiPassword = await input({
+        message: 'WiFi password (leave empty for open network):',
+      })
       if (!resolved.wifiCountry || resolved.wifiCountry === DEFAULTS.wifiCountry) {
         resolved.wifiCountry = await input({
           message: 'WiFi country code:',

--- a/builds/rpi/build.sh
+++ b/builds/rpi/build.sh
@@ -37,7 +37,7 @@ Options:
                                (default: clone to ./rpi-image-gen next to this script)
   --build-dir <path>           Build output directory (passed as -B to rpi-image-gen)
   --skip-deps                  Skip dependency installation
-  --branch <branch>            Git branch to clone (default: main)
+  --branch <branch>            Git branch to clone (default: master)
   -h, --help                   Show this help
 
 Requirements:
@@ -226,7 +226,7 @@ install_deps() {
   echo ""
 
   # Run from the
-  pushd $RPI_IMAGE_GEN
+  pushd "$RPI_IMAGE_GEN"
   sudo ./install_deps.sh
   popd
 
@@ -243,7 +243,7 @@ validate_config() {
   # Basic YAML structure check — ensure it has the required top-level keys
   if ! python3 -c "
 import yaml, sys
-with open('$CONFIG_FILE') as f:
+with open(sys.argv[1]) as f:
     cfg = yaml.safe_load(f)
 required = ['include', 'device', 'image', 'layer']
 missing = [k for k in required if k not in cfg]
@@ -255,7 +255,7 @@ print(f'  Device:   {cfg[\"device\"].get(\"layer\", \"unknown\")}')
 print(f'  Image:    {cfg[\"image\"].get(\"name\", \"unknown\")}')
 layers = cfg.get('layer', {})
 print(f'  Layers:   {list(layers.values())}')
-" 2>&1; then
+" "$CONFIG_FILE" 2>&1; then
     echo ""
     echo "ERROR: Config validation failed."
     exit 1
@@ -302,11 +302,11 @@ print_results() {
   # Try to find the output image
   local image_name
   image_name="$(python3 -c "
-import yaml
-with open('$CONFIG_FILE') as f:
+import yaml, sys
+with open(sys.argv[1]) as f:
     cfg = yaml.safe_load(f)
 print(cfg.get('image', {}).get('name', 'unknown'))
-" 2>/dev/null || echo "unknown")"
+" "$CONFIG_FILE" 2>/dev/null || echo "unknown")"
 
   local image_dir="${work_dir}/image-${image_name}"
   local image_file="${image_dir}/${image_name}.img"

--- a/builds/rpi/layer/catalyst-cloudflared.yaml
+++ b/builds/rpi/layer/catalyst-cloudflared.yaml
@@ -47,7 +47,7 @@ mmdebstrap:
       cat > "$1/etc/systemd/system/cloudflared-tunnel.service" <<SVCEOF
       [Unit]
       Description=Cloudflare Tunnel
-      After=network-online.target wpa_supplicant@wlan0.service
+      After=network-online.target
       Wants=network-online.target
 
       [Service]
@@ -55,6 +55,8 @@ mmdebstrap:
       ExecStart=/usr/bin/cloudflared tunnel --no-autoupdate run --token $IGconf_cloudflared_tunnel_token
       Restart=on-failure
       RestartSec=5
+      StartLimitBurst=5
+      StartLimitIntervalSec=120
       AmbientCapabilities=CAP_NET_RAW
       CapabilityBoundingSet=CAP_NET_RAW
 

--- a/builds/rpi/layer/catalyst-console.yaml
+++ b/builds/rpi/layer/catalyst-console.yaml
@@ -12,6 +12,8 @@
 # METAEND
 ---
 mmdebstrap:
+  packages:
+    - conspy
   customize-hooks:
     # Enable autologin on tty1 for the configured user
     - |-
@@ -34,4 +36,9 @@ mmdebstrap:
         journalctl -f --no-hostname -o short-precise
       fi
       BPEOF
-      chown -R 1000:1000 "$HOME_DIR/.bash_profile"
+      chroot "$1" chown -R $IGconf_device_user1:$IGconf_device_user1 "/home/$IGconf_device_user1/.bash_profile"
+    # Allow the configured user to run conspy without a password
+    - |-
+      echo "$IGconf_device_user1 ALL=(ALL) NOPASSWD: /usr/bin/conspy" \
+        > "$1/etc/sudoers.d/conspy"
+      chmod 440 "$1/etc/sudoers.d/conspy"

--- a/builds/rpi/layer/catalyst-docker-stack.yaml
+++ b/builds/rpi/layer/catalyst-docker-stack.yaml
@@ -54,6 +54,8 @@
 # METAEND
 ---
 mmdebstrap:
+  packages:
+    - avahi-daemon
   customize-hooks:
     # Create application directory
     - mkdir -p "$1/opt/catalyst-node"
@@ -247,7 +249,7 @@ mmdebstrap:
       Type=oneshot
       ExecStart=/usr/local/bin/catalyst-firstboot
       ExecStartPost=/usr/bin/touch /opt/catalyst-node/.firstboot-done
-      RemainAfterExit=no
+      RemainAfterExit=yes
 
       [Install]
       WantedBy=multi-user.target
@@ -259,14 +261,14 @@ mmdebstrap:
       [Unit]
       Description=Catalyst Node Stack (Docker Compose)
       After=docker.service network-online.target catalyst-stack-firstboot.service
-      Requires=docker.service catalyst-stack-firstboot.service
+      Requires=docker.service
       Wants=network-online.target
 
       [Service]
       Type=oneshot
       RemainAfterExit=yes
       WorkingDirectory=/opt/catalyst-node
-      ExecStartPre=/usr/bin/docker compose pull --quiet
+      ExecStartPre=-/usr/bin/docker compose pull --quiet
       ExecStart=/usr/bin/docker compose up -d --remove-orphans
       ExecStop=/usr/bin/docker compose down
       TimeoutStartSec=600

--- a/builds/rpi/layer/catalyst-node.yaml
+++ b/builds/rpi/layer/catalyst-node.yaml
@@ -46,6 +46,8 @@
 # METAEND
 ---
 mmdebstrap:
+  packages:
+    - avahi-daemon
   customize-hooks:
     # Install the pre-built catalyst-node binary from source directory
     - install -m 755 "$SRCROOT/bin/catalyst-node" "$1/usr/local/bin/catalyst-node"
@@ -65,6 +67,7 @@ mmdebstrap:
       CATALYST_BOOTSTRAP_TOKEN=$IGconf_catalyst_bootstrap_token
       CATALYST_AUTH_KEYS_DB=/var/lib/catalyst-node/keys.db
       CATALYST_AUTH_TOKENS_DB=/var/lib/catalyst-node/tokens.db
+      CATALYST_LOG_LEVEL=$IGconf_catalyst_log_level
       OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
       OTEL_SERVICE_NAME=catalyst-node
       ENVEOF
@@ -90,6 +93,7 @@ mmdebstrap:
       # Ensure data directory exists with correct permissions
       mkdir -p /var/lib/catalyst-node
       chmod 750 /var/lib/catalyst-node
+      chown -R catalyst:catalyst /var/lib/catalyst-node
 
       echo "First boot setup complete"
       FBEOF
@@ -107,7 +111,7 @@ mmdebstrap:
       Type=oneshot
       ExecStart=/usr/local/bin/catalyst-firstboot
       ExecStartPost=/usr/bin/touch /var/lib/catalyst-node/.firstboot-done
-      RemainAfterExit=no
+      RemainAfterExit=yes
 
       [Install]
       WantedBy=multi-user.target
@@ -120,15 +124,23 @@ mmdebstrap:
       Description=Catalyst Node
       After=otelcol.service network-online.target catalyst-node-firstboot.service
       Wants=otelcol.service network-online.target
-      Requires=catalyst-node-firstboot.service
 
       [Service]
       Type=simple
+      User=catalyst
       EnvironmentFile=/etc/catalyst-node/catalyst-node.env
       ExecStart=/usr/local/bin/catalyst-node
       WorkingDirectory=/var/lib/catalyst-node
       Restart=on-failure
       RestartSec=5
+      StartLimitBurst=5
+      StartLimitIntervalSec=120
+      ProtectSystem=strict
+      ProtectHome=yes
+      NoNewPrivileges=yes
+      ReadWritePaths=/var/lib/catalyst-node
+      MemoryMax=512M
+      LimitNOFILE=65536
 
       [Install]
       WantedBy=multi-user.target

--- a/builds/rpi/layer/catalyst-otel.yaml
+++ b/builds/rpi/layer/catalyst-otel.yaml
@@ -24,7 +24,9 @@ mmdebstrap:
       OTEL_VERSION="$IGconf_otel_version"
       OTEL_URL="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${OTEL_VERSION}/otelcol-contrib_${OTEL_VERSION}_linux_arm64.tar.gz"
       echo "Downloading otelcol-contrib v${OTEL_VERSION}..."
+      curl -fsSL "${OTEL_URL}.sha256" -o /tmp/otelcol.sha256
       curl -fsSL "$OTEL_URL" -o /tmp/otelcol.tar.gz
+      cd /tmp && sha256sum -c otelcol.sha256
       tar -xzf /tmp/otelcol.tar.gz -C /tmp otelcol-contrib
       install -m 755 /tmp/otelcol-contrib "$1/usr/local/bin/otelcol-contrib"
       rm -f /tmp/otelcol.tar.gz /tmp/otelcol-contrib
@@ -89,6 +91,8 @@ mmdebstrap:
       ExecStart=/usr/local/bin/otelcol-contrib --config /etc/catalyst-node/otel-config.yaml
       Restart=on-failure
       RestartSec=5
+      StartLimitBurst=5
+      StartLimitIntervalSec=120
       MemoryMax=300M
       LimitNOFILE=65536
 

--- a/builds/rpi/layer/catalyst-wifi.yaml
+++ b/builds/rpi/layer/catalyst-wifi.yaml
@@ -14,9 +14,9 @@
 # X-Env-Var-ssid-Set: y
 #
 # X-Env-Var-password:
-# X-Env-Var-password-Desc: WiFi network password (WPA2-PSK)
-# X-Env-Var-password-Required: y
-# X-Env-Var-password-Valid: string
+# X-Env-Var-password-Desc: WiFi network password (WPA2-PSK, leave empty for open network)
+# X-Env-Var-password-Required: n
+# X-Env-Var-password-Valid: string-or-empty
 # X-Env-Var-password-Set: y
 #
 # X-Env-Var-country: US
@@ -31,8 +31,11 @@ mmdebstrap:
     - wpasupplicant
     - wireless-tools
     - iw
+    - firmware-brcm80211
+    - wireless-regdb
+    - w3m
   customize-hooks:
-    # wpa_supplicant config with hashed PSK for the specified network
+    # wpa_supplicant config — WPA2-PSK when password is set, open network otherwise
     - |-
       mkdir -p "$1/etc/wpa_supplicant"
       {
@@ -40,8 +43,15 @@ mmdebstrap:
         echo "update_config=1"
         echo "country=$IGconf_wifi_country"
         echo ""
-        chroot "$1" wpa_passphrase "$IGconf_wifi_ssid" "$IGconf_wifi_password" \
-          | grep -v '#psk='
+        if [ -n "$IGconf_wifi_password" ]; then
+          chroot "$1" wpa_passphrase "$IGconf_wifi_ssid" "$IGconf_wifi_password" \
+            | grep -v '#psk='
+        else
+          echo "network={"
+          echo "    ssid=\"$IGconf_wifi_ssid\""
+          echo "    key_mgmt=NONE"
+          echo "}"
+        fi
       } > "$1/etc/wpa_supplicant/wpa_supplicant-wlan0.conf"
       chmod 600 "$1/etc/wpa_supplicant/wpa_supplicant-wlan0.conf"
     # systemd-networkd config for wlan0 (DHCP)
@@ -56,8 +66,23 @@ mmdebstrap:
       [DHCPv4]
       RouteMetric=600
       NETEOF
-    # Ensure WiFi radio is not soft-blocked (common on minimal images)
-    - chroot "$1" rfkill unblock wifi 2>/dev/null || true
+    # Ensure WiFi radio is not soft-blocked at boot (rfkill needs real hardware)
+    - |-
+      cat > "$1/etc/systemd/system/wifi-rfkill-unblock.service" <<'RFKEOF'
+      [Unit]
+      Description=Unblock WiFi radio
+      Before=wpa_supplicant@wlan0.service
+      ConditionPathExists=/dev/rfkill
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/sbin/rfkill unblock wifi
+      RemainAfterExit=yes
+
+      [Install]
+      WantedBy=multi-user.target
+      RFKEOF
+    - $BDEBSTRAP_HOOKS/enable-units "$1" wifi-rfkill-unblock
     # Ensure resolv.conf points to systemd-resolved stub (safety net)
     - ln -sf /run/systemd/resolve/stub-resolv.conf "$1/etc/resolv.conf"
     # Ensure network-online.target waits for an interface to get an address

--- a/builds/rpi/quickstart.sh
+++ b/builds/rpi/quickstart.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# quickstart.sh — one-command dev setup for a Catalyst RPi image.
+#
+# Detects your current WiFi, generates an SSH key, optionally sets up a
+# Cloudflare Tunnel, generates the config, compiles the binary, and builds
+# the image. Stops right before flashing.
+#
+# Usage:
+#   ./builds/rpi/quickstart.sh
+#   ./builds/rpi/quickstart.sh --no-tunnel
+#   ./builds/rpi/quickstart.sh --domain example.com --tunnel-name edge-01
+#   ./builds/rpi/quickstart.sh --hostname my-node --password secret
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR="$REPO_ROOT/dist/rpi"
+
+# ─── Defaults (edit these) ────────────────────────────────────────────────────
+PASSWORD="Catalyst1!"
+PI_HOSTNAME="catalyst-node"
+MODE="native"
+IMAGE_NAME="catalyst-node-image"
+WIFI_COUNTRY="US"
+SSH_KEY="$HOME/.ssh/catalyst-deploy"
+NO_TUNNEL=false
+DRY_RUN=false
+CF_DOMAIN=""
+TUNNEL_NAME=""
+
+# ─── Parse args ───────────────────────────────────────────────────────────────
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+One-command dev setup: detect WiFi, generate SSH key, set up Cloudflare
+Tunnel, generate config, compile binary, and build the RPi image.
+
+Options:
+  --password <pass>        Login password (default: Catalyst1!)
+  --hostname <name>        Pi hostname (default: catalyst-node)
+  --mode <native|docker>   Deployment mode (default: native)
+  --wifi-country <code>    WiFi country code (default: US)
+  --domain <domain>        Cloudflare domain for tunnel DNS route
+  --tunnel-name <name>     Cloudflare Tunnel name (default: same as hostname)
+  --no-tunnel              Skip Cloudflare Tunnel setup
+  --dry-run                Generate config only, skip build
+  -h, --help               Show this help
+
+Examples:
+  # Minimal — detect WiFi, skip tunnel
+  $(basename "$0") --no-tunnel
+
+  # Full — with Cloudflare Tunnel
+  $(basename "$0") --domain example.com
+
+  # Custom hostname and password
+  $(basename "$0") --hostname edge-01 --password mypass --domain example.com
+EOF
+  exit 0
+}
+
+needs_arg() { if [[ $# -lt 2 || "$2" == --* ]]; then err "$1 requires a value"; fi; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --password)     needs_arg "$@"; PASSWORD="$2"; shift 2 ;;
+    --hostname)     needs_arg "$@"; PI_HOSTNAME="$2"; shift 2 ;;
+    --mode)         needs_arg "$@"; MODE="$2"; shift 2 ;;
+    --wifi-country) needs_arg "$@"; WIFI_COUNTRY="$2"; shift 2 ;;
+    --domain)       needs_arg "$@"; CF_DOMAIN="$2"; shift 2 ;;
+    --tunnel-name)  needs_arg "$@"; TUNNEL_NAME="$2"; shift 2 ;;
+    --no-tunnel)    NO_TUNNEL=true; shift ;;
+    --dry-run)      DRY_RUN=true; shift ;;
+    -h|--help)      usage ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+TUNNEL_NAME="${TUNNEL_NAME:-$PI_HOSTNAME}"
+
+if [[ "$MODE" != "native" && "$MODE" != "docker" ]]; then
+  echo "Invalid mode: $MODE (must be 'native' or 'docker')" >&2; exit 1
+fi
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+info()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn()  { printf '\033[1;33m  ⚠\033[0m  %s\n' "$*"; }
+err()   { printf '\033[1;31m  ✗\033[0m  %s\n' "$*" >&2; exit 1; }
+ok()    { printf '\033[1;32m  ✓\033[0m  %s\n' "$*"; }
+
+# ─── 0. Preflight ────────────────────────────────────────────────────────────
+if [[ "$DRY_RUN" == false ]]; then
+  if ! command -v docker &>/dev/null; then
+    err "Docker is required to build the image. Install Docker Desktop first."
+  fi
+  if ! docker info &>/dev/null; then
+    err "Docker is not running. Start Docker Desktop first."
+  fi
+  ok "Docker available"
+fi
+
+if ! command -v bun &>/dev/null; then
+  err "bun is required. Install it: https://bun.sh"
+fi
+
+# ─── 1. Detect WiFi ──────────────────────────────────────────────────────────
+info "Detecting WiFi..."
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  WIFI_IF=$(networksetup -listallhardwareports | awk '/Wi-Fi|AirPort/{getline; print $2}')
+  WIFI_IF="${WIFI_IF:-en0}"
+  # ipconfig works on modern macOS where networksetup may report "not associated"
+  SSID=$(ipconfig getsummary "$WIFI_IF" 2>/dev/null | awk -F' : ' '/^  SSID /{print $2}')
+  if [[ -z "$SSID" ]]; then
+    # Fallback to networksetup for older macOS
+    SSID=$(networksetup -getairportnetwork "$WIFI_IF" 2>/dev/null | sed 's/^Current Wi-Fi Network: //')
+  fi
+  if [[ -z "$SSID" || "$SSID" == *"not associated"* ]]; then
+    err "Not connected to WiFi. Connect to a network first."
+  fi
+  # TODO: read WiFi password from macOS Keychain
+  # WIFI_PASS=$(security find-generic-password -D "AirPort network password" -a "$SSID" -w 2>/dev/null || true)
+  # if [[ -z "$WIFI_PASS" ]]; then
+  #   WIFI_PASS=$(security find-generic-password -ga "$SSID" 2>&1 | grep "password:" | sed 's/^password: "\(.*\)"$/\1/' || true)
+  # fi
+  WIFI_PASS=""
+else
+  # Linux — try nmcli
+  SSID=$(nmcli -t -f active,ssid dev wifi | grep '^yes' | sed 's/^yes://')
+  if [[ -z "$SSID" ]]; then
+    err "Not connected to WiFi."
+  fi
+  WIFI_PASS=$(nmcli -s -g 802-11-wireless-security.psk connection show "$SSID" 2>/dev/null || true)
+fi
+
+ok "WiFi: $SSID"
+
+# ─── 2. SSH Key ──────────────────────────────────────────────────────────────
+info "Checking SSH key..."
+
+if [[ -f "$SSH_KEY" ]]; then
+  ok "Using existing key: $SSH_KEY"
+else
+  SSH_DIR="$(dirname "$SSH_KEY")"
+  if [[ ! -d "$SSH_DIR" ]]; then
+    mkdir -p "$SSH_DIR"
+    chmod 700 "$SSH_DIR"
+    ok "Created $SSH_DIR"
+  fi
+  ssh-keygen -t ed25519 -f "$SSH_KEY" -C "catalyst-deploy" -N ""
+  ok "Generated key: $SSH_KEY"
+fi
+
+# ─── 3. Cloudflare Tunnel (optional) ─────────────────────────────────────────
+CF_TOKEN=""
+
+if [[ "$NO_TUNNEL" == false ]]; then
+  info "Setting up Cloudflare Tunnel..."
+
+  if ! command -v cloudflared &>/dev/null; then
+    info "Installing cloudflared..."
+    if [[ "$(uname)" == "Darwin" ]]; then
+      brew install cloudflared
+    else
+      err "cloudflared not found. Install it: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/"
+    fi
+  fi
+  ok "cloudflared installed"
+
+  # Authenticate if needed
+  if [[ ! -f "$HOME/.cloudflared/cert.pem" ]]; then
+    info "Authenticating with Cloudflare (opens browser)..."
+    cloudflared tunnel login
+  fi
+  ok "Authenticated"
+
+  # Determine the public hostname for the tunnel
+  if [[ -z "$CF_DOMAIN" ]]; then
+    err "Cloudflare Tunnel requires --domain <your-domain>. Use --no-tunnel to skip."
+  fi
+  CF_HOSTNAME="ssh-${TUNNEL_NAME}.${CF_DOMAIN}"
+
+  # Create tunnel (ignore error if it already exists)
+  if cloudflared tunnel info "$TUNNEL_NAME" &>/dev/null; then
+    ok "Tunnel '$TUNNEL_NAME' already exists"
+  else
+    info "Creating tunnel: $TUNNEL_NAME"
+    cloudflared tunnel create "$TUNNEL_NAME"
+    ok "Tunnel created"
+  fi
+
+  # Route DNS (ignore error if route already exists)
+  info "Routing $CF_HOSTNAME → tunnel"
+  cloudflared tunnel route dns "$TUNNEL_NAME" "$CF_HOSTNAME" 2>/dev/null || true
+  ok "DNS route: $CF_HOSTNAME"
+
+  # Get token
+  CF_TOKEN=$(cloudflared tunnel token "$TUNNEL_NAME")
+  ok "Got tunnel token"
+fi
+
+# ─── 4. Generate config ──────────────────────────────────────────────────────
+info "Generating config..."
+
+# Pass secrets via env vars so they don't appear in `ps aux`
+export CATALYST_PASSWORD="$PASSWORD"
+if [[ -n "$WIFI_PASS" ]]; then
+  export CATALYST_WIFI_PASSWORD="$WIFI_PASS"
+fi
+if [[ -n "$CF_TOKEN" ]]; then
+  export CATALYST_CF_TUNNEL_TOKEN="$CF_TOKEN"
+fi
+
+CONFIG_ARGS=(
+  --non-interactive
+  --mode "$MODE"
+  --hostname "$PI_HOSTNAME"
+  --wifi-ssid "$SSID"
+  --wifi-country "$WIFI_COUNTRY"
+  --ssh-pubkey-file "${SSH_KEY}.pub"
+  -o "$OUT_DIR"
+)
+
+if [[ -z "$CF_TOKEN" ]]; then
+  CONFIG_ARGS+=(--no-cloudflared)
+fi
+
+if [[ "$DRY_RUN" == true ]]; then
+  CONFIG_ARGS+=(--dry-run)
+fi
+
+(cd "$REPO_ROOT" && bun run apps/rpi-config/src/index.ts "${CONFIG_ARGS[@]}")
+
+unset CATALYST_PASSWORD CATALYST_WIFI_PASSWORD CATALYST_CF_TUNNEL_TOKEN
+
+if [[ "$DRY_RUN" == true ]]; then
+  ok "Dry run complete — config printed above, nothing built."
+  exit 0
+fi
+
+ok "Config written to $OUT_DIR/config.yaml"
+
+# ─── 5. Build binary (native mode only) ──────────────────────────────────────
+if [[ "$MODE" == "native" ]]; then
+  info "Compiling catalyst-node binary for ARM64..."
+  (cd "$REPO_ROOT" && bun build --compile --target=bun-linux-arm64 \
+    --outfile "$OUT_DIR/bin/catalyst-node" apps/node/src/index.ts)
+  ok "Binary: $OUT_DIR/bin/catalyst-node"
+fi
+
+# ─── 6. Build image ──────────────────────────────────────────────────────────
+info "Building RPi image (this runs in Docker)..."
+"$SCRIPT_DIR/build-docker.sh" --source-dir "$OUT_DIR" "$OUT_DIR/config.yaml"
+
+# ─── Done ─────────────────────────────────────────────────────────────────────
+IMG_PATH="$OUT_DIR/build/image-${IMAGE_NAME}/${IMAGE_NAME}.img"
+
+echo ""
+info "Image ready! Next steps:"
+echo ""
+echo "  1. Flash the SD card:"
+if [[ "$(uname)" == "Darwin" ]]; then
+  echo "     diskutil list                    # find your SD card"
+  echo "     diskutil unmountDisk /dev/diskN"
+  echo "     sudo dd if=$IMG_PATH \\"
+  echo "       of=/dev/rdiskN bs=4m status=progress"
+else
+  echo "     lsblk                            # find your SD card"
+  echo "     sudo dd if=$IMG_PATH \\"
+  echo "       of=/dev/sdX bs=4M status=progress"
+fi
+echo ""
+echo "  Or use Raspberry Pi Imager → 'Use custom' → select the .img file."
+echo ""
+echo "  2. Boot the Pi, then SSH in:"
+echo "     ssh -i $SSH_KEY catalyst@$PI_HOSTNAME.local"
+if [[ -n "$CF_TOKEN" ]]; then
+  echo ""
+  echo "  Or via Cloudflare Tunnel:"
+  echo "     ssh -o ProxyCommand=\"cloudflared access ssh --hostname %h\" \\"
+  echo "       -i $SSH_KEY catalyst@$CF_HOSTNAME"
+fi
+echo ""

--- a/docs/builds/rpi.md
+++ b/docs/builds/rpi.md
@@ -6,10 +6,10 @@ overhead) and **Docker Compose** (multi-container, service isolation).
 
 The build system has two parts:
 
-| Component | Location | Purpose |
-|-----------|----------|---------|
-| **Config CLI** | `apps/rpi-config/` | TypeScript CLI that generates rpi-image-gen config YAML |
-| **Build runner** | `builds/rpi/` | Shell script + layer definitions that produce a flashable `.img` |
+| Component        | Location           | Purpose                                                          |
+| ---------------- | ------------------ | ---------------------------------------------------------------- |
+| **Config CLI**   | `apps/rpi-config/` | TypeScript CLI that generates rpi-image-gen config YAML          |
+| **Build runner** | `builds/rpi/`      | Shell script + layer definitions that produce a flashable `.img` |
 
 ---
 
@@ -76,6 +76,7 @@ catalyst-router/
 │       │   ├── catalyst-otel.yaml
 │       │   ├── catalyst-node.yaml
 │       │   ├── catalyst-docker-stack.yaml
+│       │   ├── catalyst-console.yaml
 │       │   └── catalyst-cloudflared.yaml
 │       └── bin/
 │           └── .gitkeep         # Pre-built ARM64 binary (native mode)
@@ -133,39 +134,39 @@ bun run apps/rpi-config/src/index.ts \
 
 ### CLI Options
 
-| Category | Flag | Description | Default |
-|----------|------|-------------|---------|
-| **Output** | `-o, --output <path>` | Output YAML file path | `./catalyst-node.yaml` |
-| | `-m, --mode <mode>` | `native` or `docker` | `native` |
-| | `--dry-run` | Print YAML to stdout | — |
-| **Device** | `--device <layer>` | Device layer name | `rpi5` |
-| | `--hostname <name>` | System hostname | `catalyst-node` |
-| | `--username <user>` | Login username | `catalyst` |
-| | `--password <pass>` | Login password | — |
-| **WiFi** | `--wifi-ssid <ssid>` | WiFi SSID (omit to skip) | — |
-| | `--wifi-password <pass>` | WiFi password | — |
-| | `--wifi-country <code>` | Regulatory country code | `US` |
-| | `--no-wifi` | Explicitly skip WiFi | — |
-| **SSH** | `--ssh-pubkey <key>` | SSH public key string | — |
-| | `--ssh-pubkey-file <path>` | Read public key from file | — |
-| | `--no-ssh-pubkey` | Skip SSH key config | — |
-| **Node** | `--node-id <id>` | Node identifier | auto-generated |
-| | `--peering-secret <secret>` | iBGP peering secret | — |
-| | `--domains <list>` | Comma-separated trusted domains | — |
-| | `--port <port>` | Listen port | `3000` |
-| | `--bootstrap-token <token>` | Auth bootstrap token | — |
-| | `--log-level <level>` | `debug`, `info`, `warn`, `error` | `info` |
-| **Docker** | `--registry <url>` | Container registry (docker mode only) | — |
-| | `--tag <tag>` | Container image tag | `latest` |
-| **OTEL** | `--otel-version <ver>` | OTEL Collector version | `0.145.0` |
-| **Tunnel** | `--cloudflared-token <token>` | Cloudflare Tunnel token (omit to skip) | — |
-| | `--no-cloudflared` | Explicitly skip cloudflared | — |
-| **Image** | `--image-name <name>` | Output image name | `catalyst-node-image` |
-| | `--boot-part-size <size>` | Boot partition size | `200%` |
-| | `--root-part-size <size>` | Root partition size | `400%` / `500%` |
-| **Validation** | `--rpi-image-gen <path>` | Path to rpi-image-gen for layer validation | auto-detected |
-| | `--skip-validation` | Skip layer existence checks | — |
-| **General** | `--non-interactive` | Skip prompts, use defaults | — |
+| Category       | Flag                          | Description                                | Default                |
+| -------------- | ----------------------------- | ------------------------------------------ | ---------------------- |
+| **Output**     | `-o, --output <path>`         | Output YAML file path                      | `./catalyst-node.yaml` |
+|                | `-m, --mode <mode>`           | `native` or `docker`                       | `native`               |
+|                | `--dry-run`                   | Print YAML to stdout                       | —                      |
+| **Device**     | `--device <layer>`            | Device layer name                          | `rpi5`                 |
+|                | `--hostname <name>`           | System hostname                            | `catalyst-node`        |
+|                | `--username <user>`           | Login username                             | `catalyst`             |
+|                | `--password <pass>`           | Login password                             | —                      |
+| **WiFi**       | `--wifi-ssid <ssid>`          | WiFi SSID (omit to skip)                   | —                      |
+|                | `--wifi-password <pass>`      | WiFi password                              | —                      |
+|                | `--wifi-country <code>`       | Regulatory country code                    | `US`                   |
+|                | `--no-wifi`                   | Explicitly skip WiFi                       | —                      |
+| **SSH**        | `--ssh-pubkey <key>`          | SSH public key string                      | —                      |
+|                | `--ssh-pubkey-file <path>`    | Read public key from file                  | —                      |
+|                | `--no-ssh-pubkey`             | Skip SSH key config                        | —                      |
+| **Node**       | `--node-id <id>`              | Node identifier                            | auto-generated         |
+|                | `--peering-secret <secret>`   | iBGP peering secret                        | —                      |
+|                | `--domains <list>`            | Comma-separated trusted domains            | —                      |
+|                | `--port <port>`               | Listen port                                | `3000`                 |
+|                | `--bootstrap-token <token>`   | Auth bootstrap token                       | —                      |
+|                | `--log-level <level>`         | `debug`, `info`, `warn`, `error`           | `info`                 |
+| **Docker**     | `--registry <url>`            | Container registry (docker mode only)      | —                      |
+|                | `--tag <tag>`                 | Container image tag                        | `latest`               |
+| **OTEL**       | `--otel-version <ver>`        | OTEL Collector version                     | `0.145.0`              |
+| **Tunnel**     | `--cloudflared-token <token>` | Cloudflare Tunnel token (omit to skip)     | —                      |
+|                | `--no-cloudflared`            | Explicitly skip cloudflared                | —                      |
+| **Image**      | `--image-name <name>`         | Output image name                          | `catalyst-node-image`  |
+|                | `--boot-part-size <size>`     | Boot partition size                        | `200%`                 |
+|                | `--root-part-size <size>`     | Root partition size                        | `400%` / `500%`        |
+| **Validation** | `--rpi-image-gen <path>`      | Path to rpi-image-gen for layer validation | auto-detected          |
+|                | `--skip-validation`           | Skip layer existence checks                | —                      |
+| **General**    | `--non-interactive`           | Skip prompts, use defaults                 | —                      |
 
 ### Dry Run
 
@@ -203,43 +204,43 @@ include:
 
 # Target device and login credentials
 device:
-  layer: rpi5            # Hardware: Raspberry Pi 5
+  layer: rpi5 # Hardware: Raspberry Pi 5
   hostname: catalyst-node
-  user1: catalyst        # Login username
-  user1pass: changeme    # Login password (change after first boot)
+  user1: catalyst # Login username
+  user1pass: changeme # Login password (change after first boot)
 
 # Layers to include in the build.
 # Each entry pulls in a layer YAML and its transitive dependencies.
 # Remove a line to exclude that feature from the image.
 layer:
-  otel: catalyst-otel              # OpenTelemetry Collector (native binary)
-  app: catalyst-node               # Catalyst Node composite server
-  wifi: catalyst-wifi              # WiFi (wpa_supplicant + systemd-networkd)
-  tunnel: catalyst-cloudflared     # Cloudflare Tunnel for remote SSH
+  otel: catalyst-otel # OpenTelemetry Collector (native binary)
+  app: catalyst-node # Catalyst Node composite server
+  wifi: catalyst-wifi # WiFi (wpa_supplicant + systemd-networkd)
+  tunnel: catalyst-cloudflared # Cloudflare Tunnel for remote SSH
 ```
 
 > **This file will contain real passwords and secrets.** See [Security Warning](#security-warning).
 
 ### Module Breakdown
 
-| Module | Responsibility |
-|--------|---------------|
-| `index.ts` | Commander setup, option parsing, orchestrates the pipeline |
-| `prompts.ts` | Interactive prompt sequences via `@inquirer/prompts` — grouped by section, skips flags already provided |
-| `config-builder.ts` | Pure function: resolved options in, config object out. Only includes sections for selected features |
-| `yaml-writer.ts` | Serializes config to YAML using the `yaml` library Document API. Attaches section and inline comments |
-| `validator.ts` | Walks rpi-image-gen's search paths (`layer/`, `device/`, `image/`) to verify every referenced layer exists |
-| `instructions.ts` | Prints build prerequisites, `rpi-image-gen build` command, and flash instructions |
-| `defaults.ts` | Default values, supported device list, version constants |
-| `types.ts` | `ResolvedOptions` and `RpiImageGenConfig` interfaces |
+| Module              | Responsibility                                                                                             |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `index.ts`          | Commander setup, option parsing, orchestrates the pipeline                                                 |
+| `prompts.ts`        | Interactive prompt sequences via `@inquirer/prompts` — grouped by section, skips flags already provided    |
+| `config-builder.ts` | Pure function: resolved options in, config object out. Only includes sections for selected features        |
+| `yaml-writer.ts`    | Serializes config to YAML using the `yaml` library Document API. Attaches section and inline comments      |
+| `validator.ts`      | Walks rpi-image-gen's search paths (`layer/`, `device/`, `image/`) to verify every referenced layer exists |
+| `instructions.ts`   | Prints build prerequisites, `rpi-image-gen build` command, and flash instructions                          |
+| `defaults.ts`       | Default values, supported device list, version constants                                                   |
+| `types.ts`          | `ResolvedOptions` and `RpiImageGenConfig` interfaces                                                       |
 
 ### Dependencies
 
-| Package | Purpose |
-|---------|---------|
-| `commander` | CLI option parsing (already used by `apps/node`) |
+| Package             | Purpose                                              |
+| ------------------- | ---------------------------------------------------- |
+| `commander`         | CLI option parsing (already used by `apps/node`)     |
 | `@inquirer/prompts` | Interactive select, input, confirm, password prompts |
-| `yaml` | YAML serialization with comment node support |
+| `yaml`              | YAML serialization with comment node support         |
 
 ---
 
@@ -279,22 +280,22 @@ and runs these steps:
 
 ### Options
 
-| Flag | Description | Default |
-|------|-------------|---------|
+| Flag                     | Description                             | Default                               |
+| ------------------------ | --------------------------------------- | ------------------------------------- |
 | `--rpi-image-gen <path>` | Path to existing rpi-image-gen checkout | Clones to `builds/rpi/rpi-image-gen/` |
-| `--build-dir <path>` | Build output directory | rpi-image-gen default (`work/`) |
-| `--skip-deps` | Skip dependency installation | — |
-| `--branch <branch>` | Git branch to clone | `main` |
+| `--build-dir <path>`     | Build output directory                  | rpi-image-gen default (`work/`)       |
+| `--skip-deps`            | Skip dependency installation            | —                                     |
+| `--branch <branch>`      | Git branch to clone                     | `master`                              |
 
 ### Host Requirements
 
-| Requirement | Detail |
-|-------------|--------|
-| **OS** | Debian Bookworm or Trixie |
-| **Architecture** | arm64 (aarch64) |
-| **Recommended hardware** | Raspberry Pi 5 running Pi OS |
-| **Sudo access** | Required once for `install_deps.sh` |
-| **Disk space** | ~4 GB free for a minimal image build |
+| Requirement              | Detail                               |
+| ------------------------ | ------------------------------------ |
+| **OS**                   | Debian Bookworm or Trixie            |
+| **Architecture**         | arm64 (aarch64)                      |
+| **Recommended hardware** | Raspberry Pi 5 running Pi OS         |
+| **Sudo access**          | Required once for `install_deps.sh`  |
+| **Disk space**           | ~4 GB free for a minimal image build |
 
 > rpi-image-gen does not support cross-compilation. The build **must** run
 > on an arm64 Debian host. A Raspberry Pi 5 with Pi OS is the recommended
@@ -305,9 +306,9 @@ and runs these steps:
 Two base configs are included for direct use without the CLI. They include
 only the always-on layers and use placeholder credentials:
 
-| Config | Mode | Layers |
-|--------|------|--------|
-| `config/base-native.yaml` | Native binary | `catalyst-otel`, `catalyst-node` |
+| Config                    | Mode           | Layers                                            |
+| ------------------------- | -------------- | ------------------------------------------------- |
+| `config/base-native.yaml` | Native binary  | `catalyst-otel`, `catalyst-node`                  |
 | `config/base-docker.yaml` | Docker Compose | `docker-debian-bookworm`, `catalyst-docker-stack` |
 
 These are safe to commit — they contain no real secrets. To use them directly:
@@ -328,13 +329,14 @@ declare their dependencies, required variables, and install hooks.
 
 ### Layer Catalog
 
-| Layer | Category | Description |
-|-------|----------|-------------|
-| `catalyst-wifi` | net | WiFi via wpa\_supplicant + systemd-networkd for headless boot |
-| `catalyst-otel` | app | OpenTelemetry Collector (contrib) native ARM64 binary. Downloads at build time from GitHub releases |
-| `catalyst-node` | app | Catalyst Node composite server (auth + gateway + orchestrator) as a pre-compiled Bun binary |
-| `catalyst-docker-stack` | app | Catalyst Node multi-container stack via Docker Compose (auth, gateway, orchestrator, OTEL) |
-| `catalyst-cloudflared` | net | Cloudflare Tunnel for remote SSH. Installed from the Cloudflare apt repository |
+| Layer                   | Category | Description                                                                                                                                                                                         |
+| ----------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `catalyst-wifi`         | net      | WiFi via wpa_supplicant + systemd-networkd for headless boot. Includes `firmware-brcm80211` and `wireless-regdb` for RPi WiFi hardware support                                                      |
+| `catalyst-otel`         | app      | OpenTelemetry Collector (contrib) native ARM64 binary. Downloads at build time from GitHub releases with SHA256 checksum verification                                                               |
+| `catalyst-node`         | app      | Catalyst Node composite server (auth + gateway + orchestrator) as a pre-compiled Bun binary. Runs as dedicated `catalyst` user with systemd hardening (ProtectSystem, NoNewPrivileges, MemoryMax)   |
+| `catalyst-docker-stack` | app      | Catalyst Node multi-container stack via Docker Compose (auth, gateway, orchestrator, OTEL). Tolerates pull failures on boot to work with cached images                                              |
+| `catalyst-console`      | sys      | Autologin on tty1 with live systemd journal stream and `conspy` for remote console mirroring over SSH. Automatically logs in the configured user on the physical console for at-a-glance monitoring |
+| `catalyst-cloudflared`  | net      | Cloudflare Tunnel for remote SSH. Installed from the Cloudflare apt repository                                                                                                                      |
 
 ### Layer Dependencies
 
@@ -355,6 +357,10 @@ catalyst-docker-stack
   ├── ca-certificates (built-in)
   └── docker provider (docker-debian-bookworm, built-in)
 
+catalyst-console
+  ├── systemd-min (built-in)
+  └── rpi-user-credentials (built-in)
+
 catalyst-cloudflared
   ├── ca-certificates (built-in)
   └── openssh-server (built-in)
@@ -367,47 +373,73 @@ with `IGconf_<varprefix>_<name>` internally.
 
 **catalyst-wifi** (prefix: `wifi`)
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `ssid` | yes | WiFi network SSID |
-| `password` | yes | WiFi password (WPA2-PSK) |
-| `country` | no | Regulatory country code (default: `US`) |
+| Variable   | Required | Description                                            |
+| ---------- | -------- | ------------------------------------------------------ |
+| `ssid`     | yes      | WiFi network SSID                                      |
+| `password` | no       | WiFi password (WPA2-PSK, leave empty for open network) |
+| `country`  | no       | Regulatory country code (default: `US`)                |
 
 **catalyst-otel** (prefix: `otel`)
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `version` | no | OTEL Collector version (default: `0.145.0`) |
+| Variable  | Required | Description                                 |
+| --------- | -------- | ------------------------------------------- |
+| `version` | no       | OTEL Collector version (default: `0.145.0`) |
 
 **catalyst-node** (prefix: `catalyst`)
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `node_id` | no | Unique node identifier (auto-generated on first boot if empty) |
-| `peering_secret` | no | iBGP peering shared secret |
-| `domains` | no | Comma-separated trusted domains |
-| `port` | no | Listen port (default: `3000`) |
-| `bootstrap_token` | no | Initial auth bootstrap token |
-| `log_level` | no | `debug`, `info`, `warn`, `error` (default: `info`) |
+| Variable          | Required | Description                                                    |
+| ----------------- | -------- | -------------------------------------------------------------- |
+| `node_id`         | no       | Unique node identifier (auto-generated on first boot if empty) |
+| `peering_secret`  | no       | iBGP peering shared secret                                     |
+| `domains`         | no       | Comma-separated trusted domains                                |
+| `port`            | no       | Listen port (default: `3000`)                                  |
+| `bootstrap_token` | no       | Initial auth bootstrap token                                   |
+| `log_level`       | no       | `debug`, `info`, `warn`, `error` (default: `info`)             |
 
 **catalyst-docker-stack** (prefix: `catalyst`)
 
 Same as `catalyst-node`, plus:
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `registry` | yes | Container registry for catalyst images |
-| `tag` | no | Container image tag (default: `latest`) |
+| Variable   | Required | Description                             |
+| ---------- | -------- | --------------------------------------- |
+| `registry` | yes      | Container registry for catalyst images  |
+| `tag`      | no       | Container image tag (default: `latest`) |
+
+**catalyst-console** (no variables — uses `IGconf_device_user1` from device config)
+
+Enables autologin on tty1 and streams the systemd journal, so plugging in
+an HDMI monitor shows live service logs without any login required. Includes
+`conspy` for remote console mirroring over SSH (`sudo conspy 1`) and grants
+the configured user passwordless sudo for `conspy` only.
 
 **catalyst-cloudflared** (prefix: `cloudflared`)
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `tunnel_token` | yes | Cloudflare Tunnel token from the Zero Trust dashboard |
+| Variable       | Required | Description                                           |
+| -------------- | -------- | ----------------------------------------------------- |
+| `tunnel_token` | yes      | Cloudflare Tunnel token from the Zero Trust dashboard |
 
 > **All variable values that contain passwords, secrets, or tokens are written
 > in plain text** into the generated config YAML and baked into the image
 > filesystem. See [Security Warning](#security-warning).
+
+### Service Hardening
+
+All long-running systemd services include the following protections:
+
+| Directive                                         | Service(s)                                 | Purpose                                                              |
+| ------------------------------------------------- | ------------------------------------------ | -------------------------------------------------------------------- |
+| `StartLimitBurst=5` / `StartLimitIntervalSec=120` | catalyst-node, otelcol, cloudflared-tunnel | Prevents infinite crash-restart loops (max 5 restarts per 2 minutes) |
+| `User=catalyst`                                   | catalyst-node                              | Runs as a dedicated unprivileged user instead of root                |
+| `User=otelcol`                                    | otelcol                                    | Runs as a dedicated system user                                      |
+| `ProtectSystem=strict`                            | catalyst-node                              | Mounts filesystem read-only except for `ReadWritePaths`              |
+| `ProtectHome=yes`                                 | catalyst-node                              | Denies access to `/home`, `/root`, `/run/user`                       |
+| `NoNewPrivileges=yes`                             | catalyst-node                              | Prevents privilege escalation via setuid/setgid binaries             |
+| `ReadWritePaths=/var/lib/catalyst-node`           | catalyst-node                              | Only writable path for app data (keys.db, tokens.db)                 |
+| `MemoryMax=512M` / `MemoryMax=300M`               | catalyst-node / otelcol                    | OOM-kills the service before it starves the system                   |
+| `LimitNOFILE=65536`                               | catalyst-node, otelcol                     | Raises file descriptor limit for high connection counts              |
+
+The firstboot oneshot services use `RemainAfterExit=yes` so systemd correctly
+tracks their completion and dependent services start in the right order.
 
 ---
 
@@ -419,6 +451,7 @@ The composite Catalyst Node server (auth + gateway + orchestrator) runs as a
 single Bun-compiled ARM64 binary alongside a native OTEL Collector binary.
 
 **Prerequisites:**
+
 - Build the binary: `bun build --compile --target=bun-linux-arm64 --outfile builds/rpi/bin/catalyst-node apps/node/src/index.ts`
 - Place it at `builds/rpi/bin/catalyst-node`
 
@@ -426,26 +459,26 @@ single Bun-compiled ARM64 binary alongside a native OTEL Collector binary.
 
 ```
 network-online.target
-  ├── otelcol.service
+  ├── otelcol.service (User=otelcol)
   ├── sshd
   └── cloudflared-tunnel.service (optional)
         │
 otelcol ready
         │
-catalyst-node-firstboot.service (once — generates node ID if needed)
+catalyst-node-firstboot.service (once — generates node ID, chowns data dir)
         │
-catalyst-node.service
+catalyst-node.service (User=catalyst, ProtectSystem=strict)
 ```
 
 **Runtime characteristics:**
 
-| Metric | Value |
-|--------|-------|
-| RAM usage | ~300–500 MB |
-| Boot to ready | ~5–10 s |
-| Root partition | 400% |
-| Logs | `journalctl -u catalyst-node` |
-| Update | Replace binary, restart service |
+| Metric         | Value                           |
+| -------------- | ------------------------------- |
+| RAM usage      | ~300–500 MB                     |
+| Boot to ready  | ~5–10 s                         |
+| Root partition | 400%                            |
+| Logs           | `journalctl -u catalyst-node`   |
+| Update         | Replace binary, restart service |
 
 ### Docker Compose
 
@@ -453,6 +486,7 @@ Four containers (auth, gateway, orchestrator, OTEL collector) managed by
 Docker Compose with health check dependencies.
 
 **Prerequisites:**
+
 - Publish ARM64 container images to a registry
 
 **Boot sequence:**
@@ -476,25 +510,25 @@ catalyst-stack.service (docker compose up)
 
 **Runtime characteristics:**
 
-| Metric | Value |
-|--------|-------|
-| RAM usage | ~1–1.5 GB |
-| Boot to ready | ~60–90 s (pull + health checks) |
-| Root partition | 500% |
-| Logs | `docker compose logs` in `/opt/catalyst-node` |
-| Update | `docker compose pull && docker compose up -d` |
+| Metric         | Value                                         |
+| -------------- | --------------------------------------------- |
+| RAM usage      | ~1–1.5 GB                                     |
+| Boot to ready  | ~60–90 s (pull + health checks)               |
+| Root partition | 500%                                          |
+| Logs           | `docker compose logs` in `/opt/catalyst-node` |
+| Update         | `docker compose pull && docker compose up -d` |
 
 ### Comparison
 
-| Aspect | Native Binary | Docker Compose |
-|--------|---------------|----------------|
-| RAM | ~300–500 MB | ~1–1.5 GB |
-| Boot to ready | ~5–10 s | ~60–90 s |
-| Docker required | No | Yes |
-| Root partition | 400% | 500% (container images) |
-| Update strategy | Replace binary + restart | `docker compose pull` + restart |
-| Debugging | `journalctl -u catalyst-node` | `docker compose logs` |
-| Isolation | Single process | Container boundaries |
+| Aspect          | Native Binary                 | Docker Compose                  |
+| --------------- | ----------------------------- | ------------------------------- |
+| RAM             | ~300–500 MB                   | ~1–1.5 GB                       |
+| Boot to ready   | ~5–10 s                       | ~60–90 s                        |
+| Docker required | No                            | Yes                             |
+| Root partition  | 400%                          | 500% (container images)         |
+| Update strategy | Replace binary + restart      | `docker compose pull` + restart |
+| Debugging       | `journalctl -u catalyst-node` | `docker compose logs`           |
+| Isolation       | Single process                | Container boundaries            |
 
 ---
 
@@ -502,30 +536,30 @@ catalyst-stack.service (docker compose up)
 
 ### Native Mode
 
-| Service | Port | Protocol |
-|---------|------|----------|
-| Catalyst Node (composite) | 3000 | HTTP + WebSocket |
-| — `/auth/*` | (same) | Auth, JWKS, token RPC |
-| — `/gateway/*` | (same) | GraphQL federation |
-| — `/orchestrator/*` | (same) | Peering RPC |
-| OTEL Collector (gRPC) | 4317 | OTLP |
-| OTEL Collector (HTTP) | 4318 | OTLP |
-| OTEL Collector (health) | 13133 | HTTP |
-| SSH | 22 | SSH |
-| Cloudflare Tunnel | outbound | HTTPS |
+| Service                   | Port     | Protocol              |
+| ------------------------- | -------- | --------------------- |
+| Catalyst Node (composite) | 3000     | HTTP + WebSocket      |
+| — `/auth/*`               | (same)   | Auth, JWKS, token RPC |
+| — `/gateway/*`            | (same)   | GraphQL federation    |
+| — `/orchestrator/*`       | (same)   | Peering RPC           |
+| OTEL Collector (gRPC)     | 4317     | OTLP                  |
+| OTEL Collector (HTTP)     | 4318     | OTLP                  |
+| OTEL Collector (health)   | 13133    | HTTP                  |
+| SSH                       | 22       | SSH                   |
+| Cloudflare Tunnel         | outbound | HTTPS                 |
 
 ### Docker Mode
 
-| Service | Port | Protocol |
-|---------|------|----------|
-| Orchestrator | 3000 | HTTP + WebSocket |
-| Gateway | 4000 | HTTP + WebSocket |
-| Auth | 5000 | HTTP + WebSocket |
-| OTEL Collector (gRPC) | 4317 | OTLP |
-| OTEL Collector (HTTP) | 4318 | OTLP |
-| OTEL Collector (health) | 13133 | HTTP |
-| SSH | 22 | SSH |
-| Cloudflare Tunnel | outbound | HTTPS |
+| Service                 | Port     | Protocol         |
+| ----------------------- | -------- | ---------------- |
+| Orchestrator            | 3000     | HTTP + WebSocket |
+| Gateway                 | 4000     | HTTP + WebSocket |
+| Auth                    | 5000     | HTTP + WebSocket |
+| OTEL Collector (gRPC)   | 4317     | OTLP             |
+| OTEL Collector (HTTP)   | 4318     | OTLP             |
+| OTEL Collector (health) | 13133    | HTTP             |
+| SSH                     | 22       | SSH              |
+| Cloudflare Tunnel       | outbound | HTTPS            |
 
 ---
 
@@ -585,4 +619,681 @@ bun run apps/rpi-config/src/index.ts --dry-run \
   --mode native \
   --password pass \
   --peering-secret s
+```
+
+---
+
+## Quickstart Script
+
+`builds/rpi/quickstart.sh` automates the entire headless setup flow in a
+single command. It detects your current WiFi, generates an SSH key, optionally
+sets up a Cloudflare Tunnel, generates the config, compiles the binary, and
+builds the image — stopping right before flashing.
+
+### Prerequisites
+
+- macOS or Linux
+- Docker Desktop running (the image build happens inside a container)
+- `bun` installed
+- Connected to the WiFi network you want the Pi to use
+- _(Optional)_ A Cloudflare account with a domain for tunnel access
+
+### Usage
+
+```bash
+# Minimal — detect WiFi, skip tunnel
+./builds/rpi/quickstart.sh --no-tunnel
+
+# With Cloudflare Tunnel for remote SSH
+./builds/rpi/quickstart.sh --domain example.com
+
+# Custom hostname and password
+./builds/rpi/quickstart.sh --hostname edge-01 --password 'MyPass1!' --domain example.com
+
+# Dry run — generate config only, skip compile and build
+./builds/rpi/quickstart.sh --dry-run --no-tunnel
+```
+
+### Options
+
+| Flag                      | Description                            | Default          |
+| ------------------------- | -------------------------------------- | ---------------- |
+| `--password <pass>`       | Login password                         | `Catalyst1!`     |
+| `--hostname <name>`       | Pi hostname (mDNS: `<name>.local`)     | `catalyst-node`  |
+| `--mode <native\|docker>` | Deployment mode                        | `native`         |
+| `--wifi-country <code>`   | WiFi regulatory country code           | `US`             |
+| `--domain <domain>`       | Cloudflare domain for tunnel DNS route | —                |
+| `--tunnel-name <name>`    | Cloudflare Tunnel name                 | same as hostname |
+| `--no-tunnel`             | Skip Cloudflare Tunnel setup           | —                |
+| `--dry-run`               | Generate config only, skip build       | —                |
+
+### What It Does
+
+1. **Preflight** — checks Docker is running and `bun` is installed
+2. **Detect WiFi** — reads SSID and password from your current connection
+   (macOS Keychain or `nmcli` on Linux)
+3. **SSH key** — generates `~/.ssh/catalyst-deploy` if it doesn't exist,
+   reuses it if it does
+4. **Cloudflare Tunnel** _(unless `--no-tunnel`)_ — authenticates (opens
+   browser on first run), creates the tunnel, adds a DNS route, and
+   retrieves the token
+5. **Generate config** — runs the rpi-config CLI with all collected values
+6. **Compile binary** — cross-compiles `catalyst-node` for ARM64 (native
+   mode only)
+7. **Build image** — runs `build-docker.sh` to produce the `.img` file
+
+The script is idempotent — safe to re-run. SSH keys are preserved, existing
+Cloudflare Tunnels are reused, and config/binary/image are regenerated with
+the latest values.
+
+### Editable Defaults
+
+The top of the script has a defaults block you can edit directly instead of
+passing flags every time:
+
+```bash
+PASSWORD="Catalyst1!"
+PI_HOSTNAME="catalyst-node"
+MODE="native"
+IMAGE_NAME="catalyst-node-image"
+WIFI_COUNTRY="US"
+SSH_KEY="$HOME/.ssh/catalyst-deploy"
+```
+
+### Security
+
+Secrets (login password, WiFi password, tunnel token) are passed to the
+rpi-config CLI via environment variables, not CLI arguments, so they don't
+appear in `ps aux`. The env vars are unset after the CLI finishes.
+
+---
+
+## Headless Setup Guide
+
+Complete walkthrough for deploying a Catalyst Node on a Raspberry Pi without
+a monitor or keyboard attached. For a faster path, see the
+[Quickstart Script](#quickstart-script) above.
+
+### Prerequisites
+
+- Raspberry Pi 5 (or 4, CM5, CM4, Zero 2 W)
+- microSD card (16 GB+ recommended)
+- WiFi network or Ethernet connection
+- A build host: macOS with Docker Desktop, or a Debian arm64 machine
+
+### Step 1: Gather Your Values
+
+Before generating a config, collect the following:
+
+| Value                                    | Where to get it                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Login password**                       | Choose any password you want for SSH/console login to the Pi. This is _your_ password — make it up, there is no default. Must meet the validation rules shown by the CLI.                                                                                                                                                                                                                                                        |
+| **WiFi SSID**                            | The exact name of the WiFi network the Pi will connect to. Find it on your router's admin page, or in your device's WiFi settings list (e.g. "HomeNetwork", "CorpGuest"). Case-sensitive.                                                                                                                                                                                                                                        |
+| **WiFi password**                        | The password for that WiFi network — the same one you'd type on a phone or laptop. Leave empty for open networks (no password).                                                                                                                                                                                                                                                                                                  |
+| **WiFi country code**                    | Two-letter [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code for your country (e.g. `US`, `GB`, `DE`, `JP`). Needed for regulatory compliance — determines which radio frequencies the Pi is allowed to use.                                                                                                                                                                                           |
+| **SSH public key**                       | A dedicated SSH key for accessing your Pi fleet. **Don't reuse your personal key** — generate a separate one so you can rotate or revoke it independently: `ssh-keygen -t ed25519 -f ~/.ssh/catalyst-deploy -C "catalyst-deploy"`. This creates `~/.ssh/catalyst-deploy` (private, keep safe) and `~/.ssh/catalyst-deploy.pub` (public, baked into the image). To SSH in later: `ssh -i ~/.ssh/catalyst-deploy catalyst@<host>`. |
+| **Peering secret**                       | A shared secret for iBGP peering between Catalyst nodes. Choose any string — all nodes in the same cluster must use the same value. Can be left empty for single-node deployments.                                                                                                                                                                                                                                               |
+| **Hostname**                             | The name the Pi will use on the network (for mDNS: `<hostname>.local`). Choose something descriptive like `catalyst-edge-01`.                                                                                                                                                                                                                                                                                                    |
+| **Cloudflare Tunnel token** _(optional)_ | Allows SSH access from anywhere without port forwarding. See [Setting Up a Cloudflare Tunnel](#setting-up-a-cloudflare-tunnel) below for a full walkthrough.                                                                                                                                                                                                                                                                     |
+
+### Step 2: Generate the Config
+
+```bash
+bun run apps/rpi-config/src/index.ts \
+  --non-interactive \
+  --mode native \
+  --password "your-login-password" \
+  --hostname "catalyst-edge-01" \
+  --wifi-ssid "YourNetwork" \
+  --wifi-password "your-wifi-password" \
+  --wifi-country US \
+  --ssh-pubkey-file ~/.ssh/catalyst-deploy.pub \
+  --peering-secret "your-peering-secret" \
+  --log-level info \
+  -o dist/rpi
+```
+
+> **Tip:** If you're unsure about any value, omit the `--non-interactive` flag
+> and the CLI will walk you through each option with prompts instead.
+
+For remote access without port forwarding, add a Cloudflare Tunnel token
+(see [Setting Up a Cloudflare Tunnel](#setting-up-a-cloudflare-tunnel) for
+how to get one):
+
+```bash
+  --cloudflared-token "<your-tunnel-token>"
+```
+
+To disable the console journal stream (saves resources if no HDMI is ever
+connected):
+
+```bash
+  --no-autologin
+```
+
+### Step 3: Build the Binary (Native Mode)
+
+```bash
+bun build --compile --target=bun-linux-arm64 \
+  --outfile dist/rpi/bin/catalyst-node apps/node/src/index.ts
+```
+
+### Step 4: Build the Image
+
+**macOS (Docker):**
+
+```bash
+./builds/rpi/build-docker.sh --source-dir dist/rpi dist/rpi/config.yaml
+```
+
+**Linux arm64 (native):**
+
+```bash
+./builds/rpi/build.sh --source-dir dist/rpi dist/rpi/config.yaml
+```
+
+### Step 5: Flash the SD Card
+
+**macOS:**
+
+```bash
+# Identify SD card
+diskutil list
+
+# Unmount (replace N with your disk number)
+diskutil unmountDisk /dev/diskN
+
+# Flash (rdisk for raw speed)
+sudo dd if=dist/rpi/build/image-catalyst-node-image/catalyst-node-image.img \
+  of=/dev/rdiskN bs=4m status=progress
+
+diskutil eject /dev/diskN
+```
+
+Or use [Raspberry Pi Imager](https://www.raspberrypi.com/software/) — select
+"Use custom" and choose the `.img` file.
+
+### Step 6: Boot and Connect
+
+1. Insert the SD card into the Pi
+2. Connect power (and Ethernet, if not using WiFi)
+3. Wait 30-60 seconds for first boot
+
+**Find the Pi on your network:**
+
+```bash
+# mDNS (avahi-daemon is included in all images)
+ping catalyst-edge-01.local
+
+# Subnet scan (fallback if mDNS isn't working on your network)
+nmap -sn 192.168.1.0/24
+
+# ARP table (look for Raspberry Pi MAC prefixes: dc:a6, d8:3a, 2c:cf)
+arp -a | grep -i "dc:a6\|d8:3a\|2c:cf"
+```
+
+**SSH in** (using your dedicated deploy key):
+
+```bash
+ssh -i ~/.ssh/catalyst-deploy catalyst@catalyst-edge-01.local
+# or
+ssh -i ~/.ssh/catalyst-deploy catalyst@<ip-address>
+```
+
+If cloudflared is configured, SSH through the tunnel instead — no need to
+find the local IP or be on the same network:
+
+```bash
+# Requires cloudflared on your laptop (brew install cloudflared / apt install cloudflared)
+ssh -o ProxyCommand="cloudflared access ssh --hostname %h" catalyst@ssh.example.com
+```
+
+Replace `ssh.example.com` with the public hostname you configured in the
+Cloudflare Tunnel (see [Setting Up a Cloudflare Tunnel](#setting-up-a-cloudflare-tunnel)).
+
+### Step 7: Verify Services
+
+```bash
+# Check all catalyst services
+systemctl status catalyst-node-firstboot catalyst-node otelcol
+
+# Check WiFi
+ip addr show wlan0
+systemctl status wpa_supplicant@wlan0
+
+# Check cloudflared (if enabled)
+systemctl status cloudflared-tunnel
+```
+
+### Open Networks and Captive Portals
+
+Some WiFi networks — typically at hotels, airports, conference venues, or
+co-working spaces — have no password. You connect by selecting the network name
+(SSID) and are then redirected to a web page to accept terms or enter a room
+number. These are called **open networks** with **captive portals**.
+
+#### Building for an open network
+
+Omit the `--wifi-password` flag entirely. The `--wifi-ssid` is the network name
+you'd see in your phone or laptop's WiFi list (ask the venue front desk if
+unsure):
+
+```bash
+bun run apps/rpi-config/src/index.ts \
+  --non-interactive \
+  --mode native \
+  --password "your-login-password" \
+  --wifi-ssid "HotelWiFi" \
+  --ssh-pubkey-file ~/.ssh/catalyst-deploy.pub \
+  --peering-secret "your-secret" \
+  -o builds/rpi/hotel-node.yaml
+```
+
+- `--password` — the password _you choose_ for logging into the Pi via SSH or
+  console. This is unrelated to the WiFi password.
+- `--wifi-ssid` — the exact WiFi network name, case-sensitive. Look for it in
+  the venue's WiFi instructions or scan on your phone first.
+- `--ssh-pubkey-file` — path to your dedicated deploy key (see
+  [Step 1: Gather Your Values](#step-1-gather-your-values) for how to generate
+  one). Use `ssh -i ~/.ssh/catalyst-deploy catalyst@<host>` to connect.
+- `--peering-secret` — a string you choose for node-to-node communication.
+  Can be left empty for single-node setups.
+
+The image will generate a `key_mgmt=NONE` wpa_supplicant config instead of
+using `wpa_passphrase`, so the Pi will associate with the open network
+automatically on boot.
+
+#### Authenticating through a captive portal
+
+Many open networks block internet access until you accept terms through a web
+page. Since headless Pi images have no graphical browser, `w3m` (a terminal-based
+web browser) is included for this purpose.
+
+**You need a way to SSH into the Pi first.** Two options:
+
+1. **Ethernet** — plug the Pi into a wired connection and SSH in over Ethernet.
+2. **Same open network** — if your laptop is on the same open network and local
+   traffic is allowed, SSH via the Pi's mDNS hostname or IP address.
+
+Once connected via SSH:
+
+```bash
+# Open a captive portal detection URL — this will redirect to the venue's
+# login page if the network requires portal authentication
+w3m http://detectportal.firefox.com
+
+# Alternative detection URLs (some networks only intercept certain ones)
+w3m http://captive.apple.com
+w3m http://neverssl.com
+```
+
+Inside `w3m`: use arrow keys to navigate, Enter to follow links or press
+buttons, and `q` to quit when done.
+
+> **Note:** Captive portal sessions typically expire after a period of inactivity
+> or on a fixed timer (often 24 hours). This approach is best for temporary
+> deployments — conference demos, hotel setups, etc. For permanent installations,
+> prefer a WPA2-PSK network with a proper password.
+
+### Setting Up a Cloudflare Tunnel
+
+A Cloudflare Tunnel lets you SSH into your Pi from anywhere — no port
+forwarding, no static IP, no VPN. The Pi makes an outbound connection to
+Cloudflare's edge network, and you connect through that. This section walks
+through getting the tunnel token that the `catalyst-cloudflared` layer needs.
+
+#### Prerequisites
+
+- A [Cloudflare account](https://dash.cloudflare.com/sign-up) (free tier works)
+- A domain added to Cloudflare (even a cheap `.dev` or `.xyz` works — you
+  just need Cloudflare managing its DNS)
+- `cloudflared` installed on your laptop (see [step 5](#5-ssh-through-the-tunnel)
+  for install commands)
+
+#### 1. Authenticate
+
+```bash
+cloudflared tunnel login
+```
+
+This opens a browser to authorize `cloudflared` with your Cloudflare account.
+After you select the domain, credentials are saved to
+`~/.cloudflared/cert.pem`.
+
+#### 2. Create the Tunnel and DNS Route
+
+```bash
+# Create the tunnel
+cloudflared tunnel create catalyst-edge-01
+
+# Add a DNS record pointing to the tunnel (creates a CNAME automatically)
+cloudflared tunnel route dns catalyst-edge-01 ssh-edge-01.example.com
+```
+
+Replace `ssh-edge-01.example.com` with a subdomain on your
+Cloudflare-managed domain.
+
+#### 3. Get the Token
+
+```bash
+cloudflared tunnel token catalyst-edge-01
+```
+
+This prints the tunnel token — a long base64 string starting with `eyJ...`.
+Copy it.
+
+> **Dashboard alternative:** You can also do all of the above in the
+> [Cloudflare Zero Trust dashboard](https://one.dash.cloudflare.com/) →
+> **Networks** → **Tunnels** → **Create a tunnel**. The token is shown on
+> the "Install connector" page after `--token`.
+
+#### 4. Build with the Token
+
+Pass the token to the config CLI:
+
+```bash
+bun run apps/rpi-config/src/index.ts \
+  --cloudflared-token "eyJhIjoiYWJjZGVm..."
+  # ... other flags
+```
+
+#### 5. SSH Through the Tunnel
+
+On your laptop, install `cloudflared`:
+
+```bash
+# macOS
+brew install cloudflared
+
+# Debian/Ubuntu
+curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg \
+  | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main" \
+  | sudo tee /etc/apt/sources.list.d/cloudflared.list
+sudo apt update && sudo apt install cloudflared
+```
+
+Then connect:
+
+```bash
+ssh -o ProxyCommand="cloudflared access ssh --hostname %h" \
+  -i ~/.ssh/catalyst-deploy \
+  catalyst@ssh-edge-01.example.com
+```
+
+To avoid typing the `ProxyCommand` every time, add it to `~/.ssh/config`:
+
+```
+Host ssh-edge-01.example.com
+  User catalyst
+  IdentityFile ~/.ssh/catalyst-deploy
+  ProxyCommand cloudflared access ssh --hostname %h
+```
+
+Then just `ssh ssh-edge-01.example.com`.
+
+> **Tip:** You can create multiple tunnels (one per node) or add multiple
+> public hostnames to a single tunnel. For a fleet, one tunnel per node with
+> a naming convention like `ssh-edge-001.example.com` keeps things organized.
+
+---
+
+## Operations
+
+### Viewing Logs
+
+```bash
+# Catalyst Node logs
+journalctl -u catalyst-node -f
+
+# OTEL Collector logs
+journalctl -u otelcol -f
+
+# All catalyst-related logs
+journalctl -u 'catalyst-*' -u otelcol -f
+
+# Boot log (last boot)
+journalctl -b -0
+
+# Firstboot log (ran once on first boot)
+journalctl -u catalyst-node-firstboot
+```
+
+If the `catalyst-console` layer is enabled, the journal stream is
+automatically displayed on HDMI (tty1). Press Ctrl+C for an interactive
+shell.
+
+### Remote Console Viewing
+
+The `catalyst-console` layer includes `conspy`, a tool that mirrors a Linux
+virtual terminal in your SSH session. This lets you see the exact tty1
+output — boot messages, kernel output, and the live journal stream — as if
+you plugged in an HDMI monitor.
+
+```bash
+# SSH into the node
+ssh -i ~/.ssh/catalyst-deploy catalyst@<host>
+
+# Mirror tty1 (the console with the journal stream)
+sudo conspy 1
+```
+
+No password prompt — the console layer grants passwordless `sudo` for
+`conspy` only (via `/etc/sudoers.d/conspy`).
+
+**What you'll see:** the exact tty1 output. If the console layer is enabled,
+that's the live `journalctl -f` stream. You'll also see any early boot
+messages or kernel output that appeared before journald started.
+
+**Detach:** press `Escape` three times.
+
+**Interact:** you can type into the remote console as if at the physical
+keyboard. For example, press Ctrl+C to stop `journalctl` and get an
+interactive shell on tty1.
+
+### Restarting Services
+
+```bash
+# Restart the main service
+sudo systemctl restart catalyst-node
+
+# Restart OTEL collector
+sudo systemctl restart otelcol
+
+# Restart everything
+sudo systemctl restart otelcol catalyst-node
+```
+
+### Updating the Binary (Native Mode)
+
+```bash
+# Copy new binary to the Pi
+scp catalyst-node catalyst@<host>:/tmp/
+
+# On the Pi
+sudo systemctl stop catalyst-node
+sudo install -m 755 /tmp/catalyst-node /usr/local/bin/catalyst-node
+sudo systemctl start catalyst-node
+```
+
+### Updating Containers (Docker Mode)
+
+```bash
+# On the Pi
+cd /opt/catalyst-node
+sudo docker compose pull
+sudo docker compose up -d --remove-orphans
+```
+
+### Checking Service Health
+
+```bash
+# Native mode — composite server
+curl -s http://localhost:3000/health
+
+# Docker mode — individual services
+curl -s http://localhost:3000/health   # orchestrator
+curl -s http://localhost:4000/health   # gateway
+curl -s http://localhost:5000/health   # auth
+curl -s http://localhost:13133         # OTEL collector
+```
+
+### Editing Configuration
+
+```bash
+# Node environment (native mode)
+sudo nano /etc/catalyst-node/catalyst-node.env
+sudo systemctl restart catalyst-node
+
+# Node environment (docker mode)
+sudo nano /opt/catalyst-node/.env
+cd /opt/catalyst-node && sudo docker compose up -d
+```
+
+---
+
+## Troubleshooting
+
+### WiFi Not Connecting
+
+**Symptoms:** No `wlan0` interface, `wpa_supplicant@wlan0` failed, no network
+after boot.
+
+```bash
+# 1. Check if the WiFi interface exists
+ip link show wlan0
+
+# 2. If missing — check firmware loaded
+dmesg | grep -i brcm
+# Should see: "brcmfmac: brcmf_fw_alloc_request: using brcm/..."
+
+# 3. Check rfkill
+rfkill list
+# Should show "Soft blocked: no" for wlan0
+
+# 4. Check wpa_supplicant
+systemctl status wpa_supplicant@wlan0
+journalctl -u wpa_supplicant@wlan0 -b
+
+# 5. Check wpa_supplicant config
+cat /etc/wpa_supplicant/wpa_supplicant-wlan0.conf
+# Verify SSID and PSK are correct
+
+# 6. Check regulatory domain
+iw reg get
+# Should show your configured country code
+
+# 7. Manual connection test
+sudo wpa_supplicant -i wlan0 -c /etc/wpa_supplicant/wpa_supplicant-wlan0.conf -d
+```
+
+**Common causes:**
+
+| Symptom                  | Cause                        | Fix                                                   |
+| ------------------------ | ---------------------------- | ----------------------------------------------------- |
+| No `wlan0` at all        | Missing `firmware-brcm80211` | Rebuild image (fixed in current version)              |
+| `wlan0` exists but no IP | Wrong SSID/password          | Check `/etc/wpa_supplicant/wpa_supplicant-wlan0.conf` |
+| `wlan0` soft blocked     | rfkill service not running   | `sudo systemctl start wifi-rfkill-unblock`            |
+| Country code error       | Missing `wireless-regdb`     | Rebuild image (fixed in current version)              |
+
+### Service Won't Start
+
+```bash
+# Check the service status and recent logs
+systemctl status catalyst-node
+journalctl -u catalyst-node -b --no-pager -n 50
+
+# Check if firstboot completed
+ls -la /var/lib/catalyst-node/.firstboot-done
+
+# Check rate limiting (service restarted too many times)
+systemctl show catalyst-node | grep -E 'NRestarts|Result'
+# If Result=start-limit-hit:
+sudo systemctl reset-failed catalyst-node
+sudo systemctl start catalyst-node
+```
+
+### Firstboot Didn't Run
+
+```bash
+# Check if the marker file exists
+ls -la /var/lib/catalyst-node/.firstboot-done   # native
+ls -la /opt/catalyst-node/.firstboot-done       # docker
+
+# If missing, check the firstboot log
+journalctl -u catalyst-node-firstboot -b        # native
+journalctl -u catalyst-stack-firstboot -b        # docker
+
+# Force re-run
+sudo rm /var/lib/catalyst-node/.firstboot-done   # native
+sudo systemctl start catalyst-node-firstboot
+
+sudo rm /opt/catalyst-node/.firstboot-done       # docker
+sudo systemctl start catalyst-stack-firstboot
+```
+
+### Docker Compose Stack Not Starting
+
+```bash
+# Check the systemd service
+systemctl status catalyst-stack
+journalctl -u catalyst-stack -b
+
+# Check Docker is running
+systemctl status docker
+
+# Check containers directly
+cd /opt/catalyst-node
+sudo docker compose ps
+sudo docker compose logs --tail 50
+
+# If pull failed (no network on first boot), start with cached images
+sudo docker compose up -d
+```
+
+### No SSH Access
+
+```bash
+# From the Pi console (HDMI + keyboard, or serial):
+
+# 1. Check SSH is running
+systemctl status ssh
+
+# 2. Check the Pi has an IP
+ip addr
+
+# 3. Check SSH config allows your key
+cat /etc/ssh/sshd_config.d/*.conf
+
+# 4. Test from the build host
+ssh -vvv catalyst@<ip-address>
+```
+
+### OTEL Collector Using Too Much Memory
+
+The OTEL collector has a `MemoryMax=300M` limit and an internal
+`memory_limiter` processor set to 256 MiB. If it hits the limit:
+
+```bash
+# Check memory usage
+systemctl status otelcol
+journalctl -u otelcol -b | grep -i memory
+
+# Reduce batch size in the config
+sudo nano /etc/catalyst-node/otel-config.yaml
+# Lower send_batch_size or limit_mib
+sudo systemctl restart otelcol
+```
+
+### Checking System Resources
+
+```bash
+# Overall system health
+free -h            # RAM usage
+df -h              # Disk usage
+uptime             # Load average
+vcgencmd measure_temp  # CPU temperature (RPi-specific)
+
+# Per-service resource usage
+systemd-cgtop      # Live view of cgroup resource usage
 ```


### PR DESCRIPTION
- WiFi: use wpa_passphrase, support open networks
- WiFi: add rfkill systemd unit, firmware packages
- Node/Docker: add avahi, systemd hardening, catalyst user
- Node/Docker: fix firstboot RemainAfterExit
- OTEL: add sha256 verification, StartLimitBurst
- Cloudflared: remove wlan0 dep, add restart limits
- Console: fix chown, add conspy with sudoers
- Build: fix shell quoting, pass config via sys.argv
- CLI: support env vars for sensitive options
- Add quickstart.sh for one-command dev setup
- Update docs and README