### PR TITLE
feat(pki): add PKI progressive RPC API on AuthRpcServer

### DIFF
--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -9,6 +9,7 @@
   },
   "private": true,
   "dependencies": {
+    "@catalyst/pki": "catalog:",
     "@catalyst/service": "catalog:",
     "@catalyst/telemetry": "catalog:",
     "@catalyst/types": "workspace:*",


### PR DESCRIPTION
- PkiHandlers interface with 9 methods: initialize, signCsr, getCaBundle,
  getStatus, denyIdentity, allowIdentity, listDenied, listCertificates,
  purgeExpired
- Zod schemas for all PKI request/response types
- pki(token) sub-API on AuthRpcServer with Cedar policy enforcement
- CertificateManager constructor parameter on AuthRpcServer
- Add @catalyst/pki dependency to authorization package

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>