### PR TITLE
test(orchestrator): add 36 tests for untested RIB code paths and correctness invariants

### DIFF
--- a/apps/orchestrator/tests/FUTURE-TEST-GAPS.md
+++ b/apps/orchestrator/tests/FUTURE-TEST-GAPS.md
@@ -1,0 +1,261 @@
+# Future Test Gaps
+
+BGP-informed edge cases that require implementation changes before they can be tested. Each entry describes what the test would verify, why it matters for production, and what changes are needed.
+
+Research sources: OpenBGPD `rde_decide_test.c`, GoBGP `destination_test.go` + `ibgp_router_test.py` + `fsm_test.go`, FRRouting 252 topotest directories, BIRD `proto/bgp/bgp.c` + `filter/test.conf`.
+
+---
+
+## 1. Graceful Restart / Route Stale Marking
+
+**What it tests:** When a peer disconnects, routes from that peer are marked `stale` rather than immediately deleted. Stale routes remain usable during a configurable grace period. If the peer reconnects, stale routes are refreshed. If the timer expires, stale routes are purged and withdrawals sent.
+
+**Why it matters:** Without this, every momentary peer flap causes a full withdrawal-then-readvertisement cycle across the entire mesh. A 2-second WebSocket blip triggers route churn to all downstream peers. All four major BGP implementations (OpenBGPD, GoBGP, FRR, BIRD) have extensive GR test suites — FRR alone has 8+ test directories for it.
+
+**Changes required:**
+
+- Add `stale?: boolean` and `staleSince?: number` fields to `InternalRoute`
+- Add `gracePeriodMs?: number` to `InternalProtocolClose` action data
+- Modify `InternalProtocolClose` handler: when `gracePeriodMs` is set, mark routes stale instead of deleting
+- Modify `Tick` handler: purge routes where `now - staleSince > gracePeriodMs`
+- Modify `computeRouteMetadata`: deprioritize stale routes (treat as infinite path length)
+- Modify `InternalProtocolUpdate` handler: un-stale routes that are re-advertised
+- Suppress withdrawal propagations during grace period
+
+**Test scenarios (~10 tests):**
+
+- Peer disconnects with GR → routes marked stale, NOT withdrawn
+- Peer reconnects within grace period → stale routes refreshed, no downstream churn
+- Peer does NOT reconnect → stale routes purged, withdrawals sent after timeout
+- Stale route loses best-path to shorter fresh route (de-preference)
+- Partial refresh: only some routes re-advertised, rest purged
+- End-of-initial-sync marker clears remaining stale routes
+
+---
+
+## 2. Maximum Prefix Limits
+
+**What it tests:** A configurable per-peer limit on the number of routes accepted. When a peer exceeds the limit, new routes are rejected or the session is torn down.
+
+**Why it matters:** Protects against a misbehaving peer flooding the RIB with thousands of routes, exhausting memory or port allocator capacity. Both FRR and OpenBGPD have `maxprefix` integration tests.
+
+**Changes required:**
+
+- Add `maxPrefixes?: number` to `PeerRecord` or `OrchestratorConfig` per-peer settings
+- Modify `InternalProtocolUpdate` handler: check route count from that peer before adding
+- When limit exceeded: either return `{ success: false }` or produce an `InternalProtocolClose` propagation
+
+**Test scenarios (~6 tests):**
+
+- Accepting routes at exactly the limit succeeds
+- Exceeding limit by one causes plan failure
+- Batch update that would cross limit is rejected atomically
+- Removing routes below limit then adding more succeeds
+- Limit of 0 means unlimited (no enforcement)
+- Session teardown mode: exceeding limit closes the peer
+
+---
+
+## 3. Route Flap Damping
+
+**What it tests:** A penalty-based system where each withdrawal/re-announcement of the same route increments a counter. Once the penalty exceeds a suppress threshold, the route is suppressed (not propagated, deprioritized in best-path). Penalty decays over time via `Tick`.
+
+**Why it matters:** A service that crashes and restarts repeatedly causes route oscillation across all peers. Without damping, every flap cascades through the entire mesh. FRR has `bgp_dampening_per_peer` and BIRD (via Albatros project) implements RFC 2439.
+
+**Changes required:**
+
+- Add `flapPenalty?: number` and `suppressedUntil?: number` per route (keyed by name+peerName)
+- Track flap state in RIB (separate from route table, possibly a `flapState` map)
+- On `InternalProtocolUpdate` add for recently-withdrawn route: increment penalty
+- On `Tick`: decay penalties by configurable half-life
+- In `computeRouteMetadata`: exclude suppressed routes from best-path
+- In `computePropagations`: do not propagate suppressed routes
+
+**Test scenarios (~6 tests):**
+
+- Single withdraw/re-add below threshold: route remains usable
+- N rapid cycles exceed threshold: route suppressed
+- Suppressed route excluded from best-path
+- Penalty decays via Tick, route becomes reusable
+- Different routes from same peer damped independently
+- Suppressed route not propagated to downstream peers
+
+---
+
+## 4. ECMP (Equal-Cost Multipath)
+
+**What it tests:** When multiple peers advertise the same route with equal-length nodePaths, all paths are treated as "active" simultaneously (not just best + alternatives). Enables load-balancing across multiple paths.
+
+**Why it matters:** Currently, the RIB picks a single best path. Traffic always flows through one peer even when equal-cost alternatives exist. FRR has 3 ECMP topotest directories, GoBGP has `TestMultipath`, and BIRD supports ECMP via `merge_paths`.
+
+**Changes required:**
+
+- Add `ecmpPaths?: InternalRoute[]` to `LocRibEntry`
+- Modify `computeRouteMetadata`: when multiple routes have identical `nodePath.length`, mark all as ECMP candidates
+- Add `selectionReason: 'ecmp'` for multi-path entries
+- Modify `buildRouteSyncPayload`: potentially include all ECMP paths in propagation
+
+**Test scenarios (~5 tests):**
+
+- Two routes with identical path length both in ecmpPaths
+- Withdrawal of one ECMP path leaves the other active
+- Addition of third equal-cost path extends ecmpPaths
+- Unequal lengths still produce single best + alternatives (no ECMP)
+- ECMP routes propagated with correct port stamping
+
+---
+
+## 5. Import/Export Filters
+
+**What it tests:** Routes pass through configurable import filters (peer→RIB) and export filters (RIB→peer). Filters can accept, reject, or modify routes based on name patterns, tags, region, or other attributes.
+
+**Why it matters:** Currently all routes are accepted unconditionally and propagated to all peers. There's no mechanism for selective routing policies. BIRD's `filter/test.conf` has hundreds of filter assertions, and OpenBGPD's `eval_all.sh` tests community-based filtering.
+
+**Changes required:**
+
+- Define a `RouteFilter` type (accept/reject rules based on route attributes)
+- Add `importFilter?: RouteFilter` and `exportFilter?: RouteFilter` to `PeerRecord` or config
+- Modify `InternalProtocolUpdate` handler: apply import filter before adding routes
+- Modify `computePropagations`: apply export filter per-peer before including routes
+- Optionally: keep filtered routes with a `filtered: true` flag (like BIRD's `REF_FILTERED`) for soft reconfiguration
+
+**Test scenarios (~6 tests):**
+
+- Import filter rejects route by name pattern
+- Export filter prevents route from being sent to specific peer
+- Filtered route not included in full sync on peer connect
+- Filter modification: route accepted but with modified attributes
+- Soft reconfig: changing filter re-evaluates without session restart
+
+---
+
+## 6. Graceful Shutdown (Drain Signal)
+
+**What it tests:** Before a planned shutdown, a node re-advertises all routes with a "draining" marker. Peers deprioritize drained routes, preferring alternative paths. After traffic drains, the node can shut down safely.
+
+**Why it matters:** Enables zero-downtime rolling deploys of catalyst nodes. FRR has `bgp_gshut` and `bgp_peer_graceful_shutdown` test directories.
+
+**Changes required:**
+
+- Add a `draining?: boolean` field to route propagation
+- New action `Actions.AdminGracefulShutdown` that triggers re-propagation of all routes with drain marker
+- Modify `computeRouteMetadata` on receiver: add penalty to drained routes' effective path length
+- New action to cancel shutdown (remove drain marker)
+
+**Test scenarios (~5 tests):**
+
+- All routes re-propagated with drain marker on shutdown
+- Peers deprioritize drained routes in best-path
+- Cancelling shutdown removes drain marker
+- Drained routes lose to any non-drained alternative
+
+---
+
+## 7. Secondary Metrics (MED / Weight)
+
+**What it tests:** When two routes have equal nodePath length, a secondary metric (analogous to BGP MED or weight) breaks the tie. Lower metric wins. Operators can also set an administrative weight that overrides all other criteria.
+
+**Why it matters:** Without secondary metrics, equal-length path ties are broken arbitrarily by array sort order. OpenBGPD's `rde_decide_test.c` tests 13 tie-breaking steps including MED (step 5) and weight (step 7). Two peers in different datacenters may have same hop count but very different latency.
+
+**Changes required:**
+
+- Add `metric?: number` and/or `adminWeight?: number` to `InternalRoute` or `DataChannelDefinition`
+- Modify `computeRouteMetadata` sort: after nodePath length, compare metric (lower wins)
+- `adminWeight` overrides nodePath comparison entirely (higher weight always wins)
+
+**Test scenarios (~4 tests):**
+
+- Equal nodePath, different metrics → lower wins
+- Admin weight overrides longer nodePath
+- Missing metric treated as neutral
+- Metric preserved through propagation chain
+
+---
+
+## 8. End-of-RIB / Convergence Delay
+
+**What it tests:** When a peer connects, it sends its routing table followed by an End-of-RIB marker. Until EoR is received, the RIB defers propagation to prevent sending partial state downstream.
+
+**Why it matters:** Currently, each `InternalProtocolUpdate` triggers immediate propagation. If a peer sends 100 routes in 10 messages, downstream peers receive 10 separate propagation messages instead of one. BIRD has `BFS_LOADING` state, FRR has `bgp_update_delay`.
+
+**Changes required:**
+
+- Add `loading?: boolean` to `PeerRecord`
+- Set `loading: true` on `InternalProtocolOpen`
+- New action or update marker for End-of-RIB
+- Modify `computePropagations`: defer propagation while source peer is loading
+- On EoR: propagate all accumulated routes at once
+- Timeout: if EoR not received within N seconds, propagate anyway
+
+**Test scenarios (~4 tests):**
+
+- Peer marked as loading on connect → updates stored but not propagated
+- EoR received → all accumulated routes propagated at once
+- Loading timeout → routes propagated anyway
+- Non-loading peer updates propagated immediately
+
+---
+
+## 9. Conditional Advertisement
+
+**What it tests:** Routes are only advertised to a peer if a condition is met — e.g., "only advertise frontend-api to peer C if database-api exists in the RIB." If the condition route is withdrawn, the dependent route is also withdrawn.
+
+**Why it matters:** Enables dependency-based routing in service mesh topologies. FRR has `bgp_conditional_advertisement` and `bgp_conditional_advertisement_track_peer` test directories.
+
+**Changes required:**
+
+- Add `advertisementCondition?: { routeName: string; mode: 'exist' | 'non-exist' }` per peer+route
+- Modify `computePropagations`: evaluate condition before including route in propagation
+- On condition route withdrawal: re-evaluate and potentially withdraw dependent routes
+
+**Test scenarios (~5 tests):**
+
+- Route propagated when condition route present
+- Route withdrawn when condition route removed
+- Condition route re-added re-triggers advertisement
+- Non-exist mode inverts the condition
+- Condition evaluated per-peer independently
+
+---
+
+## 10. Peer Session Flap Detection
+
+**What it tests:** Tracking rapid connect/disconnect cycles at the session level. If a peer disconnects and reconnects N times within a window, it's flagged as flapping and route propagation is suppressed.
+
+**Why it matters:** A peer with an unstable network connection causes repeated full sync operations across the mesh. Without session-level damping, every reconnect triggers full route propagation to all peers. BIRD's connect delay timers provide implicit damping.
+
+**Changes required:**
+
+- Add `flapCount?: number` and `lastDisconnect?: number` to `PeerRecord`
+- On `InternalProtocolClose`: increment flapCount, record timestamp
+- On `InternalProtocolOpen`: check flapCount within window, defer full sync if flapping
+- On `Tick`: reset flapCount after stability period
+
+**Test scenarios (~5 tests):**
+
+- Peer connects/disconnects N times → detected as flapping
+- Flapping peer's full sync deferred
+- Stability period resets flap counter
+- Non-flapping peer treated normally
+- Flap counter decays over time
+
+---
+
+## 11. Route Aggregation
+
+**What it tests:** When multiple peers advertise the same route name, only the best/aggregated version is propagated downstream (instead of all individual entries). Reduces update volume.
+
+**Why it matters:** Currently, `buildRouteSyncPayload` sends all internal routes to downstream peers. With N peers advertising the same service, downstream receives N copies. BIRD 3.x has a dedicated aggregator protocol with tests.
+
+**Changes required:**
+
+- Modify `buildRouteSyncPayload`: for each unique route name, only include the best path (from `routeMetadata`)
+- Modify `computePropagations` for `InternalProtocolUpdate`: if a new route doesn't change the best path, suppress propagation
+- If best path changes: send update with new best attributes (not withdrawal+add)
+
+**Test scenarios (~4 tests):**
+
+- Multiple peers advertise same route → only best propagated
+- Withdrawal of best → alternative promoted, update (not withdrawal) sent downstream
+- New better path → downstream receives single update
+- Aggregated attributes reflect best candidate

--- a/apps/orchestrator/tests/bgp-empty-rib-sync.test.ts
+++ b/apps/orchestrator/tests/bgp-empty-rib-sync.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'bun:test'
+import { Actions, type PeerInfo } from '@catalyst/routing'
+import { RoutingInformationBase } from '../src/rib.js'
+import type { OrchestratorConfig } from '../src/types.js'
+
+/**
+ * Empty RIB Sync Tests
+ *
+ * Verifies that InternalProtocolOpen produces zero propagations
+ * when there are no routes to sync (the early-return path at
+ * rib.ts computePropagations for InternalProtocolOpen).
+ */
+
+const NODE: PeerInfo = {
+  name: 'node-a.somebiz.local.io',
+  endpoint: 'http://node-a:3000',
+  domains: ['somebiz.local.io'],
+}
+
+const PEER_B: PeerInfo = {
+  name: 'node-b.somebiz.local.io',
+  endpoint: 'http://node-b:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-b',
+}
+
+const CONFIG: OrchestratorConfig = { node: NODE }
+
+function createRib() {
+  return new RoutingInformationBase(CONFIG)
+}
+
+function planCommit(rib: RoutingInformationBase, action: Parameters<typeof rib.plan>[0]) {
+  const plan = rib.plan(action)
+  if (!plan.success) throw new Error(`plan failed: ${plan.error}`)
+  return rib.commit(plan)
+}
+
+describe('Empty RIB Sync', () => {
+  it('InternalProtocolOpen with empty RIB produces zero propagations', () => {
+    const rib = createRib()
+    planCommit(rib, { action: Actions.LocalPeerCreate, data: PEER_B })
+
+    const result = planCommit(rib, {
+      action: Actions.InternalProtocolOpen,
+      data: { peerInfo: PEER_B },
+    })
+
+    expect(result.propagations).toHaveLength(0)
+  })
+
+  it('InternalProtocolOpen with routes produces sync propagation', () => {
+    const rib = createRib()
+
+    planCommit(rib, {
+      action: Actions.LocalRouteCreate,
+      data: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://x:8080' },
+    })
+
+    planCommit(rib, { action: Actions.LocalPeerCreate, data: PEER_B })
+    const result = planCommit(rib, {
+      action: Actions.InternalProtocolOpen,
+      data: { peerInfo: PEER_B },
+    })
+
+    expect(result.propagations).toHaveLength(1)
+    if (result.propagations[0].type === 'update') {
+      expect(result.propagations[0].peer.peerToken).toBe('token-for-b')
+    }
+  })
+})

--- a/apps/orchestrator/tests/bgp-insertion-order-independence.test.ts
+++ b/apps/orchestrator/tests/bgp-insertion-order-independence.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'bun:test'
+import { Actions, type PeerInfo } from '@catalyst/routing'
+import { RoutingInformationBase } from '../src/rib.js'
+import type { OrchestratorConfig } from '../src/types.js'
+
+/**
+ * Insertion-Order Independence Tests
+ *
+ * Inspired by OpenBGPD's test_evaluate() which tries all N!
+ * insertion orderings to verify deterministic best-path selection.
+ * Ensures computeRouteMetadata produces identical results
+ * regardless of the order routes are added.
+ */
+
+const NODE: PeerInfo = {
+  name: 'node-a.somebiz.local.io',
+  endpoint: 'http://node-a:3000',
+  domains: ['somebiz.local.io'],
+}
+
+const PEER_B: PeerInfo = {
+  name: 'node-b.somebiz.local.io',
+  endpoint: 'http://node-b:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-b',
+}
+
+const PEER_C: PeerInfo = {
+  name: 'node-c.somebiz.local.io',
+  endpoint: 'http://node-c:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-c',
+}
+
+const PEER_D: PeerInfo = {
+  name: 'node-d.somebiz.local.io',
+  endpoint: 'http://node-d:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-d',
+}
+
+const CONFIG: OrchestratorConfig = { node: NODE }
+
+function createRib() {
+  return new RoutingInformationBase(CONFIG)
+}
+
+function planCommit(rib: RoutingInformationBase, action: Parameters<typeof rib.plan>[0]) {
+  const plan = rib.plan(action)
+  if (!plan.success) throw new Error(`plan failed: ${plan.error}`)
+  return rib.commit(plan)
+}
+
+function connectPeer(rib: RoutingInformationBase, peer: PeerInfo) {
+  planCommit(rib, { action: Actions.LocalPeerCreate, data: peer })
+  planCommit(rib, { action: Actions.InternalProtocolOpen, data: { peerInfo: peer } })
+}
+
+describe('Insertion-Order Independence', () => {
+  it('2 peers: same best-path regardless of insertion order', () => {
+    const routes = [
+      { peer: PEER_B, nodePath: [PEER_B.name] },
+      { peer: PEER_C, nodePath: [PEER_C.name, 'hop-2'] },
+    ]
+
+    const results: string[] = []
+    for (const ordering of [routes, [...routes].reverse()]) {
+      const rib = createRib()
+      connectPeer(rib, PEER_B)
+      connectPeer(rib, PEER_C)
+
+      for (const r of ordering) {
+        planCommit(rib, {
+          action: Actions.InternalProtocolUpdate,
+          data: {
+            peerInfo: r.peer,
+            update: {
+              updates: [
+                {
+                  action: 'add',
+                  route: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://x:8080' },
+                  nodePath: r.nodePath,
+                },
+              ],
+            },
+          },
+        })
+      }
+
+      results.push(rib.getRouteMetadata().get('svc-x')!.bestPath.peerName)
+    }
+
+    expect(results[0]).toBe(results[1])
+    expect(results[0]).toBe(PEER_B.name)
+  })
+
+  it('3 peers: all 6 permutations produce same best-path', () => {
+    const routes = [
+      { peer: PEER_B, nodePath: [PEER_B.name] },
+      { peer: PEER_C, nodePath: [PEER_C.name, 'hop-2'] },
+      { peer: PEER_D, nodePath: [PEER_D.name, 'hop-2', 'hop-3'] },
+    ]
+
+    const permutations = [
+      [0, 1, 2],
+      [0, 2, 1],
+      [1, 0, 2],
+      [1, 2, 0],
+      [2, 0, 1],
+      [2, 1, 0],
+    ]
+
+    const results: string[] = []
+    for (const perm of permutations) {
+      const rib = createRib()
+      connectPeer(rib, PEER_B)
+      connectPeer(rib, PEER_C)
+      connectPeer(rib, PEER_D)
+
+      for (const idx of perm) {
+        const r = routes[idx]
+        planCommit(rib, {
+          action: Actions.InternalProtocolUpdate,
+          data: {
+            peerInfo: r.peer,
+            update: {
+              updates: [
+                {
+                  action: 'add',
+                  route: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://x:8080' },
+                  nodePath: r.nodePath,
+                },
+              ],
+            },
+          },
+        })
+      }
+
+      results.push(rib.getRouteMetadata().get('svc-x')!.bestPath.peerName)
+    }
+
+    expect(new Set(results).size).toBe(1)
+    expect(results[0]).toBe(PEER_B.name)
+  })
+})

--- a/apps/orchestrator/tests/bgp-last-sent-tracking.test.ts
+++ b/apps/orchestrator/tests/bgp-last-sent-tracking.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'bun:test'
+import { Actions, type PeerInfo } from '@catalyst/routing'
+import { RoutingInformationBase } from '../src/rib.js'
+import type { OrchestratorConfig } from '../src/types.js'
+
+/**
+ * lastSent Tracking Tests
+ *
+ * commit() updates lastSent only for peers that receive 'update'
+ * or 'keepalive' propagations — NOT for 'open' or 'close' types.
+ */
+
+const NODE: PeerInfo = {
+  name: 'node-a.somebiz.local.io',
+  endpoint: 'http://node-a:3000',
+  domains: ['somebiz.local.io'],
+}
+
+const PEER_B: PeerInfo = {
+  name: 'node-b.somebiz.local.io',
+  endpoint: 'http://node-b:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-b',
+}
+
+const CONFIG: OrchestratorConfig = { node: NODE }
+
+function createRib() {
+  return new RoutingInformationBase(CONFIG)
+}
+
+function planCommit(rib: RoutingInformationBase, action: Parameters<typeof rib.plan>[0]) {
+  const plan = rib.plan(action)
+  if (!plan.success) throw new Error(`plan failed: ${plan.error}`)
+  return rib.commit(plan)
+}
+
+describe('lastSent Tracking', () => {
+  it('not updated for open propagation', () => {
+    const rib = createRib()
+
+    const result = planCommit(rib, { action: Actions.LocalPeerCreate, data: PEER_B })
+
+    expect(result.propagations).toHaveLength(1)
+    expect(result.propagations[0].type).toBe('open')
+
+    const peer = rib.getState().internal.peers.find((p) => p.name === PEER_B.name)
+    expect(peer).toBeDefined()
+    expect(peer!.lastSent).toBeUndefined()
+  })
+
+  it('updated for update propagation', () => {
+    const rib = createRib()
+
+    planCommit(rib, {
+      action: Actions.LocalRouteCreate,
+      data: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://x:8080' },
+    })
+
+    planCommit(rib, { action: Actions.LocalPeerCreate, data: PEER_B })
+    planCommit(rib, {
+      action: Actions.InternalProtocolOpen,
+      data: { peerInfo: PEER_B },
+    })
+
+    // lastSent should be set after the open (which triggers a full sync update)
+    const peer = rib.getState().internal.peers.find((p) => p.name === PEER_B.name)
+    expect(peer).toBeDefined()
+    expect(peer!.lastSent).toBeNumber()
+  })
+})

--- a/apps/orchestrator/tests/bgp-local-route-preference.test.ts
+++ b/apps/orchestrator/tests/bgp-local-route-preference.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'bun:test'
+import { Actions, type PeerInfo } from '@catalyst/routing'
+import { RoutingInformationBase } from '../src/rib.js'
+import type { OrchestratorConfig } from '../src/types.js'
+
+/**
+ * Local Route Preference Tests
+ *
+ * Verifies that local and internal routes with the same name coexist
+ * independently. Inspired by BIRD's DEF_PREF_DIRECT > DEF_PREF_BGP
+ * hierarchy. Documents current behavior where local/internal are
+ * separate namespaces (no cross-preference).
+ */
+
+const NODE: PeerInfo = {
+  name: 'node-a.somebiz.local.io',
+  endpoint: 'http://node-a:3000',
+  domains: ['somebiz.local.io'],
+}
+
+const PEER_B: PeerInfo = {
+  name: 'node-b.somebiz.local.io',
+  endpoint: 'http://node-b:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-b',
+}
+
+const CONFIG: OrchestratorConfig = { node: NODE }
+
+function createRib() {
+  return new RoutingInformationBase(CONFIG)
+}
+
+function planCommit(rib: RoutingInformationBase, action: Parameters<typeof rib.plan>[0]) {
+  const plan = rib.plan(action)
+  if (!plan.success) throw new Error(`plan failed: ${plan.error}`)
+  return rib.commit(plan)
+}
+
+function connectPeer(rib: RoutingInformationBase, peer: PeerInfo) {
+  planCommit(rib, { action: Actions.LocalPeerCreate, data: peer })
+  planCommit(rib, { action: Actions.InternalProtocolOpen, data: { peerInfo: peer } })
+}
+
+describe('Local Route Preference', () => {
+  it('local and internal routes with same name coexist', () => {
+    const rib = createRib()
+    connectPeer(rib, PEER_B)
+
+    planCommit(rib, {
+      action: Actions.LocalRouteCreate,
+      data: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://local:8080' },
+    })
+
+    planCommit(rib, {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_B,
+        update: {
+          updates: [
+            {
+              action: 'add',
+              route: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://b:8080' },
+              nodePath: [PEER_B.name],
+            },
+          ],
+        },
+      },
+    })
+
+    expect(rib.getState().local.routes.find((r) => r.name === 'svc-x')).toBeDefined()
+    expect(rib.getState().internal.routes.find((r) => r.name === 'svc-x')).toBeDefined()
+  })
+
+  it('deleting local route does not remove internal route with same name', () => {
+    const rib = createRib()
+    connectPeer(rib, PEER_B)
+
+    planCommit(rib, {
+      action: Actions.LocalRouteCreate,
+      data: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://local:8080' },
+    })
+
+    planCommit(rib, {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_B,
+        update: {
+          updates: [
+            {
+              action: 'add',
+              route: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://b:8080' },
+              nodePath: [PEER_B.name],
+            },
+          ],
+        },
+      },
+    })
+
+    planCommit(rib, {
+      action: Actions.LocalRouteDelete,
+      data: { name: 'svc-x', protocol: 'http' as const },
+    })
+
+    expect(rib.getState().local.routes.find((r) => r.name === 'svc-x')).toBeUndefined()
+    expect(rib.getState().internal.routes.find((r) => r.name === 'svc-x')).toBeDefined()
+  })
+})

--- a/apps/orchestrator/tests/bgp-nodepath-undefined-fallback.test.ts
+++ b/apps/orchestrator/tests/bgp-nodepath-undefined-fallback.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'bun:test'
+import { Actions, type PeerInfo } from '@catalyst/routing'
+import { RoutingInformationBase } from '../src/rib.js'
+import type { OrchestratorConfig } from '../src/types.js'
+
+/**
+ * nodePath Undefined Fallback Tests
+ *
+ * The RIB uses `nodePath ?? []` in both computeNewState and
+ * computePropagations. These tests verify the fallback works
+ * when nodePath is literally undefined (not just an empty array).
+ */
+
+const NODE: PeerInfo = {
+  name: 'node-a.somebiz.local.io',
+  endpoint: 'http://node-a:3000',
+  domains: ['somebiz.local.io'],
+}
+
+const PEER_B: PeerInfo = {
+  name: 'node-b.somebiz.local.io',
+  endpoint: 'http://node-b:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-b',
+}
+
+const PEER_C: PeerInfo = {
+  name: 'node-c.somebiz.local.io',
+  endpoint: 'http://node-c:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-c',
+}
+
+const CONFIG: OrchestratorConfig = { node: NODE }
+
+function createRib() {
+  return new RoutingInformationBase(CONFIG)
+}
+
+function planCommit(rib: RoutingInformationBase, action: Parameters<typeof rib.plan>[0]) {
+  const plan = rib.plan(action)
+  if (!plan.success) throw new Error(`plan failed: ${plan.error}`)
+  return rib.commit(plan)
+}
+
+function connectPeer(rib: RoutingInformationBase, peer: PeerInfo) {
+  planCommit(rib, { action: Actions.LocalPeerCreate, data: peer })
+  planCommit(rib, { action: Actions.InternalProtocolOpen, data: { peerInfo: peer } })
+}
+
+describe('nodePath Undefined Fallback', () => {
+  it('undefined nodePath in update defaults to empty array in state', () => {
+    const rib = createRib()
+    connectPeer(rib, PEER_B)
+
+    planCommit(rib, {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_B,
+        update: {
+          updates: [
+            {
+              action: 'add',
+              route: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://x:8080' },
+            } as any,
+          ],
+        },
+      },
+    })
+
+    const routes = rib.getState().internal.routes
+    expect(routes).toHaveLength(1)
+    expect(routes[0].nodePath).toEqual([])
+  })
+
+  it('undefined nodePath in propagation filter does not crash', () => {
+    const rib = createRib()
+    connectPeer(rib, PEER_B)
+    connectPeer(rib, PEER_C)
+
+    const result = planCommit(rib, {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_B,
+        update: {
+          updates: [
+            {
+              action: 'add',
+              route: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://x:8080' },
+            } as any,
+          ],
+        },
+      },
+    })
+
+    // Should propagate to C successfully with empty nodePath defaulted
+    const toC = result.propagations.find((p) => p.type === 'update' && p.peer.name === PEER_C.name)
+    expect(toC).toBeDefined()
+    if (toC && toC.type === 'update') {
+      // nodePath should be [NODE.name] (prepended by this node)
+      expect(toC.update.updates[0].nodePath).toEqual([NODE.name])
+    }
+  })
+})

--- a/apps/orchestrator/tests/bgp-nway-route-tie.test.ts
+++ b/apps/orchestrator/tests/bgp-nway-route-tie.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'bun:test'
+import { Actions, type PeerInfo } from '@catalyst/routing'
+import { RoutingInformationBase } from '../src/rib.js'
+import type { OrchestratorConfig } from '../src/types.js'
+
+/**
+ * N-Way Route Tie Tests
+ *
+ * When multiple peers advertise the same route with equal-length
+ * nodePaths, the RIB must store all of them and maintain correct
+ * metadata (bestPath + alternatives). Inspired by GoBGP TestMultipath.
+ */
+
+const NODE: PeerInfo = {
+  name: 'node-a.somebiz.local.io',
+  endpoint: 'http://node-a:3000',
+  domains: ['somebiz.local.io'],
+}
+
+const PEER_B: PeerInfo = {
+  name: 'node-b.somebiz.local.io',
+  endpoint: 'http://node-b:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-b',
+}
+
+const PEER_C: PeerInfo = {
+  name: 'node-c.somebiz.local.io',
+  endpoint: 'http://node-c:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-c',
+}
+
+const PEER_D: PeerInfo = {
+  name: 'node-d.somebiz.local.io',
+  endpoint: 'http://node-d:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-d',
+}
+
+const CONFIG: OrchestratorConfig = { node: NODE }
+
+function createRib() {
+  return new RoutingInformationBase(CONFIG)
+}
+
+function planCommit(rib: RoutingInformationBase, action: Parameters<typeof rib.plan>[0]) {
+  const plan = rib.plan(action)
+  if (!plan.success) throw new Error(`plan failed: ${plan.error}`)
+  return rib.commit(plan)
+}
+
+function connectPeer(rib: RoutingInformationBase, peer: PeerInfo) {
+  planCommit(rib, { action: Actions.LocalPeerCreate, data: peer })
+  planCommit(rib, { action: Actions.InternalProtocolOpen, data: { peerInfo: peer } })
+}
+
+describe('N-Way Route Tie', () => {
+  it('3 peers with equal-length nodePaths: all stored, correct alternatives count', () => {
+    const rib = createRib()
+    connectPeer(rib, PEER_B)
+    connectPeer(rib, PEER_C)
+    connectPeer(rib, PEER_D)
+
+    for (const peer of [PEER_B, PEER_C, PEER_D]) {
+      planCommit(rib, {
+        action: Actions.InternalProtocolUpdate,
+        data: {
+          peerInfo: peer,
+          update: {
+            updates: [
+              {
+                action: 'add',
+                route: {
+                  name: 'svc-x',
+                  protocol: 'http' as const,
+                  endpoint: `http://${peer.name}:8080`,
+                },
+                nodePath: [peer.name],
+              },
+            ],
+          },
+        },
+      })
+    }
+
+    const routes = rib.getState().internal.routes.filter((r) => r.name === 'svc-x')
+    expect(routes).toHaveLength(3)
+
+    const meta = rib.getRouteMetadata().get('svc-x')
+    expect(meta).toBeDefined()
+    expect(meta!.alternatives).toHaveLength(2)
+  })
+
+  it('withdrawal from 3-way tie reduces alternatives by one', () => {
+    const rib = createRib()
+    connectPeer(rib, PEER_B)
+    connectPeer(rib, PEER_C)
+    connectPeer(rib, PEER_D)
+
+    for (const peer of [PEER_B, PEER_C, PEER_D]) {
+      planCommit(rib, {
+        action: Actions.InternalProtocolUpdate,
+        data: {
+          peerInfo: peer,
+          update: {
+            updates: [
+              {
+                action: 'add',
+                route: {
+                  name: 'svc-x',
+                  protocol: 'http' as const,
+                  endpoint: `http://${peer.name}:8080`,
+                },
+                nodePath: [peer.name],
+              },
+            ],
+          },
+        },
+      })
+    }
+
+    // Withdraw B
+    planCommit(rib, {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_B,
+        update: {
+          updates: [{ action: 'remove', route: { name: 'svc-x', protocol: 'http' as const } }],
+        },
+      },
+    })
+
+    const meta = rib.getRouteMetadata().get('svc-x')
+    expect(meta).toBeDefined()
+    expect(meta!.alternatives).toHaveLength(1)
+  })
+
+  it('all peers withdraw: route metadata cleaned up', () => {
+    const rib = createRib()
+    connectPeer(rib, PEER_B)
+    connectPeer(rib, PEER_C)
+
+    for (const peer of [PEER_B, PEER_C]) {
+      planCommit(rib, {
+        action: Actions.InternalProtocolUpdate,
+        data: {
+          peerInfo: peer,
+          update: {
+            updates: [
+              {
+                action: 'add',
+                route: {
+                  name: 'svc-x',
+                  protocol: 'http' as const,
+                  endpoint: `http://${peer.name}:8080`,
+                },
+                nodePath: [peer.name],
+              },
+            ],
+          },
+        },
+      })
+    }
+
+    for (const peer of [PEER_B, PEER_C]) {
+      planCommit(rib, {
+        action: Actions.InternalProtocolUpdate,
+        data: {
+          peerInfo: peer,
+          update: {
+            updates: [{ action: 'remove', route: { name: 'svc-x', protocol: 'http' as const } }],
+          },
+        },
+      })
+    }
+
+    expect(rib.getState().internal.routes.filter((r) => r.name === 'svc-x')).toHaveLength(0)
+    expect(rib.getRouteMetadata().has('svc-x')).toBe(false)
+  })
+})

--- a/apps/orchestrator/tests/bgp-peer-churn-stability.test.ts
+++ b/apps/orchestrator/tests/bgp-peer-churn-stability.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'bun:test'
+import { Actions, type PeerInfo } from '@catalyst/routing'
+import { RoutingInformationBase } from '../src/rib.js'
+import { createPortAllocator } from '@catalyst/envoy-service'
+import type { OrchestratorConfig } from '../src/types.js'
+
+/**
+ * Peer Churn Stability Tests
+ *
+ * Verifies that repeated peer connect/disconnect cycles do not
+ * accumulate state or leak port allocator resources. Inspired by
+ * GoBGP's TestNumGoroutineWithAddDeleteNeighbor.
+ */
+
+const NODE: PeerInfo = {
+  name: 'node-a.somebiz.local.io',
+  endpoint: 'http://node-a:3000',
+  domains: ['somebiz.local.io'],
+}
+
+const PEER_B: PeerInfo = {
+  name: 'node-b.somebiz.local.io',
+  endpoint: 'http://node-b:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-b',
+}
+
+function planCommit(rib: RoutingInformationBase, action: Parameters<typeof rib.plan>[0]) {
+  const plan = rib.plan(action)
+  if (!plan.success) throw new Error(`plan failed: ${plan.error}`)
+  return rib.commit(plan)
+}
+
+function connectPeer(rib: RoutingInformationBase, peer: PeerInfo) {
+  planCommit(rib, { action: Actions.LocalPeerCreate, data: peer })
+  planCommit(rib, { action: Actions.InternalProtocolOpen, data: { peerInfo: peer } })
+}
+
+describe('Peer Churn Stability', () => {
+  it('100 connect/route/close cycles leave zero state', () => {
+    const config: OrchestratorConfig = { node: NODE }
+    const rib = new RoutingInformationBase(config)
+
+    for (let i = 0; i < 100; i++) {
+      connectPeer(rib, PEER_B)
+
+      planCommit(rib, {
+        action: Actions.InternalProtocolUpdate,
+        data: {
+          peerInfo: PEER_B,
+          update: {
+            updates: [
+              {
+                action: 'add',
+                route: {
+                  name: `svc-${i}`,
+                  protocol: 'http' as const,
+                  endpoint: 'http://svc:8080',
+                },
+                nodePath: [PEER_B.name],
+              },
+            ],
+          },
+        },
+      })
+
+      planCommit(rib, {
+        action: Actions.InternalProtocolClose,
+        data: { peerInfo: PEER_B, code: 1000 },
+      })
+    }
+
+    expect(rib.getState().internal.peers).toHaveLength(0)
+    expect(rib.getState().internal.routes).toHaveLength(0)
+    expect(rib.getRouteMetadata().size).toBe(0)
+  })
+
+  it('port allocator churn: 20 cycles release all ports', () => {
+    const config: OrchestratorConfig = {
+      node: NODE,
+      envoyConfig: {
+        endpoint: 'http://envoy:18000',
+        portRange: [[10000, 10100]],
+      },
+    }
+    const allocator = createPortAllocator([[10000, 10100]])
+    const rib = new RoutingInformationBase(config, allocator)
+
+    const initialAvailable = allocator.availableCount()
+
+    for (let i = 0; i < 20; i++) {
+      connectPeer(rib, PEER_B)
+
+      planCommit(rib, {
+        action: Actions.InternalProtocolUpdate,
+        data: {
+          peerInfo: PEER_B,
+          update: {
+            updates: [
+              {
+                action: 'add',
+                route: {
+                  name: 'svc-x',
+                  protocol: 'http' as const,
+                  endpoint: 'http://x:8080',
+                },
+                nodePath: [PEER_B.name],
+              },
+            ],
+          },
+        },
+      })
+
+      planCommit(rib, {
+        action: Actions.InternalProtocolClose,
+        data: { peerInfo: PEER_B, code: 1000 },
+      })
+    }
+
+    expect(rib.getState().internal.peers).toHaveLength(0)
+    expect(rib.getState().internal.routes).toHaveLength(0)
+    expect(allocator.availableCount()).toBe(initialAvailable)
+  })
+})

--- a/apps/orchestrator/tests/bgp-plan-error-paths.test.ts
+++ b/apps/orchestrator/tests/bgp-plan-error-paths.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'bun:test'
+import { Actions, type PeerInfo } from '@catalyst/routing'
+import { RoutingInformationBase } from '../src/rib.js'
+import type { OrchestratorConfig } from '../src/types.js'
+
+/**
+ * Plan Error Path Tests
+ *
+ * Every plan() call that returns { success: false } — validates
+ * that all error guard branches are exercised.
+ */
+
+const NODE: PeerInfo = {
+  name: 'node-a.somebiz.local.io',
+  endpoint: 'http://node-a:3000',
+  domains: ['somebiz.local.io'],
+}
+
+const PEER_B: PeerInfo = {
+  name: 'node-b.somebiz.local.io',
+  endpoint: 'http://node-b:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-b',
+}
+
+const CONFIG: OrchestratorConfig = { node: NODE }
+
+function createRib() {
+  return new RoutingInformationBase(CONFIG)
+}
+
+function planCommit(rib: RoutingInformationBase, action: Parameters<typeof rib.plan>[0]) {
+  const plan = rib.plan(action)
+  if (!plan.success) throw new Error(`plan failed: ${plan.error}`)
+  return rib.commit(plan)
+}
+
+describe('Plan Error Paths', () => {
+  it('LocalPeerUpdate for nonexistent peer returns failure', () => {
+    const rib = createRib()
+    const result = rib.plan({
+      action: Actions.LocalPeerUpdate,
+      data: {
+        name: 'nonexistent-peer',
+        endpoint: 'http://x:3000',
+        domains: ['x.local.io'],
+        peerToken: 'token',
+      },
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('Peer not found')
+    }
+  })
+
+  it('LocalPeerDelete for nonexistent peer returns failure', () => {
+    const rib = createRib()
+    const result = rib.plan({
+      action: Actions.LocalPeerDelete,
+      data: { name: 'nonexistent-peer' },
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('Peer not found')
+    }
+  })
+
+  it('LocalRouteDelete for nonexistent route returns failure', () => {
+    const rib = createRib()
+    const result = rib.plan({
+      action: Actions.LocalRouteDelete,
+      data: { name: 'nonexistent-route', protocol: 'http' as const },
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('Route not found')
+    }
+  })
+
+  it('LocalPeerCreate without peerToken returns failure', () => {
+    const rib = createRib()
+    const result = rib.plan({
+      action: Actions.LocalPeerCreate,
+      data: {
+        name: 'peer-no-token',
+        endpoint: 'http://x:3000',
+        domains: ['x.local.io'],
+      },
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('peerToken is required when creating a peer')
+    }
+  })
+
+  it('LocalPeerCreate for existing peer returns failure', () => {
+    const rib = createRib()
+    planCommit(rib, { action: Actions.LocalPeerCreate, data: PEER_B })
+
+    const result = rib.plan({ action: Actions.LocalPeerCreate, data: PEER_B })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('Peer already exists')
+    }
+  })
+
+  it('LocalRouteCreate for existing route returns failure', () => {
+    const rib = createRib()
+    planCommit(rib, {
+      action: Actions.LocalRouteCreate,
+      data: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://x:8080' },
+    })
+
+    const result = rib.plan({
+      action: Actions.LocalRouteCreate,
+      data: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://x:9090' },
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('Route already exists')
+    }
+  })
+})

--- a/apps/orchestrator/tests/bgp-plan-state-isolation.test.ts
+++ b/apps/orchestrator/tests/bgp-plan-state-isolation.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'bun:test'
+import { Actions, type PeerInfo } from '@catalyst/routing'
+import { RoutingInformationBase, type Plan } from '../src/rib.js'
+import type { OrchestratorConfig } from '../src/types.js'
+
+/**
+ * Plan State Isolation Tests
+ *
+ * Verifies that plan() produces isolated state objects — mutating
+ * one plan's output does not affect another. Inspired by GoBGP's
+ * immutable state design and the JavaScript shallow-copy footgun.
+ */
+
+const NODE: PeerInfo = {
+  name: 'node-a.somebiz.local.io',
+  endpoint: 'http://node-a:3000',
+  domains: ['somebiz.local.io'],
+}
+
+const PEER_B: PeerInfo = {
+  name: 'node-b.somebiz.local.io',
+  endpoint: 'http://node-b:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-b',
+}
+
+const CONFIG: OrchestratorConfig = { node: NODE }
+
+function createRib() {
+  return new RoutingInformationBase(CONFIG)
+}
+
+function planCommit(rib: RoutingInformationBase, action: Parameters<typeof rib.plan>[0]) {
+  const plan = rib.plan(action)
+  if (!plan.success) throw new Error(`plan failed: ${plan.error}`)
+  return rib.commit(plan)
+}
+
+function connectPeer(rib: RoutingInformationBase, peer: PeerInfo) {
+  planCommit(rib, { action: Actions.LocalPeerCreate, data: peer })
+  planCommit(rib, { action: Actions.InternalProtocolOpen, data: { peerInfo: peer } })
+}
+
+describe('Plan State Isolation', () => {
+  it('two plans from same state have independent route lists', () => {
+    const rib = createRib()
+    connectPeer(rib, PEER_B)
+
+    const planA = rib.plan({
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_B,
+        update: {
+          updates: [
+            {
+              action: 'add',
+              route: { name: 'svc-a', protocol: 'http' as const, endpoint: 'http://a:8080' },
+              nodePath: [PEER_B.name],
+            },
+          ],
+        },
+      },
+    }) as Plan
+
+    const planB = rib.plan({
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_B,
+        update: {
+          updates: [
+            {
+              action: 'add',
+              route: { name: 'svc-b', protocol: 'http' as const, endpoint: 'http://b:8080' },
+              nodePath: [PEER_B.name],
+            },
+          ],
+        },
+      },
+    }) as Plan
+
+    const aNames = planA.newState.internal.routes.map((r) => r.name)
+    const bNames = planB.newState.internal.routes.map((r) => r.name)
+
+    expect(aNames).toContain('svc-a')
+    expect(aNames).not.toContain('svc-b')
+    expect(bNames).toContain('svc-b')
+    expect(bNames).not.toContain('svc-a')
+  })
+
+  it('committing plan A does not corrupt plan B', () => {
+    const rib = createRib()
+    connectPeer(rib, PEER_B)
+
+    const planA = rib.plan({
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_B,
+        update: {
+          updates: [
+            {
+              action: 'add',
+              route: { name: 'svc-a', protocol: 'http' as const, endpoint: 'http://a:8080' },
+              nodePath: [PEER_B.name],
+            },
+          ],
+        },
+      },
+    }) as Plan
+
+    const planB = rib.plan({
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_B,
+        update: {
+          updates: [
+            {
+              action: 'add',
+              route: { name: 'svc-b', protocol: 'http' as const, endpoint: 'http://b:8080' },
+              nodePath: [PEER_B.name],
+            },
+          ],
+        },
+      },
+    }) as Plan
+
+    rib.commit(planA)
+
+    // Plan B should still only have svc-b
+    const bNames = planB.newState.internal.routes.map((r) => r.name)
+    expect(bNames).toContain('svc-b')
+    expect(bNames).not.toContain('svc-a')
+  })
+})

--- a/apps/orchestrator/tests/bgp-protocol-connected.test.ts
+++ b/apps/orchestrator/tests/bgp-protocol-connected.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'bun:test'
+import { Actions, type PeerInfo } from '@catalyst/routing'
+import { RoutingInformationBase } from '../src/rib.js'
+import type { OrchestratorConfig } from '../src/types.js'
+
+/**
+ * InternalProtocolConnected Tests
+ *
+ * The Connected action is the outbound connection path (vs Open for inbound).
+ * Tests cover full sync propagation, unknown peer no-op, empty RIB sync,
+ * and the missing peerToken guard.
+ */
+
+const NODE: PeerInfo = {
+  name: 'node-a.somebiz.local.io',
+  endpoint: 'http://node-a:3000',
+  domains: ['somebiz.local.io'],
+}
+
+const PEER_B: PeerInfo = {
+  name: 'node-b.somebiz.local.io',
+  endpoint: 'http://node-b:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-b',
+}
+
+const CONFIG: OrchestratorConfig = { node: NODE }
+
+function createRib() {
+  return new RoutingInformationBase(CONFIG)
+}
+
+function planCommit(rib: RoutingInformationBase, action: Parameters<typeof rib.plan>[0]) {
+  const plan = rib.plan(action)
+  if (!plan.success) throw new Error(`plan failed: ${plan.error}`)
+  return rib.commit(plan)
+}
+
+describe('InternalProtocolConnected', () => {
+  it('unknown peer is a silent no-op', () => {
+    const rib = createRib()
+
+    const result = planCommit(rib, {
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: PEER_B },
+    })
+
+    expect(rib.getState().internal.peers).toHaveLength(0)
+    expect(result.propagations).toHaveLength(0)
+  })
+
+  it('produces full sync propagation when routes exist', () => {
+    const rib = createRib()
+
+    planCommit(rib, {
+      action: Actions.LocalRouteCreate,
+      data: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://x:8080' },
+    })
+
+    planCommit(rib, { action: Actions.LocalPeerCreate, data: PEER_B })
+
+    const result = planCommit(rib, {
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: PEER_B },
+    })
+
+    expect(result.propagations).toHaveLength(1)
+    expect(result.propagations[0].type).toBe('update')
+    if (result.propagations[0].type === 'update') {
+      expect(result.propagations[0].update.updates).toHaveLength(1)
+      expect(result.propagations[0].update.updates[0].route.name).toBe('svc-x')
+    }
+  })
+
+  it('empty RIB produces zero propagations', () => {
+    const rib = createRib()
+    planCommit(rib, { action: Actions.LocalPeerCreate, data: PEER_B })
+
+    const result = planCommit(rib, {
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: PEER_B },
+    })
+
+    expect(result.propagations).toHaveLength(0)
+  })
+
+  it('missing peerToken produces zero propagations', () => {
+    const rib = createRib()
+
+    planCommit(rib, {
+      action: Actions.LocalRouteCreate,
+      data: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://x:8080' },
+    })
+
+    planCommit(rib, { action: Actions.LocalPeerCreate, data: PEER_B })
+
+    const peerWithoutToken: PeerInfo = {
+      name: PEER_B.name,
+      endpoint: PEER_B.endpoint,
+      domains: PEER_B.domains,
+    }
+    const result = planCommit(rib, {
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: peerWithoutToken },
+    })
+
+    expect(result.propagations).toHaveLength(0)
+  })
+})

--- a/apps/orchestrator/tests/bgp-routes-changed-flag.test.ts
+++ b/apps/orchestrator/tests/bgp-routes-changed-flag.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'bun:test'
+import { Actions, type PeerInfo } from '@catalyst/routing'
+import { RoutingInformationBase, type Plan } from '../src/rib.js'
+import type { OrchestratorConfig } from '../src/types.js'
+
+/**
+ * routesChanged Flag Tests
+ *
+ * The commit() result includes a routesChanged boolean that indicates
+ * whether local or internal routes changed. This is used by the
+ * orchestrator to decide if envoy config needs updating.
+ */
+
+const NODE: PeerInfo = {
+  name: 'node-a.somebiz.local.io',
+  endpoint: 'http://node-a:3000',
+  domains: ['somebiz.local.io'],
+}
+
+const PEER_B: PeerInfo = {
+  name: 'node-b.somebiz.local.io',
+  endpoint: 'http://node-b:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-b',
+}
+
+const CONFIG: OrchestratorConfig = { node: NODE }
+
+function createRib() {
+  return new RoutingInformationBase(CONFIG)
+}
+
+function planCommit(rib: RoutingInformationBase, action: Parameters<typeof rib.plan>[0]) {
+  const plan = rib.plan(action)
+  if (!plan.success) throw new Error(`plan failed: ${plan.error}`)
+  return rib.commit(plan)
+}
+
+function connectPeer(rib: RoutingInformationBase, peer: PeerInfo) {
+  planCommit(rib, { action: Actions.LocalPeerCreate, data: peer })
+  planCommit(rib, { action: Actions.InternalProtocolOpen, data: { peerInfo: peer } })
+}
+
+describe('routesChanged Flag', () => {
+  it('true when internal routes change via InternalProtocolUpdate', () => {
+    const rib = createRib()
+    connectPeer(rib, PEER_B)
+
+    const plan = rib.plan({
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_B,
+        update: {
+          updates: [
+            {
+              action: 'add',
+              route: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://x:8080' },
+              nodePath: [PEER_B.name],
+            },
+          ],
+        },
+      },
+    })
+    expect(plan.success).toBe(true)
+    const result = rib.commit(plan as Plan)
+    expect(result.routesChanged).toBe(true)
+  })
+
+  it('true when local routes change via LocalRouteCreate', () => {
+    const rib = createRib()
+
+    const plan = rib.plan({
+      action: Actions.LocalRouteCreate,
+      data: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://x:8080' },
+    })
+    expect(plan.success).toBe(true)
+    const result = rib.commit(plan as Plan)
+    expect(result.routesChanged).toBe(true)
+  })
+
+  it('false for peer-only state changes', () => {
+    const rib = createRib()
+
+    const plan = rib.plan({ action: Actions.LocalPeerCreate, data: PEER_B })
+    expect(plan.success).toBe(true)
+    const result = rib.commit(plan as Plan)
+    expect(result.routesChanged).toBe(false)
+  })
+
+  it('false for InternalProtocolOpen (only peer status changes)', () => {
+    const rib = createRib()
+    planCommit(rib, { action: Actions.LocalPeerCreate, data: PEER_B })
+
+    const plan = rib.plan({
+      action: Actions.InternalProtocolOpen,
+      data: { peerInfo: PEER_B },
+    })
+    expect(plan.success).toBe(true)
+    const result = rib.commit(plan as Plan)
+    expect(result.routesChanged).toBe(false)
+  })
+})

--- a/apps/orchestrator/tests/bgp-scale-stress.test.ts
+++ b/apps/orchestrator/tests/bgp-scale-stress.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'bun:test'
+import { Actions, type PeerInfo } from '@catalyst/routing'
+import { RoutingInformationBase } from '../src/rib.js'
+import type { OrchestratorConfig } from '../src/types.js'
+
+/**
+ * Scale / Stress Tests
+ *
+ * Validates RIB behavior under high route counts. Inspired by
+ * GoBGP BenchmarkMultiPath, BIRD table GC tests, and FRR
+ * bgp_batch_clearing (100K route operations).
+ */
+
+const NODE: PeerInfo = {
+  name: 'node-a.somebiz.local.io',
+  endpoint: 'http://node-a:3000',
+  domains: ['somebiz.local.io'],
+}
+
+const PEER_B: PeerInfo = {
+  name: 'node-b.somebiz.local.io',
+  endpoint: 'http://node-b:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-b',
+}
+
+const PEER_C: PeerInfo = {
+  name: 'node-c.somebiz.local.io',
+  endpoint: 'http://node-c:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-c',
+}
+
+const CONFIG: OrchestratorConfig = { node: NODE }
+
+function createRib() {
+  return new RoutingInformationBase(CONFIG)
+}
+
+function planCommit(rib: RoutingInformationBase, action: Parameters<typeof rib.plan>[0]) {
+  const plan = rib.plan(action)
+  if (!plan.success) throw new Error(`plan failed: ${plan.error}`)
+  return rib.commit(plan)
+}
+
+function connectPeer(rib: RoutingInformationBase, peer: PeerInfo) {
+  planCommit(rib, { action: Actions.LocalPeerCreate, data: peer })
+  planCommit(rib, { action: Actions.InternalProtocolOpen, data: { peerInfo: peer } })
+}
+
+describe('Scale / Stress', () => {
+  it('100 local routes in single full sync propagation', () => {
+    const rib = createRib()
+
+    for (let i = 0; i < 100; i++) {
+      planCommit(rib, {
+        action: Actions.LocalRouteCreate,
+        data: {
+          name: `svc-${i.toString().padStart(3, '0')}`,
+          protocol: 'http' as const,
+          endpoint: `http://svc-${i}:8080`,
+        },
+      })
+    }
+
+    expect(rib.getState().local.routes).toHaveLength(100)
+
+    planCommit(rib, { action: Actions.LocalPeerCreate, data: PEER_B })
+    const result = planCommit(rib, {
+      action: Actions.InternalProtocolOpen,
+      data: { peerInfo: PEER_B },
+    })
+
+    const syncProp = result.propagations.find((p) => p.type === 'update')
+    expect(syncProp).toBeDefined()
+    if (syncProp && syncProp.type === 'update') {
+      expect(syncProp.update.updates).toHaveLength(100)
+    }
+  })
+
+  it('bulk add then bulk remove leaves clean state', () => {
+    const rib = createRib()
+    connectPeer(rib, PEER_B)
+
+    planCommit(rib, {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_B,
+        update: {
+          updates: Array.from({ length: 50 }, (_, i) => ({
+            action: 'add' as const,
+            route: {
+              name: `svc-${i}`,
+              protocol: 'http' as const,
+              endpoint: `http://svc-${i}:8080`,
+            },
+            nodePath: [PEER_B.name],
+          })),
+        },
+      },
+    })
+    expect(rib.getState().internal.routes).toHaveLength(50)
+
+    planCommit(rib, {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_B,
+        update: {
+          updates: Array.from({ length: 50 }, (_, i) => ({
+            action: 'remove' as const,
+            route: { name: `svc-${i}`, protocol: 'http' as const },
+          })),
+        },
+      },
+    })
+
+    expect(rib.getState().internal.routes).toHaveLength(0)
+    expect(rib.getRouteMetadata().size).toBe(0)
+  })
+
+  it('routeMetadata map size matches unique route names after churn', () => {
+    const rib = createRib()
+    connectPeer(rib, PEER_B)
+    connectPeer(rib, PEER_C)
+
+    // B: svc-0..svc-9, C: svc-5..svc-14 (5 overlap)
+    for (let i = 0; i < 10; i++) {
+      planCommit(rib, {
+        action: Actions.InternalProtocolUpdate,
+        data: {
+          peerInfo: PEER_B,
+          update: {
+            updates: [
+              {
+                action: 'add',
+                route: {
+                  name: `svc-${i}`,
+                  protocol: 'http' as const,
+                  endpoint: `http://b-${i}:8080`,
+                },
+                nodePath: [PEER_B.name],
+              },
+            ],
+          },
+        },
+      })
+    }
+    for (let i = 5; i < 15; i++) {
+      planCommit(rib, {
+        action: Actions.InternalProtocolUpdate,
+        data: {
+          peerInfo: PEER_C,
+          update: {
+            updates: [
+              {
+                action: 'add',
+                route: {
+                  name: `svc-${i}`,
+                  protocol: 'http' as const,
+                  endpoint: `http://c-${i}:8080`,
+                },
+                nodePath: [PEER_C.name],
+              },
+            ],
+          },
+        },
+      })
+    }
+
+    // 20 routes, 15 unique names
+    expect(rib.getState().internal.routes).toHaveLength(20)
+    expect(rib.getRouteMetadata().size).toBe(15)
+
+    // Close B → 10 routes left, 10 unique names
+    planCommit(rib, {
+      action: Actions.InternalProtocolClose,
+      data: { peerInfo: PEER_B, code: 1000 },
+    })
+
+    expect(rib.getState().internal.routes).toHaveLength(10)
+    expect(rib.getRouteMetadata().size).toBe(10)
+  })
+})

--- a/apps/orchestrator/tests/bgp-upsert-propagation.test.ts
+++ b/apps/orchestrator/tests/bgp-upsert-propagation.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'bun:test'
+import { Actions, type PeerInfo } from '@catalyst/routing'
+import { RoutingInformationBase } from '../src/rib.js'
+import type { OrchestratorConfig } from '../src/types.js'
+
+/**
+ * Upsert Propagation Tests
+ *
+ * When a peer sends an 'add' for an existing route (implicit withdrawal),
+ * the downstream propagation semantics and best-path recalculation.
+ * Inspired by GoBGP TestDestination_Calculate_ImplicitWithdraw and
+ * TestRTCWithdrawUpdatedPath.
+ */
+
+const NODE: PeerInfo = {
+  name: 'node-a.somebiz.local.io',
+  endpoint: 'http://node-a:3000',
+  domains: ['somebiz.local.io'],
+}
+
+const PEER_B: PeerInfo = {
+  name: 'node-b.somebiz.local.io',
+  endpoint: 'http://node-b:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-b',
+}
+
+const PEER_C: PeerInfo = {
+  name: 'node-c.somebiz.local.io',
+  endpoint: 'http://node-c:3000',
+  domains: ['somebiz.local.io'],
+  peerToken: 'token-for-c',
+}
+
+const CONFIG: OrchestratorConfig = { node: NODE }
+
+function createRib() {
+  return new RoutingInformationBase(CONFIG)
+}
+
+function planCommit(rib: RoutingInformationBase, action: Parameters<typeof rib.plan>[0]) {
+  const plan = rib.plan(action)
+  if (!plan.success) throw new Error(`plan failed: ${plan.error}`)
+  return rib.commit(plan)
+}
+
+function connectPeer(rib: RoutingInformationBase, peer: PeerInfo) {
+  planCommit(rib, { action: Actions.LocalPeerCreate, data: peer })
+  planCommit(rib, { action: Actions.InternalProtocolOpen, data: { peerInfo: peer } })
+}
+
+describe('Upsert Propagation', () => {
+  it('sends single add (not remove+add) to downstream on upsert', () => {
+    const rib = createRib()
+    connectPeer(rib, PEER_B)
+    connectPeer(rib, PEER_C)
+
+    planCommit(rib, {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_B,
+        update: {
+          updates: [
+            {
+              action: 'add',
+              route: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://old:8080' },
+              nodePath: [PEER_B.name],
+            },
+          ],
+        },
+      },
+    })
+
+    // B upserts with new endpoint
+    const result = planCommit(rib, {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_B,
+        update: {
+          updates: [
+            {
+              action: 'add',
+              route: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://new:9090' },
+              nodePath: [PEER_B.name],
+            },
+          ],
+        },
+      },
+    })
+
+    const toC = result.propagations.find((p) => p.type === 'update' && p.peer.name === PEER_C.name)
+    expect(toC).toBeDefined()
+    if (toC && toC.type === 'update') {
+      expect(toC.update.updates).toHaveLength(1)
+      expect(toC.update.updates[0].action).toBe('add')
+      expect(toC.update.updates[0].route.endpoint).toBe('http://new:9090')
+    }
+  })
+
+  it('implicit withdrawal with longer nodePath recalculates best-path', () => {
+    const rib = createRib()
+    connectPeer(rib, PEER_B)
+    connectPeer(rib, PEER_C)
+
+    // B: 1-hop (best)
+    planCommit(rib, {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_B,
+        update: {
+          updates: [
+            {
+              action: 'add',
+              route: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://b:8080' },
+              nodePath: [PEER_B.name],
+            },
+          ],
+        },
+      },
+    })
+
+    // C: 2-hop (alternative)
+    planCommit(rib, {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_C,
+        update: {
+          updates: [
+            {
+              action: 'add',
+              route: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://c:8080' },
+              nodePath: [PEER_C.name, 'other-node'],
+            },
+          ],
+        },
+      },
+    })
+
+    expect(rib.getRouteMetadata().get('svc-x')!.bestPath.peerName).toBe(PEER_B.name)
+
+    // B upserts with 3-hop path
+    planCommit(rib, {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: PEER_B,
+        update: {
+          updates: [
+            {
+              action: 'add',
+              route: { name: 'svc-x', protocol: 'http' as const, endpoint: 'http://b:8080' },
+              nodePath: [PEER_B.name, 'hop-1', 'hop-2'],
+            },
+          ],
+        },
+      },
+    })
+
+    // C should now be best (2-hop < 3-hop)
+    const meta = rib.getRouteMetadata().get('svc-x')
+    expect(meta!.bestPath.peerName).toBe(PEER_C.name)
+    expect(meta!.selectionReason).toBe('shortest nodePath')
+  })
+})


### PR DESCRIPTION
## Summary

Cross-referenced four major BGP implementations (GoBGP, FRRouting, OpenBGPD, BIRD) against our RIB to identify untested code paths, edge cases, and structural correctness properties.

**13 new test files, 36 tests:**

| File | Tests | What it covers |
|------|-------|---------------|
| `bgp-plan-error-paths` | 6 | Every `{ success: false }` guard branch |
| `bgp-protocol-connected` | 4 | `InternalProtocolConnected` action (zero prior coverage) |
| `bgp-empty-rib-sync` | 2 | Zero-route early return in `InternalProtocolOpen` |
| `bgp-nodepath-undefined-fallback` | 2 | `nodePath ?? []` fallback in state + propagation |
| `bgp-routes-changed-flag` | 4 | `routesChanged` for local, internal, and peer-only changes |
| `bgp-last-sent-tracking` | 2 | `lastSent` only updated for update/keepalive, not open/close |
| `bgp-upsert-propagation` | 2 | Implicit withdrawal propagation semantics + best-path recalc |
| `bgp-insertion-order-independence` | 2 | All N! permutations produce same best-path (OpenBGPD pattern) |
| `bgp-plan-state-isolation` | 2 | Two plans don't share mutable references (GoBGP pattern) |
| `bgp-peer-churn-stability` | 2 | 100 connect/close cycles leave zero state + port leaks |
| `bgp-nway-route-tie` | 3 | 3-way equal-path tie metadata (GoBGP TestMultipath) |
| `bgp-local-route-preference` | 2 | Local/internal route namespace independence (BIRD pattern) |
| `bgp-scale-stress` | 3 | 100-route sync, bulk add/remove, metadata map sizing |

**Future gaps documented** in `FUTURE-TEST-GAPS.md` — 11 feature gaps with required changes and ~55 test scenarios covering: graceful restart, max prefix limits, flap damping, ECMP, import/export filters, graceful shutdown, secondary metrics, end-of-RIB, conditional advertisement, session flap detection, route aggregation.

## Test plan

- [x] 36 new tests pass
- [x] Full orchestrator suite — 206 pass, 0 fail
- [x] Full unit suite — 648 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)