### PR TITLE
feat(pki): add CertificateManager facade with CA hierarchy lifecycle

### DIFF
--- a/packages/pki/src/certificate-manager.ts
+++ b/packages/pki/src/certificate-manager.ts
@@ -1,0 +1,508 @@
+import * as x509 from '@peculiar/x509'
+import type {
+  ICertificateStore,
+  ISigningBackend,
+  CertificateRecord,
+  SignCSRRequest,
+  SignCSRResult,
+  CaBundleResponse,
+  PkiStatusResponse,
+  CaStatusInfo,
+  DenyListEntry,
+  ExtKeyUsage,
+} from './types.js'
+import { BunSqliteCertificateStore } from './store/sqlite-certificate-store.js'
+import { WebCryptoSigningBackend } from './signing/webcrypto-signing-backend.js'
+import { buildSpiffeId } from './spiffe.js'
+
+// Set the @peculiar/x509 crypto provider to use Bun's SubtleCrypto
+x509.cryptoProvider.set(crypto)
+
+/** Configuration for CertificateManager */
+export interface CertificateManagerConfig {
+  /** SPIFFE trust domain (e.g., 'catalyst.example.com') */
+  trustDomain?: string
+  /** Default SVID TTL in seconds (default: 3600 = 1 hour) */
+  svidTtlSeconds?: number
+  /** Maximum SVID TTL in seconds (hard cap: 86400 = 24 hours) */
+  maxSvidTtlSeconds?: number
+}
+
+/** The 24-hour hard cap from ADR 0011 Section 5 */
+const MAX_SVID_TTL_SECONDS = 86400
+const DEFAULT_SVID_TTL_SECONDS = 3600
+const DEFAULT_TRUST_DOMAIN = 'catalyst.example.com'
+
+/** Name constraints for the Services CA — permits core service SPIFFE URIs */
+const SERVICES_CA_PERMITTED_URIS = [
+  'spiffe://TRUST_DOMAIN/orchestrator/',
+  'spiffe://TRUST_DOMAIN/auth/',
+  'spiffe://TRUST_DOMAIN/node/',
+  'spiffe://TRUST_DOMAIN/gateway/',
+]
+
+/** Name constraints for the Transport CA — permits envoy SPIFFE URIs */
+const TRANSPORT_CA_PERMITTED_URIS = ['spiffe://TRUST_DOMAIN/envoy/']
+
+/**
+ * Batteries-included facade for PKI certificate lifecycle management.
+ *
+ * Wires together certificate storage and a signing backend behind a single
+ * config-driven API. Mirrors `JWTTokenFactory` from
+ * `packages/authorization/src/jwt/jwt-token-factory.ts`.
+ *
+ * @example
+ * ```typescript
+ * // Production
+ * const manager = new CertificateManager(store, backend, { trustDomain: 'mesh.example.com' })
+ * await manager.initialize()
+ *
+ * // Testing — ephemeral in-memory
+ * const manager = CertificateManager.ephemeral()
+ * await manager.initialize()
+ * ```
+ */
+export class CertificateManager {
+  private readonly store: ICertificateStore
+  private readonly backend: ISigningBackend
+  private readonly trustDomain: string
+  private readonly svidTtlSeconds: number
+  private readonly maxSvidTtlSeconds: number
+  private initialized = false
+
+  constructor(
+    store: ICertificateStore,
+    backend: ISigningBackend,
+    config?: CertificateManagerConfig
+  ) {
+    this.store = store
+    this.backend = backend
+    this.trustDomain = config?.trustDomain ?? DEFAULT_TRUST_DOMAIN
+    this.svidTtlSeconds = config?.svidTtlSeconds ?? DEFAULT_SVID_TTL_SECONDS
+    this.maxSvidTtlSeconds = Math.min(
+      config?.maxSvidTtlSeconds ?? MAX_SVID_TTL_SECONDS,
+      MAX_SVID_TTL_SECONDS
+    )
+  }
+
+  /**
+   * Create an ephemeral CertificateManager with in-memory SQLite.
+   * Useful for testing — no files created on disk.
+   *
+   * Pattern: Mirrors JWTTokenFactory.ephemeral()
+   */
+  static ephemeral(config?: {
+    trustDomain?: string
+    svidTtlSeconds?: number
+    maxSvidTtlSeconds?: number
+  }): CertificateManager {
+    return new CertificateManager(
+      new BunSqliteCertificateStore(':memory:'),
+      new WebCryptoSigningBackend(),
+      config
+    )
+  }
+
+  /** Whether the CA hierarchy has been initialized */
+  isInitialized(): boolean {
+    return this.initialized
+  }
+
+  // ===== CA Lifecycle =====
+
+  /**
+   * Initialize the full CA hierarchy (root + services CA + transport CA).
+   * If a root CA already exists, loads it and skips generation.
+   * Idempotent — safe to call multiple times.
+   */
+  async initialize(): Promise<{
+    rootFingerprint: string
+    servicesCaFingerprint: string
+    transportCaFingerprint: string
+  }> {
+    // Check for existing root CA — resume from stored state
+    const existingRoot = await this.store.loadCaCertificate('root-ca')
+    if (existingRoot) {
+      const existingServices = await this.store.loadCaCertificate('services-ca')
+      const existingTransport = await this.store.loadCaCertificate('transport-ca')
+      if (!existingServices || !existingTransport) {
+        throw new Error('Corrupt CA state: root exists but intermediates missing')
+      }
+      this.initialized = true
+      return {
+        rootFingerprint: existingRoot.fingerprint,
+        servicesCaFingerprint: existingServices.fingerprint,
+        transportCaFingerprint: existingTransport.fingerprint,
+      }
+    }
+
+    // Generate Root CA (self-signed, pathlen:1, 10-year validity)
+    const rootKeyPair = await this.backend.generateKeyPair()
+    const now = new Date()
+    const rootNotAfter = new Date(now.getTime() + 10 * 365.25 * 24 * 60 * 60 * 1000)
+
+    const rootCertPem = await this.backend.signCertificate({
+      subjectCN: 'Catalyst Root CA',
+      signingKey: rootKeyPair.privateKey,
+      signingCert: '', // self-signed
+      subjectPublicKey: rootKeyPair.publicKey,
+      notBefore: now,
+      notAfter: rootNotAfter,
+      isCa: true,
+      pathLenConstraint: 1,
+      keyUsage: { keyCertSign: true, crlSign: true },
+    })
+
+    const rootCert = new x509.X509Certificate(rootCertPem)
+    const rootFingerprint = await this.backend.computeFingerprint(rootCert.rawData)
+    const rootSerial = rootCert.serialNumber
+    const rootPrivateKeyPem = await this.backend.exportPrivateKeyPem(rootKeyPair.privateKey)
+
+    await this.store.saveCaCertificate({
+      serial: rootSerial,
+      fingerprint: rootFingerprint,
+      type: 'root-ca',
+      commonName: 'Catalyst Root CA',
+      spiffeId: null,
+      certificatePem: rootCertPem,
+      privateKeyPem: rootPrivateKeyPem,
+      issuerSerial: null,
+      notBefore: now.getTime(),
+      notAfter: rootNotAfter.getTime(),
+      status: 'active',
+      createdAt: now.getTime(),
+    })
+
+    // Generate Services CA (signed by root, pathlen:0, 5-year validity)
+    const servicesCaFingerprint = await this.generateIntermediateCa({
+      commonName: 'Catalyst Services CA',
+      caType: 'services-ca',
+      rootKeyPair,
+      rootCertPem,
+      rootSerial,
+      now,
+      permittedUris: SERVICES_CA_PERMITTED_URIS.map((u) =>
+        u.replace('TRUST_DOMAIN', this.trustDomain)
+      ),
+    })
+
+    // Generate Transport CA (signed by root, pathlen:0, 5-year validity)
+    const transportCaFingerprint = await this.generateIntermediateCa({
+      commonName: 'Catalyst Transport CA',
+      caType: 'transport-ca',
+      rootKeyPair,
+      rootCertPem,
+      rootSerial,
+      now,
+      permittedUris: TRANSPORT_CA_PERMITTED_URIS.map((u) =>
+        u.replace('TRUST_DOMAIN', this.trustDomain)
+      ),
+    })
+
+    this.initialized = true
+    return { rootFingerprint, servicesCaFingerprint, transportCaFingerprint }
+  }
+
+  private async generateIntermediateCa(params: {
+    commonName: string
+    caType: 'services-ca' | 'transport-ca'
+    rootKeyPair: CryptoKeyPair
+    rootCertPem: string
+    rootSerial: string
+    now: Date
+    permittedUris: string[]
+  }): Promise<string> {
+    const keyPair = await this.backend.generateKeyPair()
+    const notAfter = new Date(params.now.getTime() + 5 * 365.25 * 24 * 60 * 60 * 1000)
+
+    const certPem = await this.backend.signCertificate({
+      subjectCN: params.commonName,
+      signingKey: params.rootKeyPair.privateKey,
+      signingCert: params.rootCertPem,
+      subjectPublicKey: keyPair.publicKey,
+      notBefore: params.now,
+      notAfter,
+      isCa: true,
+      pathLenConstraint: 0,
+      keyUsage: { keyCertSign: true, crlSign: true },
+      nameConstraints: { permittedUris: params.permittedUris },
+    })
+
+    const cert = new x509.X509Certificate(certPem)
+    const fingerprint = await this.backend.computeFingerprint(cert.rawData)
+    const privateKeyPem = await this.backend.exportPrivateKeyPem(keyPair.privateKey)
+
+    await this.store.saveCaCertificate({
+      serial: cert.serialNumber,
+      fingerprint,
+      type: params.caType,
+      commonName: params.commonName,
+      spiffeId: null,
+      certificatePem: certPem,
+      privateKeyPem,
+      issuerSerial: params.rootSerial,
+      notBefore: params.now.getTime(),
+      notAfter: notAfter.getTime(),
+      status: 'active',
+      createdAt: params.now.getTime(),
+    })
+
+    return fingerprint
+  }
+
+  // ===== CSR Signing =====
+
+  /**
+   * Validate and sign a CSR, producing an end-entity SVID.
+   *
+   * @throws Error if identity is denied, CSR is invalid, or CA is not initialized
+   */
+  async signCSR(request: SignCSRRequest): Promise<SignCSRResult> {
+    if (!this.initialized) throw new Error('CA not initialized')
+
+    // Build expected SPIFFE ID
+    const expectedSpiffeId = buildSpiffeId(
+      this.trustDomain,
+      request.serviceType,
+      request.instanceId
+    )
+
+    // Check deny list before issuing
+    const denied = await this.store.isDenied(expectedSpiffeId)
+    if (denied) throw new Error(`Identity denied: ${expectedSpiffeId}`)
+
+    // Parse and validate CSR
+    const csr = new x509.Pkcs10CertificateRequest(request.csrPem)
+
+    // Verify CSR self-signature (proof-of-possession)
+    const csrValid = await csr.verify()
+    if (!csrValid) throw new Error('CSR signature verification failed')
+
+    // Extract subject public key
+    const subjectPublicKey = await csr.publicKey.export()
+
+    // Validate key algorithm is P-384
+    const keyAlg = subjectPublicKey.algorithm as EcKeyAlgorithm
+    if (keyAlg.namedCurve !== 'P-384') {
+      throw new Error(`Key algorithm must be P-384, got ${keyAlg.namedCurve}`)
+    }
+
+    // Determine which CA signs this cert
+    const isTransport = request.serviceType.startsWith('envoy/')
+    const caType = isTransport ? 'transport-ca' : 'services-ca'
+    const ca = await this.store.loadCaCertificate(caType)
+    if (!ca || !ca.privateKeyPem) {
+      throw new Error(`Signing CA not available: ${caType}`)
+    }
+
+    // Compute TTL (requested, capped at max)
+    const ttl = Math.min(request.ttlSeconds ?? this.svidTtlSeconds, this.maxSvidTtlSeconds)
+    const notBefore = new Date()
+    const notAfter = new Date(notBefore.getTime() + ttl * 1000)
+
+    // Determine EKU based on service type
+    const extKeyUsage = this.getExtKeyUsage(request.serviceType)
+
+    // Sign the certificate
+    const caPrivateKey = await this.backend.importPrivateKeyPem(ca.privateKeyPem)
+    const certPem = await this.backend.signCertificate({
+      subjectCN: request.instanceId,
+      sanUri: expectedSpiffeId,
+      sanDns: [request.instanceId],
+      signingKey: caPrivateKey,
+      signingCert: ca.certificatePem,
+      subjectPublicKey,
+      notBefore,
+      notAfter,
+      isCa: false,
+      keyUsage: { digitalSignature: true },
+      extKeyUsage,
+    })
+
+    // Compute fingerprint and serial
+    const cert = new x509.X509Certificate(certPem)
+    const fingerprint = await this.backend.computeFingerprint(cert.rawData)
+    const serial = cert.serialNumber
+
+    // Store the end-entity certificate
+    await this.store.saveEndEntityCertificate({
+      serial,
+      fingerprint,
+      type: 'end-entity',
+      commonName: request.instanceId,
+      spiffeId: expectedSpiffeId,
+      certificatePem: certPem,
+      privateKeyPem: null, // we don't hold the client's private key
+      issuerSerial: ca.serial,
+      notBefore: notBefore.getTime(),
+      notAfter: notAfter.getTime(),
+      status: 'active',
+      createdAt: Date.now(),
+    })
+
+    // Build chain: intermediate CA + root CA
+    const rootCa = await this.store.loadCaCertificate('root-ca')
+    if (!rootCa) throw new Error('Root CA not found')
+
+    return {
+      certificatePem: certPem,
+      chain: [ca.certificatePem, rootCa.certificatePem],
+      expiresAt: notAfter.toISOString(),
+      // renewAfter: 50% of lifetime, relative to notBefore (per PKI review corrections)
+      renewAfter: new Date(notBefore.getTime() + ttl * 500).toISOString(),
+      fingerprint,
+      serial,
+    }
+  }
+
+  private getExtKeyUsage(serviceType: string): ExtKeyUsage[] {
+    // Gateway is server-only (ADR 0011 Section 3.7)
+    if (serviceType === 'gateway') return ['serverAuth']
+    // All others are both server and client
+    return ['serverAuth', 'clientAuth']
+  }
+
+  // ===== CA Bundle =====
+
+  /** Get the trust bundle for distribution. */
+  async getCaBundle(): Promise<CaBundleResponse> {
+    const root = await this.store.loadCaCertificate('root-ca')
+    if (!root) throw new Error('CA not initialized')
+
+    const servicesCas = await this.store.loadAllCaCertificates('services-ca')
+    const transportCas = await this.store.loadAllCaCertificates('transport-ca')
+
+    return {
+      trustDomain: this.trustDomain,
+      servicesBundle: [...servicesCas.map((c) => c.certificatePem), root.certificatePem],
+      transportBundle: [...transportCas.map((c) => c.certificatePem), root.certificatePem],
+      version: `v${root.fingerprint.slice(0, 8)}`,
+      expiresAt: new Date(
+        Math.min(...servicesCas.map((c) => c.notAfter), ...transportCas.map((c) => c.notAfter))
+      ).toISOString(),
+    }
+  }
+
+  // ===== Deny List =====
+
+  /** Deny a SPIFFE identity. Returns info about existing certs that will expire naturally. */
+  async denyIdentity(
+    spiffeId: string,
+    reason: string
+  ): Promise<{ expiringCerts: { serial: string; expiresAt: string }[] }> {
+    await this.store.denyIdentity(spiffeId, reason)
+    const certs = await this.store.findBySpiffeId(spiffeId)
+    return {
+      expiringCerts: certs.map((c) => ({
+        serial: c.serial,
+        expiresAt: new Date(c.notAfter).toISOString(),
+      })),
+    }
+  }
+
+  /** Re-enable a denied identity. */
+  async allowIdentity(spiffeId: string): Promise<void> {
+    await this.store.allowIdentity(spiffeId)
+  }
+
+  /** List all denied identities. */
+  async listDeniedIdentities(): Promise<DenyListEntry[]> {
+    return this.store.listDeniedIdentities()
+  }
+
+  // ===== Status =====
+
+  /** Get PKI system status. */
+  async getStatus(): Promise<PkiStatusResponse> {
+    const root = await this.store.loadCaCertificate('root-ca')
+    if (!root) {
+      return {
+        status: 'uninitialized',
+        trustDomain: this.trustDomain,
+        rootCa: null,
+        servicesCa: null,
+        transportCa: null,
+        activeCertCount: 0,
+        deniedIdentityCount: 0,
+        warnings: [],
+      }
+    }
+
+    const servicesCa = await this.store.loadCaCertificate('services-ca')
+    const transportCa = await this.store.loadCaCertificate('transport-ca')
+    const activeCerts = await this.store.listActiveCertificates()
+    const denied = await this.store.listDeniedIdentities()
+    const counts = await this.store.countCertificates()
+
+    const warnings: string[] = []
+    const now = Date.now()
+    const thirtyDays = 30 * 24 * 60 * 60 * 1000
+
+    // Check for CA certificates approaching expiry
+    if (root.notAfter - now < thirtyDays) {
+      warnings.push('Root CA expires within 30 days')
+    }
+    if (servicesCa && servicesCa.notAfter - now < thirtyDays) {
+      warnings.push('Services CA expires within 30 days')
+    }
+    if (transportCa && transportCa.notAfter - now < thirtyDays) {
+      warnings.push('Transport CA expires within 30 days')
+    }
+
+    const status = warnings.length > 0 ? 'degraded' : 'healthy'
+
+    const buildCaInfo = (ca: CertificateRecord): CaStatusInfo => {
+      const issuedCount = counts
+        .filter((c) => c.type === 'end-entity' && c.status === 'active')
+        .reduce((sum, c) => sum + c.count, 0)
+      return {
+        fingerprint: ca.fingerprint,
+        commonName: ca.commonName,
+        algorithm: 'ECDSA P-384',
+        expiresAt: new Date(ca.notAfter).toISOString(),
+        issuedCertCount: issuedCount,
+      }
+    }
+
+    return {
+      status,
+      trustDomain: this.trustDomain,
+      rootCa: buildCaInfo(root),
+      servicesCa: servicesCa ? buildCaInfo(servicesCa) : null,
+      transportCa: transportCa ? buildCaInfo(transportCa) : null,
+      activeCertCount: activeCerts.length,
+      deniedIdentityCount: denied.length,
+      warnings,
+    }
+  }
+
+  // ===== Maintenance =====
+
+  /** Purge expired certificates. Keeps recently expired for audit trail (24h grace). */
+  async purgeExpired(): Promise<number> {
+    const cutoff = Date.now() - 24 * 60 * 60 * 1000
+    return this.store.purgeExpired(cutoff)
+  }
+
+  /** Cleanup. No-op for now but matches the lifecycle pattern. */
+  async shutdown(): Promise<void> {
+    // Reserved for future cleanup (e.g., releasing KMS sessions)
+  }
+
+  // ===== Accessors =====
+
+  /** Access the underlying certificate store */
+  getStore(): ICertificateStore {
+    return this.store
+  }
+
+  /** Access the underlying signing backend */
+  getBackend(): ISigningBackend {
+    return this.backend
+  }
+
+  /** Get the configured trust domain */
+  getTrustDomain(): string {
+    return this.trustDomain
+  }
+}

--- a/packages/pki/src/index.ts
+++ b/packages/pki/src/index.ts
@@ -31,3 +31,6 @@ export { parseSpiffeId, buildSpiffeId, isValidSpiffeId, type SpiffeId } from './
 
 // Implementations
 export { BunSqliteCertificateStore } from './store/sqlite-certificate-store.js'
+export { WebCryptoSigningBackend } from './signing/webcrypto-signing-backend.js'
+export { CertificateManager } from './certificate-manager.js'
+export type { CertificateManagerConfig } from './certificate-manager.js'

--- a/packages/pki/tests/certificate-manager.test.ts
+++ b/packages/pki/tests/certificate-manager.test.ts
@@ -1,0 +1,519 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import * as x509 from '@peculiar/x509'
+import { CertificateManager } from '../src/certificate-manager.js'
+
+// Ensure @peculiar/x509 uses Bun's crypto
+x509.cryptoProvider.set(crypto)
+
+const EC_ALGORITHM: EcKeyGenParams = { name: 'ECDSA', namedCurve: 'P-384' }
+const SIGNING_ALGORITHM: EcdsaParams = { name: 'ECDSA', hash: 'SHA-384' }
+
+/**
+ * Generate a CSR (PKCS#10) for testing. Returns the PEM and key pair.
+ * The CSR includes a SPIFFE URI SAN matching the expected identity.
+ */
+async function generateCSR(
+  spiffeId: string,
+  instanceId: string
+): Promise<{
+  csrPem: string
+  keyPair: CryptoKeyPair
+}> {
+  const keyPair = await crypto.subtle.generateKey(EC_ALGORITHM, true, ['sign', 'verify'])
+
+  const csr = await x509.Pkcs10CertificateRequestGenerator.create({
+    name: `CN=${instanceId}`,
+    keys: keyPair,
+    signingAlgorithm: SIGNING_ALGORITHM,
+    extensions: [new x509.SubjectAlternativeNameExtension([{ type: 'url', value: spiffeId }])],
+  })
+
+  return { csrPem: csr.toString('pem'), keyPair }
+}
+
+describe('CertificateManager', () => {
+  let manager: CertificateManager
+
+  beforeEach(async () => {
+    manager = CertificateManager.ephemeral({ trustDomain: 'test.example.com' })
+  })
+
+  // ===== Lifecycle =====
+
+  describe('lifecycle', () => {
+    it('should report uninitialized before initialize()', () => {
+      expect(manager.isInitialized()).toBe(false)
+    })
+
+    it('should report initialized after initialize()', async () => {
+      await manager.initialize()
+      expect(manager.isInitialized()).toBe(true)
+    })
+
+    it('should return fingerprints for all 3 CAs on initialize', async () => {
+      const result = await manager.initialize()
+      expect(result.rootFingerprint).toBeString()
+      expect(result.rootFingerprint.length).toBeGreaterThan(0)
+      expect(result.servicesCaFingerprint).toBeString()
+      expect(result.servicesCaFingerprint.length).toBeGreaterThan(0)
+      expect(result.transportCaFingerprint).toBeString()
+      expect(result.transportCaFingerprint.length).toBeGreaterThan(0)
+    })
+
+    it('should be idempotent — second call loads existing CAs', async () => {
+      const first = await manager.initialize()
+      const second = await manager.initialize()
+
+      // Same fingerprints — no new keys generated
+      expect(second.rootFingerprint).toBe(first.rootFingerprint)
+      expect(second.servicesCaFingerprint).toBe(first.servicesCaFingerprint)
+      expect(second.transportCaFingerprint).toBe(first.transportCaFingerprint)
+    })
+
+    it('should create root CA + services CA + transport CA in the store', async () => {
+      await manager.initialize()
+      const store = manager.getStore()
+
+      const root = await store.loadCaCertificate('root-ca')
+      const services = await store.loadCaCertificate('services-ca')
+      const transport = await store.loadCaCertificate('transport-ca')
+
+      expect(root).not.toBeNull()
+      expect(root!.commonName).toBe('Catalyst Root CA')
+      expect(root!.issuerSerial).toBeNull() // self-signed
+      expect(root!.privateKeyPem).not.toBeNull()
+
+      expect(services).not.toBeNull()
+      expect(services!.commonName).toBe('Catalyst Services CA')
+      expect(services!.issuerSerial).toBe(root!.serial)
+      expect(services!.privateKeyPem).not.toBeNull()
+
+      expect(transport).not.toBeNull()
+      expect(transport!.commonName).toBe('Catalyst Transport CA')
+      expect(transport!.issuerSerial).toBe(root!.serial)
+      expect(transport!.privateKeyPem).not.toBeNull()
+    })
+
+    it('should generate valid X.509 certificates in the CA hierarchy', async () => {
+      await manager.initialize()
+      const store = manager.getStore()
+
+      const root = await store.loadCaCertificate('root-ca')
+      const rootCert = new x509.X509Certificate(root!.certificatePem)
+
+      // Root is self-signed
+      expect(rootCert.subject).toBe('CN=Catalyst Root CA')
+      expect(rootCert.issuer).toBe('CN=Catalyst Root CA')
+
+      const services = await store.loadCaCertificate('services-ca')
+      const servicesCert = new x509.X509Certificate(services!.certificatePem)
+
+      // Services CA signed by root
+      expect(servicesCert.subject).toBe('CN=Catalyst Services CA')
+      expect(servicesCert.issuer).toBe('CN=Catalyst Root CA')
+    })
+
+    it('should call shutdown without error', async () => {
+      await manager.initialize()
+      await manager.shutdown()
+    })
+
+    it('should call shutdown without initialization', async () => {
+      await manager.shutdown()
+    })
+  })
+
+  // ===== CSR Signing =====
+
+  describe('signCSR', () => {
+    beforeEach(async () => {
+      await manager.initialize()
+    })
+
+    it('should produce valid end-entity cert for orchestrator', async () => {
+      const spiffeId = 'spiffe://test.example.com/orchestrator/orch-1'
+      const { csrPem } = await generateCSR(spiffeId, 'orch-1')
+
+      const result = await manager.signCSR({
+        csrPem,
+        serviceType: 'orchestrator',
+        instanceId: 'orch-1',
+      })
+
+      expect(result.certificatePem).toContain('BEGIN CERTIFICATE')
+      expect(result.chain).toHaveLength(2) // services CA + root CA
+      expect(result.serial).toBeString()
+      expect(result.fingerprint).toBeString()
+      expect(result.expiresAt).toBeString()
+      expect(result.renewAfter).toBeString()
+
+      // Verify the cert itself
+      const cert = new x509.X509Certificate(result.certificatePem)
+      expect(cert.subject).toBe('CN=orch-1')
+
+      // Verify SPIFFE URI SAN
+      const sanExt = cert.getExtension(x509.SubjectAlternativeNameExtension)
+      expect(sanExt).not.toBeNull()
+      const uriNames = sanExt!.names.items.filter((n: x509.GeneralName) => n.type === 'url')
+      expect(uriNames).toHaveLength(1)
+      expect(uriNames[0].value).toBe(spiffeId)
+    })
+
+    it('should use default TTL of 1 hour', async () => {
+      const { csrPem } = await generateCSR('spiffe://test.example.com/node/n1', 'n1')
+
+      const result = await manager.signCSR({
+        csrPem,
+        serviceType: 'node',
+        instanceId: 'n1',
+      })
+
+      const cert = new x509.X509Certificate(result.certificatePem)
+      const duration = cert.notAfter.getTime() - cert.notBefore.getTime()
+      // Default is 1 hour (3600s) = 3_600_000ms
+      expect(duration).toBe(3_600_000)
+    })
+
+    it('should cap TTL at maxSvidTtlSeconds', async () => {
+      const shortManager = CertificateManager.ephemeral({
+        trustDomain: 'test.example.com',
+        maxSvidTtlSeconds: 1800, // 30 min cap
+      })
+      await shortManager.initialize()
+
+      const { csrPem } = await generateCSR('spiffe://test.example.com/node/n1', 'n1')
+
+      const result = await shortManager.signCSR({
+        csrPem,
+        serviceType: 'node',
+        instanceId: 'n1',
+        ttlSeconds: 7200, // request 2 hours
+      })
+
+      const cert = new x509.X509Certificate(result.certificatePem)
+      const duration = cert.notAfter.getTime() - cert.notBefore.getTime()
+      // Should be capped at 30 min
+      expect(duration).toBe(1_800_000)
+    })
+
+    it('should compute renewAfter from notBefore + 50% of TTL', async () => {
+      const { csrPem } = await generateCSR('spiffe://test.example.com/node/n1', 'n1')
+
+      const result = await manager.signCSR({
+        csrPem,
+        serviceType: 'node',
+        instanceId: 'n1',
+      })
+
+      const cert = new x509.X509Certificate(result.certificatePem)
+      const notBefore = cert.notBefore.getTime()
+      const notAfter = cert.notAfter.getTime()
+      const ttl = notAfter - notBefore
+
+      const renewAfter = new Date(result.renewAfter).getTime()
+      // renewAfter should be notBefore + 50% of TTL
+      // X.509 dates are truncated to seconds so allow 2s tolerance
+      const expected = notBefore + ttl / 2
+      expect(Math.abs(renewAfter - expected)).toBeLessThan(2000)
+    })
+
+    it('should produce gateway cert with serverAuth only', async () => {
+      const { csrPem } = await generateCSR('spiffe://test.example.com/gateway/gw-1', 'gw-1')
+
+      const result = await manager.signCSR({
+        csrPem,
+        serviceType: 'gateway',
+        instanceId: 'gw-1',
+      })
+
+      const cert = new x509.X509Certificate(result.certificatePem)
+      const ekuExt = cert.getExtension(x509.ExtendedKeyUsageExtension)
+      expect(ekuExt).not.toBeNull()
+
+      // Gateway should have serverAuth only, NOT clientAuth
+      expect(ekuExt!.usages).toContain(x509.ExtendedKeyUsage.serverAuth)
+      expect(ekuExt!.usages).not.toContain(x509.ExtendedKeyUsage.clientAuth)
+    })
+
+    it('should sign envoy cert with transport CA (not services CA)', async () => {
+      const { csrPem } = await generateCSR('spiffe://test.example.com/envoy/app/proxy-1', 'proxy-1')
+
+      const result = await manager.signCSR({
+        csrPem,
+        serviceType: 'envoy/app',
+        instanceId: 'proxy-1',
+      })
+
+      // The chain[0] should be the transport CA, not services CA
+      const issuingCa = new x509.X509Certificate(result.chain[0])
+      expect(issuingCa.subject).toBe('CN=Catalyst Transport CA')
+    })
+
+    it('should sign orchestrator cert with services CA', async () => {
+      const { csrPem } = await generateCSR(
+        'spiffe://test.example.com/orchestrator/orch-1',
+        'orch-1'
+      )
+
+      const result = await manager.signCSR({
+        csrPem,
+        serviceType: 'orchestrator',
+        instanceId: 'orch-1',
+      })
+
+      const issuingCa = new x509.X509Certificate(result.chain[0])
+      expect(issuingCa.subject).toBe('CN=Catalyst Services CA')
+    })
+
+    it('should store the end-entity cert in the store', async () => {
+      const { csrPem } = await generateCSR('spiffe://test.example.com/node/n1', 'n1')
+
+      const result = await manager.signCSR({
+        csrPem,
+        serviceType: 'node',
+        instanceId: 'n1',
+      })
+
+      const stored = await manager.getStore().findBySerial(result.serial)
+      expect(stored).not.toBeNull()
+      expect(stored!.type).toBe('end-entity')
+      expect(stored!.spiffeId).toBe('spiffe://test.example.com/node/n1')
+      expect(stored!.fingerprint).toBe(result.fingerprint)
+    })
+
+    it('should reject signing when identity is denied', async () => {
+      const spiffeId = 'spiffe://test.example.com/node/bad-node'
+      await manager.denyIdentity(spiffeId, 'compromised')
+
+      const { csrPem } = await generateCSR(spiffeId, 'bad-node')
+
+      expect(
+        manager.signCSR({
+          csrPem,
+          serviceType: 'node',
+          instanceId: 'bad-node',
+        })
+      ).rejects.toThrow('Identity denied')
+    })
+
+    it('should throw if CA not initialized', async () => {
+      const uninitManager = CertificateManager.ephemeral({
+        trustDomain: 'test.example.com',
+      })
+
+      const { csrPem } = await generateCSR('spiffe://test.example.com/node/n1', 'n1')
+
+      expect(
+        uninitManager.signCSR({
+          csrPem,
+          serviceType: 'node',
+          instanceId: 'n1',
+        })
+      ).rejects.toThrow('CA not initialized')
+    })
+  })
+
+  // ===== CA Bundle =====
+
+  describe('getCaBundle', () => {
+    it('should return services and transport bundles after init', async () => {
+      await manager.initialize()
+      const bundle = await manager.getCaBundle()
+
+      expect(bundle.trustDomain).toBe('test.example.com')
+
+      // Services bundle: services CA + root CA
+      expect(bundle.servicesBundle).toHaveLength(2)
+      expect(bundle.servicesBundle[0]).toContain('BEGIN CERTIFICATE')
+      expect(bundle.servicesBundle[1]).toContain('BEGIN CERTIFICATE')
+
+      // Transport bundle: transport CA + root CA
+      expect(bundle.transportBundle).toHaveLength(2)
+      expect(bundle.transportBundle[0]).toContain('BEGIN CERTIFICATE')
+      expect(bundle.transportBundle[1]).toContain('BEGIN CERTIFICATE')
+
+      // Root is the last in both bundles
+      expect(bundle.servicesBundle[1]).toBe(bundle.transportBundle[1])
+
+      // Version is derived from root fingerprint
+      expect(bundle.version).toStartWith('v')
+      expect(bundle.expiresAt).toBeString()
+    })
+
+    it('should throw if CA not initialized', async () => {
+      expect(manager.getCaBundle()).rejects.toThrow('CA not initialized')
+    })
+  })
+
+  // ===== Deny List =====
+
+  describe('deny list', () => {
+    beforeEach(async () => {
+      await manager.initialize()
+    })
+
+    it('should add identity to deny list and return expiring certs', async () => {
+      const spiffeId = 'spiffe://test.example.com/node/n1'
+
+      // First, issue a cert
+      const { csrPem } = await generateCSR(spiffeId, 'n1')
+      await manager.signCSR({
+        csrPem,
+        serviceType: 'node',
+        instanceId: 'n1',
+      })
+
+      // Deny the identity
+      const result = await manager.denyIdentity(spiffeId, 'compromised key')
+      expect(result.expiringCerts).toHaveLength(1)
+      expect(result.expiringCerts[0].serial).toBeString()
+      expect(result.expiringCerts[0].expiresAt).toBeString()
+    })
+
+    it('should allow re-enabling a denied identity', async () => {
+      const spiffeId = 'spiffe://test.example.com/node/temp'
+      await manager.denyIdentity(spiffeId, 'temporary')
+
+      const denied = await manager.getStore().isDenied(spiffeId)
+      expect(denied).toBe(true)
+
+      await manager.allowIdentity(spiffeId)
+      const deniedAfter = await manager.getStore().isDenied(spiffeId)
+      expect(deniedAfter).toBe(false)
+    })
+
+    it('should list denied identities', async () => {
+      await manager.denyIdentity('spiffe://test.example.com/node/a', 'reason-a')
+      await new Promise((r) => setTimeout(r, 2))
+      await manager.denyIdentity('spiffe://test.example.com/node/b', 'reason-b')
+
+      const list = await manager.listDeniedIdentities()
+      expect(list).toHaveLength(2)
+    })
+
+    it('should allow signing after identity is re-enabled', async () => {
+      const spiffeId = 'spiffe://test.example.com/node/reallowed'
+      await manager.denyIdentity(spiffeId, 'temp deny')
+
+      // Deny should block signing
+      const { csrPem } = await generateCSR(spiffeId, 'reallowed')
+      expect(
+        manager.signCSR({
+          csrPem,
+          serviceType: 'node',
+          instanceId: 'reallowed',
+        })
+      ).rejects.toThrow('Identity denied')
+
+      // Re-allow should unblock
+      await manager.allowIdentity(spiffeId)
+      const { csrPem: csrPem2 } = await generateCSR(spiffeId, 'reallowed')
+      const result = await manager.signCSR({
+        csrPem: csrPem2,
+        serviceType: 'node',
+        instanceId: 'reallowed',
+      })
+      expect(result.certificatePem).toContain('BEGIN CERTIFICATE')
+    })
+  })
+
+  // ===== Status =====
+
+  describe('getStatus', () => {
+    it('should return uninitialized before initialize()', async () => {
+      const status = await manager.getStatus()
+      expect(status.status).toBe('uninitialized')
+      expect(status.trustDomain).toBe('test.example.com')
+      expect(status.rootCa).toBeNull()
+      expect(status.servicesCa).toBeNull()
+      expect(status.transportCa).toBeNull()
+      expect(status.activeCertCount).toBe(0)
+      expect(status.deniedIdentityCount).toBe(0)
+    })
+
+    it('should return healthy after initialize()', async () => {
+      await manager.initialize()
+      const status = await manager.getStatus()
+
+      expect(status.status).toBe('healthy')
+      expect(status.rootCa).not.toBeNull()
+      expect(status.rootCa!.commonName).toBe('Catalyst Root CA')
+      expect(status.rootCa!.algorithm).toBe('ECDSA P-384')
+      expect(status.servicesCa).not.toBeNull()
+      expect(status.servicesCa!.commonName).toBe('Catalyst Services CA')
+      expect(status.transportCa).not.toBeNull()
+      expect(status.transportCa!.commonName).toBe('Catalyst Transport CA')
+      expect(status.warnings).toHaveLength(0)
+    })
+
+    it('should track active cert and deny counts', async () => {
+      await manager.initialize()
+
+      // Issue a cert
+      const { csrPem } = await generateCSR('spiffe://test.example.com/node/n1', 'n1')
+      await manager.signCSR({
+        csrPem,
+        serviceType: 'node',
+        instanceId: 'n1',
+      })
+
+      // Deny an identity
+      await manager.denyIdentity('spiffe://test.example.com/node/bad', 'compromised')
+
+      const status = await manager.getStatus()
+      expect(status.activeCertCount).toBe(1)
+      expect(status.deniedIdentityCount).toBe(1)
+    })
+  })
+
+  // ===== Maintenance =====
+
+  describe('purgeExpired', () => {
+    it('should return zero when nothing to purge', async () => {
+      await manager.initialize()
+      const count = await manager.purgeExpired()
+      expect(count).toBe(0)
+    })
+  })
+
+  // ===== Accessors =====
+
+  describe('accessors', () => {
+    it('should expose the store', () => {
+      expect(manager.getStore()).toBeDefined()
+    })
+
+    it('should expose the backend', () => {
+      expect(manager.getBackend()).toBeDefined()
+    })
+
+    it('should expose the trust domain', () => {
+      expect(manager.getTrustDomain()).toBe('test.example.com')
+    })
+  })
+
+  // ===== Ephemeral factory =====
+
+  describe('ephemeral()', () => {
+    it('should create a working in-memory instance', async () => {
+      const eph = CertificateManager.ephemeral()
+      await eph.initialize()
+      expect(eph.isInitialized()).toBe(true)
+
+      const status = await eph.getStatus()
+      expect(status.status).toBe('healthy')
+    })
+
+    it('should use default trust domain', () => {
+      const eph = CertificateManager.ephemeral()
+      expect(eph.getTrustDomain()).toBe('catalyst.example.com')
+    })
+
+    it('should accept custom trust domain', () => {
+      const eph = CertificateManager.ephemeral({
+        trustDomain: 'custom.domain',
+      })
+      expect(eph.getTrustDomain()).toBe('custom.domain')
+    })
+  })
+})

--- a/packages/pki/tests/signing/webcrypto-signing-backend.test.ts
+++ b/packages/pki/tests/signing/webcrypto-signing-backend.test.ts
@@ -143,17 +143,17 @@ describe('WebCryptoSigningBackend', () => {
 
     test('does NOT have AuthorityKeyIdentifier (self-signed)', () => {
       const aki = rootCert.getExtension(x509.AuthorityKeyIdentifierExtension)
-      expect(aki).toBeUndefined()
+      expect(aki).toBeNull()
     })
 
     test('does NOT have Extended Key Usage (CAs should not have EKU)', () => {
       const eku = rootCert.getExtension(x509.ExtendedKeyUsageExtension)
-      expect(eku).toBeUndefined()
+      expect(eku).toBeNull()
     })
 
     test('does NOT have Subject Alternative Names', () => {
       const san = rootCert.getExtension(x509.SubjectAlternativeNameExtension)
-      expect(san).toBeUndefined()
+      expect(san).toBeNull()
     })
 
     test('validity period matches parameters', () => {
@@ -276,7 +276,10 @@ describe('WebCryptoSigningBackend', () => {
     })
 
     test('signature is valid (signed by root)', async () => {
-      const isValid = await servicesCert.verify({ publicKey: rootKeyPair.publicKey })
+      const isValid = await servicesCert.verify({
+        signatureOnly: true,
+        publicKey: rootKeyPair.publicKey,
+      })
       expect(isValid).toBe(true)
     })
   })
@@ -474,13 +477,16 @@ describe('WebCryptoSigningBackend', () => {
     })
 
     test('signature is valid (signed by Services CA)', async () => {
-      const isValid = await leafCert.verify({ publicKey: servicesKeyPair.publicKey })
+      const isValid = await leafCert.verify({
+        signatureOnly: true,
+        publicKey: servicesKeyPair.publicKey,
+      })
       expect(isValid).toBe(true)
     })
 
     test('does NOT have Name Constraints (end-entity)', () => {
-      const nc = leafCert.getExtension(x509.NameConstraintsExtension)
-      expect(nc).toBeUndefined()
+      const nc = leafCert.getExtension(NAME_CONSTRAINTS_OID)
+      expect(nc).toBeNull()
     })
   })
 


### PR DESCRIPTION
- CertificateManager: initialize Root CA + Services CA + Transport CA
- CSR signing with deny-list enforcement and SPIFFE routing
- CA bundle export, identity deny/allow, purge expired certs
- Static ephemeral() factory for test isolation
- 34 tests for lifecycle, CSR signing, deny list, status
- Fix signing backend test assertions for @peculiar/x509 API
- Updated implementation plan with PKI review corrections

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>