### PR TITLE
feat(ci): add per-package lint scripts and turbo lint task

### DIFF
--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Install Node.js 22
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       with:
         node-version-file: .nvmrc
 
@@ -19,7 +19,7 @@ runs:
       run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Cache pnpm store
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
         key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -14,7 +14,8 @@
     "test:unit": "vitest run --exclude '**/*{integration,container}*' --passWithNoTests",
     "test:integration": "vitest run --passWithNoTests container integration",
     "start": "tsx src/server.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@catalyst/authorization": "workspace:*",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -11,7 +11,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:unit": "vitest run --exclude '**/*{integration,container}*' --passWithNoTests",
-    "test:integration": "vitest run --passWithNoTests container integration"
+    "test:integration": "vitest run --passWithNoTests container integration",
+    "lint": "eslint ."
   },
   "dependencies": {
     "capnweb": "catalog:",

--- a/apps/envoy/package.json
+++ b/apps/envoy/package.json
@@ -9,7 +9,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:unit": "vitest run --exclude '**/*{integration,container}*' --passWithNoTests",
-    "test:integration": "vitest run --passWithNoTests container integration"
+    "test:integration": "vitest run --passWithNoTests container integration",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@catalyst/config": "workspace:*",

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run",
     "test:unit": "vitest run --exclude '**/*{integration,container}*' --passWithNoTests",
     "test:integration": "vitest run --passWithNoTests container integration",
-    "test:rpc": "tsx scripts/test-rpc.ts"
+    "test:rpc": "tsx scripts/test-rpc.ts",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@graphql-tools/delegate": "catalog:",

--- a/apps/node/package.json
+++ b/apps/node/package.json
@@ -11,7 +11,8 @@
     "build": "tsup",
     "typecheck": "tsc --noEmit",
     "dev": "tsup --watch",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "lint": "eslint ."
   },
   "keywords": [],
   "author": "",

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:unit": "vitest run --exclude '**/*{integration,container}*' --passWithNoTests",
-    "test:integration": "vitest run --passWithNoTests container integration"
+    "test:integration": "vitest run --passWithNoTests container integration",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@catalyst/authorization": "workspace:*",

--- a/apps/rpi-config/package.json
+++ b/apps/rpi-config/package.json
@@ -11,7 +11,8 @@
     "start": "node dist/index.js",
     "compile": "esbuild src/index.ts --bundle --platform=node --target=node22 --outfile=../../dist/rpi-config/catalyst-rpi-config.mjs --format=esm --packages=external --banner:js='#!/usr/bin/env node'",
     "test": "vitest",
-    "test:watch": "vitest --watch"
+    "test:watch": "vitest --watch",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@inquirer/prompts": "^7.0.0",

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -24,7 +24,8 @@
     "test": "vitest run",
     "test:unit": "vitest run --exclude '**/*{integration,container}*' --passWithNoTests",
     "test:integration": "vitest run --passWithNoTests container integration",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint ."
   },
   "devDependencies": {
     "@types/better-sqlite3": "catalog:dev",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "vitest run"
+    "test": "vitest run",
+    "lint": "eslint ."
   },
   "dependencies": {
     "zod": "catalog:"

--- a/packages/routing/package.json
+++ b/packages/routing/package.json
@@ -12,7 +12,8 @@
   "private": true,
   "scripts": {
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@catalyst/config": "workspace:*",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -9,7 +9,8 @@
     "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
     "test": "vitest",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint ."
   },
   "devDependencies": {
     "@types/node": "catalog:dev",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run",
     "test:unit": "vitest run --exclude '**/*{integration,container}*' --passWithNoTests",
     "test:integration": "vitest run --passWithNoTests container integration",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@catalyst/config": "workspace:*",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -13,7 +13,8 @@
     "test": "vitest run",
     "test:unit": "vitest run --exclude '**/*{integration,container}*' --passWithNoTests",
     "test:integration": "vitest run --passWithNoTests container integration",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@logtape/logtape": "^0.12.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,7 +15,8 @@
     "test": "vitest run",
     "test:unit": "vitest run --exclude '**/*{integration,container}*' --passWithNoTests",
     "test:integration": "vitest run --passWithNoTests container integration",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint ."
   },
   "devDependencies": {
     "@types/node": "catalog:dev",

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
+    "lint": {
+      "dependsOn": ["^lint"]
+    },
     "typecheck": {},
     "test:unit": {},
     "test:integration": {


### PR DESCRIPTION
### TL;DR

Added lint script to all packages and apps, updated GitHub Actions dependencies, and added a data control presentation PDF.

### What changed?

- Updated `actions/setup-node` from v4.4.0 to v6.2.0 and `actions/cache` from v4.2.3 to v5.0.3 in the setup-repo GitHub Action
- Added `"lint": "eslint ."` script to all package.json files across apps and packages
- Added lint task configuration to turbo.json with dependency on upstream lint tasks
- Added `data-control.pdf` presentation file to the docs/presentations/overview directory

### How to test?

- Run `pnpm lint` in any app or package directory to verify the new lint script works
- Run `turbo lint` from the root to test the new Turbo task configuration
- Verify GitHub Actions still work correctly with the updated action versions

### Why make this change?

This standardizes linting across the entire monorepo by ensuring every package has a consistent lint script, enables running linting through Turbo's task runner for better performance and caching, and keeps GitHub Actions dependencies up to date for security and feature improvements.