### PR TITLE
fix(orchestrator): clean up routes on LocalPeerDelete to prevent zombie routes

### DIFF
--- a/apps/orchestrator/src/rib.ts
+++ b/apps/orchestrator/src/rib.ts
@@ -324,6 +324,7 @@ export class RoutingInformationBase {
           internal: {
             ...state.internal,
             peers: peerList.filter((p) => p.name !== action.data.name),
+            routes: state.internal.routes.filter((r) => r.peerName !== action.data.name),
           },
         }
         break

--- a/apps/orchestrator/tests/bgp-zombie-routes.test.ts
+++ b/apps/orchestrator/tests/bgp-zombie-routes.test.ts
@@ -231,7 +231,7 @@ describe('Zombie Routes / State Corruption', () => {
     }
   })
 
-  it('LocalPeerDelete removes peer but leaves routes as zombies', () => {
+  it('LocalPeerDelete removes peer and all its routes (no zombies)', () => {
     const rib = createRib()
     connectPeer(rib, PEER_B)
 
@@ -258,16 +258,14 @@ describe('Zombie Routes / State Corruption', () => {
     })
     expect(rib.getState().internal.routes).toHaveLength(2)
 
-    // Delete the peer (not close — delete skips route cleanup)
+    // Delete the peer — should also remove all routes from that peer
     planCommit(rib, { action: Actions.LocalPeerDelete, data: { name: PEER_B.name } })
 
     // Peer is gone
     expect(rib.getState().internal.peers).toHaveLength(0)
 
-    // Routes are NOT cleaned up — they become zombies.
-    // (Unlike InternalProtocolClose which removes routes from the closed peer.)
-    // This documents actual behavior: LocalPeerDelete only removes the peer record.
-    expect(rib.getState().internal.routes).toHaveLength(2)
+    // Routes are also gone — no zombies
+    expect(rib.getState().internal.routes).toHaveLength(0)
   })
 
   it('route removal propagates withdrawal to other connected peers', () => {


### PR DESCRIPTION
## Summary

- **Bug**: `LocalPeerDelete` only removed the peer record from `state.internal.peers` but left all routes from that peer in `state.internal.routes`, creating zombie routes
- **Fix**: Added `routes: state.internal.routes.filter((r) => r.peerName !== action.data.name)` to the `LocalPeerDelete` case in `rib.plan()`, matching the cleanup behavior of `InternalProtocolClose`
- **Test**: Updated the regression test in `bgp-zombie-routes.test.ts` to assert routes are cleaned up (was previously documenting the bug)

## Test plan

- [x] `bgp-zombie-routes.test.ts` — 6 pass, 0 fail
- [x] Full orchestrator suite — 170 pass, 0 fail
- [x] Full unit suite — 612 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)