### PR TITLE
test(routing): improve test names for clarity and specificity

### DIFF
--- a/packages/routing/tests/unit/datachannel.test.ts
+++ b/packages/routing/tests/unit/datachannel.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'bun:test'
 import { DataChannelDefinitionSchema } from '../../src/datachannel.js'
 
 describe('DataChannelDefinitionSchema', () => {
-  describe('existing fields (backward compatibility)', () => {
-    it('parses a minimal definition with name and protocol', () => {
+  describe('core fields', () => {
+    it('accepts minimal definition with required name and protocol', () => {
       const result = DataChannelDefinitionSchema.safeParse({
         name: 'test-service',
         protocol: 'http',
@@ -15,7 +15,7 @@ describe('DataChannelDefinitionSchema', () => {
       }
     })
 
-    it('parses with all existing optional fields', () => {
+    it('accepts all optional fields (endpoint, region, tags)', () => {
       const result = DataChannelDefinitionSchema.safeParse({
         name: 'graphql-service',
         protocol: 'http:graphql',
@@ -31,7 +31,7 @@ describe('DataChannelDefinitionSchema', () => {
       }
     })
 
-    it('parses all valid protocol types', () => {
+    it('accepts all valid protocol types (http, http:graphql, http:gql, http:grpc, tcp)', () => {
       for (const protocol of ['http', 'http:graphql', 'http:gql', 'http:grpc', 'tcp']) {
         const result = DataChannelDefinitionSchema.safeParse({
           name: 'test',
@@ -41,7 +41,7 @@ describe('DataChannelDefinitionSchema', () => {
       }
     })
 
-    it('rejects invalid protocol', () => {
+    it('rejects unsupported protocol type', () => {
       const result = DataChannelDefinitionSchema.safeParse({
         name: 'test',
         protocol: 'ftp',
@@ -60,7 +60,7 @@ describe('DataChannelDefinitionSchema', () => {
   })
 
   describe('envoyPort field', () => {
-    it('parses without envoyPort (backward compatible)', () => {
+    it('defaults envoyPort to undefined when omitted', () => {
       const result = DataChannelDefinitionSchema.safeParse({
         name: 'test-service',
         protocol: 'http',
@@ -71,7 +71,7 @@ describe('DataChannelDefinitionSchema', () => {
       }
     })
 
-    it('parses with valid envoyPort', () => {
+    it('accepts valid integer envoyPort', () => {
       const result = DataChannelDefinitionSchema.safeParse({
         name: 'test-service',
         protocol: 'http',
@@ -92,7 +92,7 @@ describe('DataChannelDefinitionSchema', () => {
       expect(result.success).toBe(false)
     })
 
-    it('accepts envoyPort at boundary values', () => {
+    it('accepts envoyPort at port boundaries (1 and 65535)', () => {
       expect(
         DataChannelDefinitionSchema.safeParse({
           name: 'test',
@@ -110,7 +110,7 @@ describe('DataChannelDefinitionSchema', () => {
       ).toBe(true)
     })
 
-    it('coexists with all other fields', () => {
+    it('accepts envoyPort alongside all other fields', () => {
       const result = DataChannelDefinitionSchema.safeParse({
         name: 'full-service',
         protocol: 'http:grpc',

--- a/packages/routing/tests/unit/tick-action.test.ts
+++ b/packages/routing/tests/unit/tick-action.test.ts
@@ -4,7 +4,7 @@ import { ActionSchema } from '../../src/schema.js'
 import { Actions } from '../../src/action-types.js'
 
 describe('TickMessageSchema', () => {
-  it('parses a valid tick action', () => {
+  it('accepts valid tick action with numeric now timestamp', () => {
     const result = TickMessageSchema.safeParse({
       action: 'system:tick',
       data: { now: Date.now() },
@@ -32,14 +32,14 @@ describe('TickMessageSchema', () => {
     expect(result.success).toBe(false)
   })
 
-  it('rejects tick with missing data', () => {
+  it('rejects tick with missing data payload', () => {
     const result = TickMessageSchema.safeParse({
       action: 'system:tick',
     })
     expect(result.success).toBe(false)
   })
 
-  it('rejects tick with wrong action type', () => {
+  it('rejects non-tick action type', () => {
     const result = TickMessageSchema.safeParse({
       action: 'system:wrong',
       data: { now: Date.now() },
@@ -48,8 +48,8 @@ describe('TickMessageSchema', () => {
   })
 })
 
-describe('ActionSchema includes Tick', () => {
-  it('parses tick through the unified ActionSchema', () => {
+describe('ActionSchema', () => {
+  it('accepts system:tick via unified ActionSchema', () => {
     const result = ActionSchema.safeParse({
       action: 'system:tick',
       data: { now: 1707745200000 },
@@ -60,7 +60,7 @@ describe('ActionSchema includes Tick', () => {
     }
   })
 
-  it('Actions.Tick has the correct value', () => {
+  it('Actions.Tick equals "system:tick"', () => {
     expect(Actions.Tick).toBe('system:tick')
   })
 })


### PR DESCRIPTION
## Summary
- Improve test names in the routing package to be specification-style and specific
- Replace vague verbs ("parses") with precise behavior descriptions ("accepts", "rejects", "defaults")
- Add specifics to group names and edge case descriptions

### Before → After

| Before | After |
|--------|-------|
| `existing fields (backward compatibility)` | `core fields` |
| `parses a minimal definition with name and protocol` | `accepts minimal definition with required name and protocol` |
| `parses with all existing optional fields` | `accepts all optional fields (endpoint, region, tags)` |
| `parses all valid protocol types` | `accepts all valid protocol types (http, http:graphql, http:gql, http:grpc, tcp)` |
| `rejects invalid protocol` | `rejects unsupported protocol type` |
| `parses without envoyPort (backward compatible)` | `defaults envoyPort to undefined when omitted` |
| `parses with valid envoyPort` | `accepts valid integer envoyPort` |
| `accepts envoyPort at boundary values` | `accepts envoyPort at port boundaries (1 and 65535)` |
| `coexists with all other fields` | `accepts envoyPort alongside all other fields` |
| `parses a valid tick action` | `accepts valid tick action with numeric now timestamp` |
| `rejects tick with missing data` | `rejects tick with missing data payload` |
| `rejects tick with wrong action type` | `rejects non-tick action type` |
| `ActionSchema includes Tick` | `ActionSchema` |
| `parses tick through the unified ActionSchema` | `accepts system:tick via unified ActionSchema` |
| `Actions.Tick has the correct value` | `Actions.Tick equals "system:tick"` |

## Test plan
- [x] `bun test packages/routing/tests/` — 17 pass, 0 failures
- [x] Full suite: 610 pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)