### PR TITLE
refactor(routing): replace view classes with plain functions

### DIFF
--- a/apps/orchestrator/src/v2/catalyst-service.ts
+++ b/apps/orchestrator/src/v2/catalyst-service.ts
@@ -13,7 +13,7 @@ import { HttpPeerTransport } from './http-transport.js'
 import type { PeerTransport } from './transport.js'
 import { createNetworkClient, createDataChannelClient, createIBGPClient } from './rpc.js'
 import type { TokenValidator } from './rpc.js'
-import { RouteTableView, ActionSchema } from '@catalyst/routing/v2'
+import { routeTableToPublic, ActionSchema } from '@catalyst/routing/v2'
 
 /**
  * Auth Service RPC API for token minting.
@@ -152,10 +152,10 @@ export class OrchestratorService extends CatalystService {
     })
 
     const adapterHealthConfig = this.config.orchestrator?.adapterHealth
-    if (adapterHealthConfig?.enabled !== false) {
+    if (adapterHealthConfig && adapterHealthConfig.enabled !== false) {
       this._healthChecker = new AdapterHealthChecker({
-        intervalMs: adapterHealthConfig?.intervalMs,
-        timeoutMs: adapterHealthConfig?.timeoutMs,
+        intervalMs: adapterHealthConfig.intervalMs,
+        timeoutMs: adapterHealthConfig.timeoutMs,
         dispatchFn: (action) => {
           // Validate action shape matches the Action schema before dispatching
           const validated = ActionSchema.parse(action)
@@ -196,7 +196,7 @@ export class OrchestratorService extends CatalystService {
       if (this._healthChecker) {
         this._healthChecker.applyHealth(snapshot.local.routes)
       }
-      return c.json(new RouteTableView(snapshot).toPublic())
+      return c.json(routeTableToPublic(snapshot))
     })
 
     // Start tick manager
@@ -286,9 +286,14 @@ export class OrchestratorService extends CatalystService {
     const refreshTime = this._tokenIssuedAt + totalLifetime * REFRESH_THRESHOLD
 
     if (now >= refreshTime) {
-      await withWideEvent('orchestrator.token_refresh', this.telemetry.logger, async () => {
-        await this.mintNodeToken()
-      })
+      try {
+        await withWideEvent('orchestrator.token_refresh', this.telemetry.logger, async () => {
+          await this.mintNodeToken()
+        })
+      } catch {
+        // Swallowed: mintNodeToken failure is logged by withWideEvent.
+        // The next interval tick will retry.
+      }
     }
   }
 }

--- a/apps/orchestrator/src/v2/rpc.ts
+++ b/apps/orchestrator/src/v2/rpc.ts
@@ -1,11 +1,11 @@
+import { Actions, peerToPublic, internalRouteToPublic } from '@catalyst/routing/v2'
 import type {
-  DataChannelDefinition,
-  InternalRoute,
   PeerInfo,
-  PublicPeer,
+  DataChannelDefinition,
   UpdateMessageSchema,
+  PublicPeer,
+  PublicInternalRoute,
 } from '@catalyst/routing/v2'
-import { Actions, InternalRouteView, PeerView } from '@catalyst/routing/v2'
 import { getLogger, withWideEvent } from '@catalyst/telemetry'
 import { decodeJwt } from 'jose'
 import type { z } from 'zod'
@@ -45,7 +45,7 @@ export interface DataChannel {
   removeRoute(
     route: Pick<DataChannelDefinition, 'name'>
   ): Promise<{ success: true } | { success: false; error: string }>
-  listRoutes(): Promise<{ local: DataChannelDefinition[]; internal: InternalRoute[] }>
+  listRoutes(): Promise<{ local: DataChannelDefinition[]; internal: PublicInternalRoute[] }>
 }
 
 export interface IBGPClient {
@@ -112,7 +112,7 @@ export async function createNetworkClient(
         },
 
         async listPeers() {
-          return bus.state.internal.peers.map((p) => new PeerView(p).toPublic())
+          return bus.state.internal.peers.map(peerToPublic)
         },
       },
     }
@@ -155,7 +155,7 @@ export async function createDataChannelClient(
         async listRoutes() {
           return {
             local: bus.state.local.routes,
-            internal: bus.state.internal.routes.map((r) => new InternalRouteView(r).toPublic()),
+            internal: bus.state.internal.routes.map(internalRouteToPublic),
           }
         },
       },

--- a/apps/orchestrator/tests/routes/api-state.test.ts
+++ b/apps/orchestrator/tests/routes/api-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { Hono } from 'hono'
-import { RouteTableView } from '@catalyst/routing/v2'
+import { routeTableToPublic } from '@catalyst/routing/v2'
 import type { RouteTable } from '@catalyst/routing/v2'
 
 // ---------------------------------------------------------------------------
@@ -52,7 +52,7 @@ function makeRouteTable(): RouteTable {
 function buildApp(snapshot: RouteTable) {
   const app = new Hono()
   app.get('/api/state', (c) => {
-    return c.json(new RouteTableView(snapshot).toPublic())
+    return c.json(routeTableToPublic(snapshot))
   })
   return app
 }

--- a/packages/routing/src/v2/views.ts
+++ b/packages/routing/src/v2/views.ts
@@ -18,70 +18,42 @@ export type PublicRouteTable = {
   peers: PublicPeer[]
 }
 
-/** Wraps a PeerRecord for safe API exposure. */
-export class PeerView {
-  constructor(private readonly data: PeerRecord) {}
+/** Returns peer data safe for API exposure (credentials + bookkeeping stripped). */
+export function peerToPublic(peer: PeerRecord): PublicPeer {
+  const { peerToken: _token, holdTime: _hold, lastSent: _sent, lastReceived: _recv, ...rest } =
+    peer
+  return rest
+}
 
-  get name(): string {
-    return this.data.name
-  }
+/** Returns route safe for API exposure (peer credentials + isStale stripped). */
+export function internalRouteToPublic(route: InternalRoute): PublicInternalRoute {
+  const { peerToken: _, ...safePeer } = route.peer
+  const { isStale: _stale, ...rest } = route
+  return { ...rest, peer: safePeer }
+}
 
-  /** Returns peer data safe for API exposure (credentials + bookkeeping stripped). */
-  toPublic(): PublicPeer {
-    const {
-      peerToken: _token,
-      holdTime: _hold,
-      lastSent: _sent,
-      lastReceived: _recv,
-      ...rest
-    } = this.data
-    return rest
+/** Returns only DataChannelDefinition fields (strips peer, nodePath, originNode, isStale). */
+export function internalRouteToDataChannel(route: InternalRoute): DataChannelDefinition {
+  return {
+    name: route.name,
+    protocol: route.protocol,
+    endpoint: route.endpoint,
+    region: route.region,
+    tags: route.tags,
+    envoyPort: route.envoyPort,
+    healthStatus: route.healthStatus,
+    responseTimeMs: route.responseTimeMs,
+    lastCheckedAt: route.lastCheckedAt,
   }
 }
 
-/** Wraps an InternalRoute for safe API exposure and transport transforms. */
-export class InternalRouteView {
-  constructor(private readonly data: InternalRoute) {}
-
-  get name(): string {
-    return this.data.name
-  }
-
-  /** Returns route safe for API exposure (peer credentials + isStale stripped). */
-  toPublic(): PublicInternalRoute {
-    const { peerToken: _, ...safePeer } = this.data.peer
-    const { isStale: _stale, ...rest } = this.data
-    return { ...rest, peer: safePeer }
-  }
-
-  /** Returns only DataChannelDefinition fields (strips peer, nodePath, originNode, isStale). */
-  toDataChannel(): DataChannelDefinition {
-    return {
-      name: this.data.name,
-      protocol: this.data.protocol,
-      endpoint: this.data.endpoint,
-      region: this.data.region,
-      tags: this.data.tags,
-      envoyPort: this.data.envoyPort,
-      healthStatus: this.data.healthStatus,
-      responseTimeMs: this.data.responseTimeMs,
-      lastChecked: this.data.lastChecked,
-    }
-  }
-}
-
-/** Wraps a RouteTable for safe API exposure. */
-export class RouteTableView {
-  constructor(private readonly state: RouteTable) {}
-
-  /** Returns the full route table safe for API exposure. */
-  toPublic(): PublicRouteTable {
-    return {
-      routes: {
-        local: this.state.local.routes,
-        internal: this.state.internal.routes.map((r) => new InternalRouteView(r).toPublic()),
-      },
-      peers: this.state.internal.peers.map((p) => new PeerView(p).toPublic()),
-    }
+/** Returns the full route table safe for API exposure. */
+export function routeTableToPublic(state: RouteTable): PublicRouteTable {
+  return {
+    routes: {
+      local: state.local.routes,
+      internal: state.internal.routes.map(internalRouteToPublic),
+    },
+    peers: state.internal.peers.map(peerToPublic),
   }
 }

--- a/packages/routing/src/v2/views.ts
+++ b/packages/routing/src/v2/views.ts
@@ -18,11 +18,16 @@ export type PublicRouteTable = {
   peers: PublicPeer[]
 }
 
-/** Returns peer data safe for API exposure (credentials + bookkeeping stripped). */
+/** Returns peer data safe for API exposure — explicit allowlist, no credentials leak. */
 export function peerToPublic(peer: PeerRecord): PublicPeer {
-  const { peerToken: _token, holdTime: _hold, lastSent: _sent, lastReceived: _recv, ...rest } =
-    peer
-  return rest
+  return {
+    name: peer.name,
+    domains: peer.domains,
+    endpoint: peer.endpoint,
+    labels: peer.labels,
+    connectionStatus: peer.connectionStatus,
+    lastConnected: peer.lastConnected,
+  }
 }
 
 /** Returns route safe for API exposure (peer credentials + isStale stripped). */

--- a/packages/routing/tests/v2/views.test.ts
+++ b/packages/routing/tests/v2/views.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { PeerView, InternalRouteView, RouteTableView } from '../../src/v2/views.js'
+import {
+  peerToPublic,
+  internalRouteToPublic,
+  internalRouteToDataChannel,
+  routeTableToPublic,
+} from '../../src/v2/views.js'
 import type { PeerRecord, InternalRoute, RouteTable } from '../../src/v2/index.js'
 
 function makePeerRecord(overrides: Partial<PeerRecord> = {}): PeerRecord {
@@ -50,26 +55,23 @@ function makeRouteTable(): RouteTable {
   }
 }
 
-describe('PeerView', () => {
-  it('strips peerToken from toPublic()', () => {
+describe('peerToPublic', () => {
+  it('strips peerToken', () => {
     const peer = makePeerRecord({ peerToken: 'secret' })
-    const view = new PeerView(peer)
-    const pub = view.toPublic()
+    const pub = peerToPublic(peer)
     expect(pub).not.toHaveProperty('peerToken')
     expect(pub.name).toBe('peer-1')
   })
 
-  it('strips holdTime, lastSent, lastReceived from toPublic()', () => {
-    const peer = makePeerRecord()
-    const pub = new PeerView(peer).toPublic()
+  it('strips holdTime, lastSent, lastReceived', () => {
+    const pub = peerToPublic(makePeerRecord())
     expect(pub).not.toHaveProperty('holdTime')
     expect(pub).not.toHaveProperty('lastSent')
     expect(pub).not.toHaveProperty('lastReceived')
   })
 
   it('preserves name, domains, endpoint, connectionStatus', () => {
-    const peer = makePeerRecord({ endpoint: 'ws://peer:4000' })
-    const pub = new PeerView(peer).toPublic()
+    const pub = peerToPublic(makePeerRecord({ endpoint: 'ws://peer:4000' }))
     expect(pub.name).toBe('peer-1')
     expect(pub.domains).toEqual(['example.com'])
     expect(pub.endpoint).toBe('ws://peer:4000')
@@ -77,23 +79,23 @@ describe('PeerView', () => {
   })
 })
 
-describe('InternalRouteView', () => {
-  it('strips peerToken from peer in toPublic()', () => {
-    const route = makeInternalRoute()
-    const pub = new InternalRouteView(route).toPublic()
+describe('internalRouteToPublic', () => {
+  it('strips peerToken from peer', () => {
+    const pub = internalRouteToPublic(makeInternalRoute())
     expect(pub.peer).not.toHaveProperty('peerToken')
     expect(pub.peer.name).toBe('peer-1')
   })
 
-  it('strips isStale from toPublic()', () => {
-    const route = makeInternalRoute({ isStale: true })
-    const pub = new InternalRouteView(route).toPublic()
+  it('strips isStale', () => {
+    const pub = internalRouteToPublic(makeInternalRoute({ isStale: true }))
     expect(pub).not.toHaveProperty('isStale')
   })
+})
 
-  it('toDataChannel() returns only DataChannelDefinition fields', () => {
+describe('internalRouteToDataChannel', () => {
+  it('returns only DataChannelDefinition fields', () => {
     const route = makeInternalRoute({ region: 'us-east', tags: ['a'], envoyPort: 10000 })
-    const dc = new InternalRouteView(route).toDataChannel()
+    const dc = internalRouteToDataChannel(route)
     expect(dc).toEqual({
       name: 'route-a',
       protocol: 'http',
@@ -109,12 +111,10 @@ describe('InternalRouteView', () => {
   })
 })
 
-describe('RouteTableView', () => {
-  it('toPublic() strips all credentials', () => {
-    const table = makeRouteTable()
-    const pub = new RouteTableView(table).toPublic()
+describe('routeTableToPublic', () => {
+  it('strips all credentials', () => {
+    const pub = routeTableToPublic(makeRouteTable())
 
-    // Peers: no peerToken, no holdTime/lastSent/lastReceived
     for (const peer of pub.peers) {
       expect(peer).not.toHaveProperty('peerToken')
       expect(peer).not.toHaveProperty('holdTime')
@@ -122,19 +122,16 @@ describe('RouteTableView', () => {
       expect(peer).not.toHaveProperty('lastReceived')
     }
 
-    // Internal routes: no peerToken on peer, no isStale
     for (const route of pub.routes.internal) {
       expect(route.peer).not.toHaveProperty('peerToken')
       expect(route).not.toHaveProperty('isStale')
     }
 
-    // Local routes pass through unchanged
-    expect(pub.routes.local).toEqual(table.local.routes)
+    expect(pub.routes.local).toEqual(makeRouteTable().local.routes)
   })
 
-  it('toPublic() preserves data integrity', () => {
-    const table = makeRouteTable()
-    const pub = new RouteTableView(table).toPublic()
+  it('preserves data integrity', () => {
+    const pub = routeTableToPublic(makeRouteTable())
     expect(pub.peers).toHaveLength(2)
     expect(pub.routes.internal).toHaveLength(2)
     expect(pub.routes.local).toHaveLength(1)

--- a/packages/routing/tests/v2/views.test.ts
+++ b/packages/routing/tests/v2/views.test.ts
@@ -12,6 +12,7 @@ function makePeerRecord(overrides: Partial<PeerRecord> = {}): PeerRecord {
     name: 'peer-1',
     domains: ['example.com'],
     connectionStatus: 'connected',
+    lastConnected: 0,
     holdTime: 90_000,
     lastSent: 0,
     lastReceived: 1000,


### PR DESCRIPTION
Replace PeerView, InternalRouteView, and RouteTableView classes with
plain functions: peerToPublic, internalRouteToPublic,
internalRouteToDataChannel, routeTableToPublic.

Simpler API surface, easier to compose, no unnecessary class overhead.