### PR TITLE
chore: example zenoh config

### DIFF
--- a/examples/zeno-tak-adapter-v2/build/zenoh-test-config.json5
+++ b/examples/zeno-tak-adapter-v2/build/zenoh-test-config.json5
@@ -1,0 +1,29 @@
+{
+  // Zenoh router configuration for integration tests
+  mode: "router",
+
+  listen: {
+    endpoints: [
+      "tcp/0.0.0.0:7447"
+    ]
+  },
+
+  plugins_loading: {
+    enabled: true,
+    search_dirs: [
+      "/",
+      "/usr/lib",
+      "/usr/local/lib",
+      "~/.zenoh/lib"
+    ]
+  },
+
+  plugins: {
+    rest: {
+      http_port: 8000
+    },
+    remote_api: {
+      websocket_port: "10000"
+    }
+  }
+}


### PR DESCRIPTION
### TL;DR

Added Zenoh router configuration file for integration testing of the TAK adapter.

### What changed?

Added a new `zenoh-test-config.json5` file to the `examples/zeno-tak-adapter-v2/build/` directory. This configuration file sets up a Zenoh router with:
- Router mode enabled
- TCP endpoint listening on port 7447
- Plugin loading enabled with specified search directories
- REST plugin configured on port 8000
- Remote API plugin with WebSocket on port 10000

### How to test?

1. Navigate to the `examples/zeno-tak-adapter-v2/build/` directory
2. Start the Zenoh router using this configuration:
   ```
   zenohd -c zenoh-test-config.json5
   ```
3. Verify the router starts successfully and listens on the configured ports
4. Test connectivity to the REST endpoint at port 8000 and WebSocket at port 10000

### Why make this change?

This configuration file provides a standardized Zenoh router setup for integration testing of the TAK adapter, ensuring consistent test environments and enabling proper communication between components during testing.