### PR TITLE
feat(pki): wire CertificateManager into AuthService with HTTP endpoints

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -228,6 +228,7 @@
       "name": "@catalyst/authorization",
       "version": "0.0.0",
       "dependencies": {
+        "@catalyst/pki": "catalog:",
         "@catalyst/service": "catalog:",
         "@catalyst/telemetry": "catalog:",
         "@catalyst/types": "workspace:*",
@@ -239,6 +240,7 @@
         "zod": "catalog:",
       },
       "devDependencies": {
+        "@peculiar/x509": "^1.14.3",
         "@types/bun": "catalog:dev",
         "@types/node": "catalog:dev",
         "typescript": "catalog:dev",

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -26,6 +26,7 @@
     "test:integration": "bun test $(find . \\( -name '*.test.ts' -o -name '*.spec.ts' \\) ! -path '*/node_modules/*' | grep -E 'integration|container')"
   },
   "devDependencies": {
+    "@peculiar/x509": "^1.14.3",
     "@types/bun": "catalog:dev",
     "@types/node": "catalog:dev",
     "typescript": "catalog:dev"

--- a/packages/authorization/src/service/service.ts
+++ b/packages/authorization/src/service/service.ts
@@ -1,5 +1,11 @@
 import { JWTTokenFactory } from '../jwt/jwt-token-factory.js'
 import {
+  CertificateManager,
+  BunSqliteCertificateStore,
+  WebCryptoSigningBackend,
+  SignCSRRequestSchema,
+} from '@catalyst/pki'
+import {
   ALL_POLICIES,
   AuthorizationEngine,
   CATALYST_SCHEMA,
@@ -17,6 +23,7 @@ export class AuthService extends CatalystService {
   private _tokenFactory!: JWTTokenFactory
   private _rpcServer!: AuthRpcServer
   private _systemToken!: string
+  private _certificateManager?: CertificateManager
 
   constructor(options: CatalystServiceOptions) {
     super(options)
@@ -34,6 +41,10 @@ export class AuthService extends CatalystService {
     return this._systemToken
   }
 
+  get certificateManager(): CertificateManager | undefined {
+    return this._certificateManager
+  }
+
   protected async onInitialize(): Promise<void> {
     const logger = this.telemetry.logger
 
@@ -48,6 +59,18 @@ export class AuthService extends CatalystService {
     await this._tokenFactory.initialize()
 
     void logger.info`JWTTokenFactory initialized`
+
+    // Initialize PKI Certificate Manager
+    const pkiConfig = this.config.auth?.pki
+    const certsDbFile = pkiConfig?.certsDb ?? 'certs.db'
+    const store = new BunSqliteCertificateStore(certsDbFile)
+    const backend = new WebCryptoSigningBackend()
+    this._certificateManager = new CertificateManager(store, backend, {
+      trustDomain: pkiConfig?.trustDomain,
+      svidTtlSeconds: pkiConfig?.svidTtlSeconds,
+    })
+    const pkiResult = await this._certificateManager.initialize()
+    void logger.info`PKI initialized — root: ${pkiResult.rootFingerprint}, services: ${pkiResult.servicesCaFingerprint}, transport: ${pkiResult.transportCaFingerprint}`
 
     // Initialize the policy authorization engine using the standard Catalyst domain
     const policyService = new AuthorizationEngine<CatalystPolicyDomain>(
@@ -76,13 +99,14 @@ export class AuthService extends CatalystService {
 
     void logger.info`System Admin Token minted: ${this._systemToken}`
 
-    // Build RPC server
+    // Build RPC server with CertificateManager
     this._rpcServer = new AuthRpcServer(
       this._tokenFactory,
       this.telemetry,
       policyService,
       this.config.node.name,
-      this.config.node.domains[0] || ''
+      this.config.node.domains[0] || '',
+      this._certificateManager
     )
     this._rpcServer.setSystemToken(this._systemToken)
 
@@ -93,9 +117,59 @@ export class AuthService extends CatalystService {
       return c.json(jwks)
     })
     this.handler.route('/rpc', createAuthRpcHandler(this._rpcServer))
+
+    // Mount PKI HTTP endpoints
+    if (this._certificateManager) {
+      // Public: CA bundle (no auth — read-only trust anchor distribution)
+      this.handler.get('/pki/ca/bundle', async (c) => {
+        try {
+          const bundle = await this._certificateManager!.getCaBundle()
+          const etag = `"${bundle.version}"`
+          if (c.req.header('If-None-Match') === etag) {
+            return c.body(null, 304)
+          }
+          c.header('ETag', etag)
+          c.header('Cache-Control', 'public, max-age=300')
+          return c.json(bundle)
+        } catch {
+          return c.json({ error: 'CA not initialized' }, 503)
+        }
+      })
+
+      // Authenticated: CSR signing
+      this.handler.post('/pki/csr/sign', async (c) => {
+        const authHeader = c.req.header('Authorization')
+        if (!authHeader?.startsWith('Bearer ')) {
+          return c.json({ error: 'Missing authorization' }, 401)
+        }
+        const token = authHeader.slice(7)
+        const auth = await this._tokenFactory.verify(token)
+        if (!auth.valid) {
+          return c.json({ error: 'Invalid token' }, 401)
+        }
+
+        const body = await c.req.json()
+        const parsed = SignCSRRequestSchema.safeParse(body)
+        if (!parsed.success) {
+          return c.json({ error: parsed.error.message }, 400)
+        }
+
+        try {
+          const result = await this._certificateManager!.signCSR(parsed.data)
+          return c.json(result)
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          if (message.startsWith('Identity denied')) {
+            return c.json({ error: message }, 403)
+          }
+          return c.json({ error: message }, 500)
+        }
+      })
+    }
   }
 
   protected async onShutdown(): Promise<void> {
     await this._tokenFactory.shutdown()
+    await this._certificateManager?.shutdown()
   }
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -88,6 +88,14 @@ export const AuthConfigSchema = z.object({
         .optional(), // 24 hours
     })
     .default({}),
+  pki: z
+    .object({
+      certsDb: z.string().default('certs.db'),
+      trustDomain: z.string().default('catalyst.example.com'),
+      svidTtlSeconds: z.number().int().min(60).max(86400).default(3600),
+      autoRenew: z.boolean().default(true),
+    })
+    .optional(),
 })
 
 export type AuthConfig = z.infer<typeof AuthConfigSchema>
@@ -206,6 +214,14 @@ export function loadDefaultConfig(options: ConfigLoadOptions = {}): CatalystConf
         ttl: process.env.CATALYST_BOOTSTRAP_TTL
           ? Number(process.env.CATALYST_BOOTSTRAP_TTL)
           : undefined,
+      },
+      pki: {
+        certsDb: process.env.CATALYST_PKI_CERTS_DB,
+        trustDomain: process.env.CATALYST_PKI_TRUST_DOMAIN,
+        svidTtlSeconds: process.env.CATALYST_PKI_SVID_TTL
+          ? Number(process.env.CATALYST_PKI_SVID_TTL)
+          : undefined,
+        autoRenew: process.env.CATALYST_PKI_AUTO_RENEW !== 'false',
       },
     },
   })


### PR DESCRIPTION
- Add PkiConfigSchema to AuthConfigSchema (certsDb, trustDomain, svidTtlSeconds)
- Add CATALYST_PKI_* environment variable loading in loadDefaultConfig()
- Initialize CertificateManager in AuthService.onInitialize()
- Pass CertificateManager to AuthRpcServer constructor
- Mount GET /pki/ca/bundle (public, ETag/304 support, Cache-Control)
- Mount POST /pki/csr/sign (Bearer token auth, Zod validation)
- Add @peculiar/x509 as devDependency for PKI RPC tests

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>