### PR TITLE
refactor(routing): convert RouteTable from arrays to Maps

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -83,7 +83,7 @@ export const OrchestratorConfigSchema = z.object({
       intervalMs: z.number().int().min(0).default(30_000),
       timeoutMs: z.number().int().min(100).default(3_000),
     })
-    .optional(),
+    .default({}),
 })
 
 export type OrchestratorConfig = z.infer<typeof OrchestratorConfigSchema>

--- a/packages/routing/src/v2/datachannel.ts
+++ b/packages/routing/src/v2/datachannel.ts
@@ -26,7 +26,7 @@ export const DataChannelDefinitionSchema = z.object({
   envoyAddress: z.string().optional(),
   healthStatus: z.enum(['up', 'down']).optional(),
   responseTimeMs: z.number().nullable().optional(),
-  lastChecked: z.string().optional(),
+  lastCheckedAt: z.string().datetime().optional(),
 })
 export type DataChannelDefinition = z.infer<typeof DataChannelDefinitionSchema>
 

--- a/packages/routing/src/v2/local/actions.ts
+++ b/packages/routing/src/v2/local/actions.ts
@@ -47,6 +47,6 @@ export const localRouteHealthUpdateMessageSchema = z.object({
     name: z.string(),
     healthStatus: z.enum(['up', 'down']),
     responseTimeMs: z.number().nullable(),
-    lastChecked: z.string(),
+    lastCheckedAt: z.string().datetime(),
   }),
 })

--- a/packages/routing/src/v2/rib/rib.ts
+++ b/packages/routing/src/v2/rib/rib.ts
@@ -1,10 +1,19 @@
 import { Actions } from '../action-types.js'
 import { CloseCodes } from '../close-codes.js'
 import { routeKey } from '../datachannel.js'
+import {
+  mapWith,
+  mapWithout,
+  nestedMapGet,
+  nestedMapSet,
+  nestedMapDelete,
+  nestedMapDeleteOuter,
+} from '../map-helpers.js'
 import type { Action } from '../schema.js'
 import type { ActionLog } from '../journal/action-log.js'
 import {
   newRouteTable,
+  internalRouteKey,
   type RouteTable,
   type PeerRecord,
   type InternalRoute,
@@ -156,9 +165,7 @@ export class RoutingInformationBase {
   // -------------------------------------------------------------------------
 
   private planLocalPeerCreate(data: PeerInfo, state: RouteTable): PlanResult {
-    const exists = state.internal.peers.some((p) => p.name === data.name)
-    if (exists) return noChange(state)
-
+    if (state.internal.peers.has(data.name)) return noChange(state)
     const newPeer: PeerRecord = {
       ...data,
       connectionStatus: 'initializing',
@@ -171,55 +178,48 @@ export class RoutingInformationBase {
       ...state,
       internal: {
         ...state.internal,
-        peers: [...state.internal.peers, newPeer],
+        peers: mapWith(state.internal.peers, data.name, newPeer),
       },
     }
     return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges: NO_ROUTE_CHANGES }
   }
 
   private planLocalPeerUpdate(data: PeerInfo, state: RouteTable): PlanResult {
-    const idx = state.internal.peers.findIndex((p) => p.name === data.name)
-    if (idx === -1) return noChange(state)
-
-    const existing = state.internal.peers[idx]
+    const existing = state.internal.peers.get(data.name)
+    if (existing === undefined) return noChange(state)
     const updated: PeerRecord = {
-      // Apply all incoming PeerInfo fields
       ...existing,
       ...data,
-      // Preserve runtime-only fields — they are managed by protocol events
       connectionStatus: existing.connectionStatus,
       lastConnected: existing.lastConnected,
       holdTime: existing.holdTime,
       lastSent: existing.lastSent,
       lastReceived: existing.lastReceived,
     }
-    const peers = state.internal.peers.map((p, i) => (i === idx ? updated : p))
     const newState: RouteTable = {
       ...state,
-      internal: { ...state.internal, peers },
+      internal: { ...state.internal, peers: mapWith(state.internal.peers, data.name, updated) },
     }
     return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges: NO_ROUTE_CHANGES }
   }
 
   private planLocalPeerDelete(data: LocalPeerDeleteData, state: RouteTable): PlanResult {
-    const peers = state.internal.peers.filter((p) => p.name !== data.name)
-    if (peers.length === state.internal.peers.length) return noChange(state)
-
-    const removedRoutes = state.internal.routes.filter((r) => r.peer.name === data.name)
-    const routes = state.internal.routes.filter((r) => r.peer.name !== data.name)
-
+    if (!state.internal.peers.has(data.name)) return noChange(state)
+    const peerRouteMap = state.internal.routes.get(data.name)
+    const removedRoutes = peerRouteMap ? [...peerRouteMap.values()] : []
     const portOps: PortOperation[] = removedRoutes
       .filter((r) => r.envoyPort != null)
       .map((r) => ({ type: 'release' as const, routeKey: routeKey(r), port: r.envoyPort! }))
-
     const routeChanges: RouteChange[] = removedRoutes.map((r) => ({
       type: 'removed' as const,
       route: r,
     }))
-
     const newState: RouteTable = {
       ...state,
-      internal: { peers, routes },
+      internal: {
+        peers: mapWithout(state.internal.peers, data.name),
+        routes: nestedMapDeleteOuter(state.internal.routes, data.name),
+      },
     }
     return { prevState: state, newState, portOps, routeChanges }
   }
@@ -229,12 +229,10 @@ export class RoutingInformationBase {
   // -------------------------------------------------------------------------
 
   private planLocalRouteCreate(data: LocalRouteCreateData, state: RouteTable): PlanResult {
-    const exists = state.local.routes.some((r) => r.name === data.name)
-    if (exists) return noChange(state)
-
+    if (state.local.routes.has(routeKey(data))) return noChange(state)
     const newState: RouteTable = {
       ...state,
-      local: { ...state.local, routes: [...state.local.routes, data] },
+      local: { ...state.local, routes: mapWith(state.local.routes, routeKey(data), data) },
     }
     return {
       prevState: state,
@@ -245,18 +243,15 @@ export class RoutingInformationBase {
   }
 
   private planLocalRouteDelete(data: LocalRouteDeleteData, state: RouteTable): PlanResult {
-    const route = state.local.routes.find((r) => r.name === data.name)
+    const route = state.local.routes.get(routeKey(data))
     if (route === undefined) return noChange(state)
-
-    const routes = state.local.routes.filter((r) => r.name !== data.name)
     const portOps: PortOperation[] =
       route.envoyPort != null
         ? [{ type: 'release' as const, routeKey: routeKey(route), port: route.envoyPort }]
         : NO_PORT_OPS
-
     const newState: RouteTable = {
       ...state,
-      local: { ...state.local, routes },
+      local: { ...state.local, routes: mapWithout(state.local.routes, routeKey(data)) },
     }
     return {
       prevState: state,
@@ -270,16 +265,14 @@ export class RoutingInformationBase {
     data: LocalRouteHealthUpdateData,
     state: RouteTable
   ): PlanResult {
-    const idx = state.local.routes.findIndex((r) => r.name === data.name)
-    if (idx === -1) return noChange(state)
-
-    const existing = state.local.routes[idx]
+    const existing = state.local.routes.get(data.name)
+    if (existing === undefined) return noChange(state)
 
     // No-op if health fields are identical (prevent iBGP churn)
     if (
       existing.healthStatus === data.healthStatus &&
       existing.responseTimeMs === data.responseTimeMs &&
-      existing.lastChecked === data.lastChecked
+      existing.lastCheckedAt === data.lastCheckedAt
     ) {
       return noChange(state)
     }
@@ -288,12 +281,11 @@ export class RoutingInformationBase {
       ...existing,
       healthStatus: data.healthStatus,
       responseTimeMs: data.responseTimeMs,
-      lastChecked: data.lastChecked,
+      lastCheckedAt: data.lastCheckedAt,
     }
-    const routes = state.local.routes.map((r, i) => (i === idx ? updated : r))
     const newState: RouteTable = {
       ...state,
-      local: { ...state.local, routes },
+      local: { ...state.local, routes: mapWith(state.local.routes, data.name, updated) },
     }
     return {
       prevState: state,
@@ -308,24 +300,22 @@ export class RoutingInformationBase {
   // -------------------------------------------------------------------------
 
   private planInternalProtocolOpen(data: InternalProtocolOpenData, state: RouteTable): PlanResult {
-    const idx = state.internal.peers.findIndex((p) => p.name === data.peerInfo.name)
-    // Unknown peer — we only accept opens for pre-configured peers
-    if (idx === -1) return noChange(state)
-
-    const existing = state.internal.peers[idx]
+    const existing = state.internal.peers.get(data.peerInfo.name)
+    if (existing === undefined) return noChange(state)
     const negotiatedHoldTime =
       data.holdTime != null ? Math.min(existing.holdTime, data.holdTime) : existing.holdTime
-
     const updated: PeerRecord = {
       ...existing,
       connectionStatus: 'connected',
       holdTime: negotiatedHoldTime,
       lastReceived: Date.now(),
     }
-    const peers = state.internal.peers.map((p, i) => (i === idx ? updated : p))
     const newState: RouteTable = {
       ...state,
-      internal: { ...state.internal, peers },
+      internal: {
+        ...state.internal,
+        peers: mapWith(state.internal.peers, data.peerInfo.name, updated),
+      },
     }
     return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges: NO_ROUTE_CHANGES }
   }
@@ -334,10 +324,8 @@ export class RoutingInformationBase {
     data: InternalProtocolConnectedData,
     state: RouteTable
   ): PlanResult {
-    const idx = state.internal.peers.findIndex((p) => p.name === data.peerInfo.name)
-    if (idx === -1) return noChange(state)
-
-    const existing = state.internal.peers[idx]
+    const existing = state.internal.peers.get(data.peerInfo.name)
+    if (existing === undefined) return noChange(state)
     // Reset holdTime to default on reconnect so it can be re-negotiated
     // via the subsequent InternalProtocolOpen exchange.
     const now = Date.now()
@@ -349,10 +337,12 @@ export class RoutingInformationBase {
       holdTime: 90_000,
       lastSent: 0,
     }
-    const peers = state.internal.peers.map((p, i) => (i === idx ? updated : p))
     const newState: RouteTable = {
       ...state,
-      internal: { ...state.internal, peers },
+      internal: {
+        ...state.internal,
+        peers: mapWith(state.internal.peers, data.peerInfo.name, updated),
+      },
     }
     return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges: NO_ROUTE_CHANGES }
   }
@@ -361,45 +351,45 @@ export class RoutingInformationBase {
     data: InternalProtocolCloseData,
     state: RouteTable
   ): PlanResult {
-    const idx = state.internal.peers.findIndex((p) => p.name === data.peerInfo.name)
-    if (idx === -1) return noChange(state)
+    const existing = state.internal.peers.get(data.peerInfo.name)
+    if (existing === undefined) return noChange(state)
 
     const isTransportError = data.code === CloseCodes.TRANSPORT_ERROR
-    const peerRoutes = state.internal.routes.filter((r) => r.peer.name === data.peerInfo.name)
+    const peerRouteMap = state.internal.routes.get(data.peerInfo.name)
+    const peerRoutes = peerRouteMap ? [...peerRouteMap.values()] : []
 
-    let routes: InternalRoute[]
+    let routes: RouteTable['internal']['routes']
     let routeChanges: RouteChange[]
     let portOps: PortOperation[]
 
     if (isTransportError) {
-      // Graceful-restart behaviour: mark routes stale rather than withdrawing
-      // them immediately. They will be replaced on reconnect or purged by Tick
-      // once the peer's holdTime grace period elapses without reconnection.
-      routes = state.internal.routes.map((r) =>
-        r.peer.name === data.peerInfo.name ? { ...r, isStale: true } : r
-      )
+      if (peerRouteMap && peerRouteMap.size > 0) {
+        const staleInner = new Map<string, InternalRoute>()
+        for (const [key, r] of peerRouteMap) {
+          staleInner.set(key, { ...r, isStale: true })
+        }
+        routes = mapWith(state.internal.routes, data.peerInfo.name, staleInner)
+      } else {
+        routes = state.internal.routes
+      }
       routeChanges = peerRoutes.map((r) => ({
         type: 'updated' as const,
         route: { ...r, isStale: true },
       }))
       portOps = NO_PORT_OPS
     } else {
-      // Hard close (normal, hold-expired, admin-shutdown, protocol-error):
-      // withdraw routes and release any allocated envoy ports.
-      routes = state.internal.routes.filter((r) => r.peer.name !== data.peerInfo.name)
+      routes = nestedMapDeleteOuter(state.internal.routes, data.peerInfo.name)
       routeChanges = peerRoutes.map((r) => ({ type: 'removed' as const, route: r }))
       portOps = peerRoutes
         .filter((r) => r.envoyPort != null)
         .map((r) => ({ type: 'release' as const, routeKey: routeKey(r), port: r.envoyPort! }))
     }
 
-    const peers = state.internal.peers.map((p, i) =>
-      i === idx ? { ...p, connectionStatus: 'closed' as const } : p
-    )
-    const newState: RouteTable = {
-      ...state,
-      internal: { peers, routes },
-    }
+    const peers = mapWith(state.internal.peers, data.peerInfo.name, {
+      ...existing,
+      connectionStatus: 'closed' as const,
+    })
+    const newState: RouteTable = { ...state, internal: { peers, routes } }
     return { prevState: state, newState, portOps, routeChanges }
   }
 
@@ -407,19 +397,16 @@ export class RoutingInformationBase {
     data: InternalProtocolUpdateData,
     state: RouteTable
   ): PlanResult {
-    let routes = [...state.internal.routes]
+    let routes = state.internal.routes
     const portOps: PortOperation[] = []
     const routeChanges: RouteChange[] = []
 
     for (const item of data.update.updates) {
       if (item.action === 'add') {
-        // Loop detection — discard advertisements that already include this node
         if (item.nodePath.includes(this._nodeId)) continue
 
-        const key = routeKey(item.route)
-        const existingIdx = routes.findIndex(
-          (r) => routeKey(r) === key && r.originNode === item.originNode
-        )
+        const irKey = internalRouteKey({ name: item.route.name, originNode: item.originNode })
+        const existing = nestedMapGet(routes, data.peerInfo.name, irKey)
 
         const newRoute: InternalRoute = {
           ...item.route,
@@ -429,52 +416,46 @@ export class RoutingInformationBase {
           isStale: false,
         }
 
-        if (existingIdx !== -1) {
-          const existing = routes[existingIdx]
-          // Best-path selection: prefer shorter path, or replace a stale route
+        if (existing !== undefined) {
           const betterPath = item.nodePath.length < existing.nodePath.length
           const replacingStale = existing.isStale === true
           if (betterPath || replacingStale) {
-            routes = routes.map((r, i) => (i === existingIdx ? newRoute : r))
+            routes = nestedMapSet(routes, data.peerInfo.name, irKey, newRoute)
             routeChanges.push({ type: 'updated', route: newRoute })
           }
-          // else: existing path is equal or better and fresh — no change
         } else {
-          routes = [...routes, newRoute]
+          routes = nestedMapSet(routes, data.peerInfo.name, irKey, newRoute)
           routeChanges.push({ type: 'added', route: newRoute })
         }
       } else {
         // action === 'remove'
-        const key = routeKey(item.route)
-        const removed = routes.find((r) => routeKey(r) === key && r.originNode === item.originNode)
+        const irKey = internalRouteKey({ name: item.route.name, originNode: item.originNode })
+        const removed = nestedMapGet(routes, data.peerInfo.name, irKey)
         if (removed !== undefined) {
-          routes = routes.filter((r) => !(routeKey(r) === key && r.originNode === item.originNode))
+          routes = nestedMapDelete(routes, data.peerInfo.name, irKey)
           routeChanges.push({ type: 'removed', route: removed })
           if (removed.envoyPort != null) {
-            portOps.push({ type: 'release', routeKey: key, port: removed.envoyPort })
+            portOps.push({ type: 'release', routeKey: routeKey(removed), port: removed.envoyPort })
           }
         }
       }
     }
 
     // Always update lastReceived on the peer, even when no routes changed
-    const peerIdx = state.internal.peers.findIndex((p) => p.name === data.peerInfo.name)
+    const existingPeer = state.internal.peers.get(data.peerInfo.name)
     const peers =
-      peerIdx !== -1
-        ? state.internal.peers.map((p, i) =>
-            i === peerIdx ? { ...p, lastReceived: Date.now() } : p
-          )
+      existingPeer !== undefined
+        ? mapWith(state.internal.peers, data.peerInfo.name, {
+            ...existingPeer,
+            lastReceived: Date.now(),
+          })
         : state.internal.peers
 
-    // No-op: no route changes and peer was unknown (nothing touched)
-    if (routeChanges.length === 0 && peerIdx === -1) {
+    if (routeChanges.length === 0 && existingPeer === undefined) {
       return noChange(state)
     }
 
-    const newState: RouteTable = {
-      ...state,
-      internal: { peers, routes },
-    }
+    const newState: RouteTable = { ...state, internal: { peers, routes } }
     return { prevState: state, newState, portOps, routeChanges }
   }
 
@@ -482,16 +463,13 @@ export class RoutingInformationBase {
     data: InternalProtocolKeepaliveData,
     state: RouteTable
   ): PlanResult {
-    const idx = state.internal.peers.findIndex((p) => p.name === data.peerInfo.name)
-    if (idx === -1) return noChange(state)
-
-    const peers = state.internal.peers.map((p, i) =>
-      i === idx ? { ...p, lastReceived: Date.now() } : p
-    )
-    const newState: RouteTable = {
-      ...state,
-      internal: { ...state.internal, peers },
-    }
+    const existing = state.internal.peers.get(data.peerInfo.name)
+    if (existing === undefined) return noChange(state)
+    const peers = mapWith(state.internal.peers, data.peerInfo.name, {
+      ...existing,
+      lastReceived: Date.now(),
+    })
+    const newState: RouteTable = { ...state, internal: { ...state.internal, peers } }
     return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges: NO_ROUTE_CHANGES }
   }
 
@@ -500,54 +478,55 @@ export class RoutingInformationBase {
   // -------------------------------------------------------------------------
 
   private planTick(data: TickData, state: RouteTable): PlanResult {
-    // Find connected peers whose hold timer has expired
     const expiredPeerNames = new Set<string>()
-    const peers = state.internal.peers.map((p) => {
+    let peers = state.internal.peers
+
+    for (const [name, p] of state.internal.peers) {
       const timerActive = p.connectionStatus === 'connected' && p.holdTime > 0 && p.lastReceived > 0
       if (timerActive && data.now - p.lastReceived > p.holdTime) {
-        expiredPeerNames.add(p.name)
-        return { ...p, connectionStatus: 'closed' as const }
+        expiredPeerNames.add(name)
+        peers = mapWith(peers, name, { ...p, connectionStatus: 'closed' as const })
       }
-      return p
-    })
+    }
 
-    // Find closed peers whose stale routes have exceeded the hold timer grace
-    // period. After a transport-error close, routes are marked stale to allow
-    // reconnect. Once holdTime elapses without reconnect, purge them.
     const stalePeerNames = new Set<string>()
-    for (const p of peers) {
+    for (const [name, p] of peers) {
       if (
         p.connectionStatus === 'closed' &&
         p.holdTime > 0 &&
         p.lastReceived > 0 &&
         data.now - p.lastReceived > p.holdTime
       ) {
-        const hasStaleRoutes = state.internal.routes.some(
-          (r) => r.peer.name === p.name && r.isStale === true
-        )
-        if (hasStaleRoutes) stalePeerNames.add(p.name)
+        const peerRouteMap = state.internal.routes.get(name)
+        if (peerRouteMap) {
+          const hasStaleRoutes = [...peerRouteMap.values()].some((r) => r.isStale === true)
+          if (hasStaleRoutes) stalePeerNames.add(name)
+        }
       }
     }
 
     const purgedPeerNames = new Set([...expiredPeerNames, ...stalePeerNames])
     if (purgedPeerNames.size === 0) return noChange(state)
 
-    const removedRoutes = state.internal.routes.filter((r) => purgedPeerNames.has(r.peer.name))
-    const routes = state.internal.routes.filter((r) => !purgedPeerNames.has(r.peer.name))
+    const removedRoutes: InternalRoute[] = []
+    let routes = state.internal.routes
+    for (const peerName of purgedPeerNames) {
+      const peerRouteMap = routes.get(peerName)
+      if (peerRouteMap) {
+        removedRoutes.push(...peerRouteMap.values())
+        routes = nestedMapDeleteOuter(routes, peerName)
+      }
+    }
 
     const portOps: PortOperation[] = removedRoutes
       .filter((r) => r.envoyPort != null)
       .map((r) => ({ type: 'release' as const, routeKey: routeKey(r), port: r.envoyPort! }))
-
     const routeChanges: RouteChange[] = removedRoutes.map((r) => ({
       type: 'removed' as const,
       route: r,
     }))
 
-    const newState: RouteTable = {
-      ...state,
-      internal: { peers, routes },
-    }
+    const newState: RouteTable = { ...state, internal: { peers, routes } }
     return { prevState: state, newState, portOps, routeChanges }
   }
 }

--- a/packages/routing/src/v2/state.ts
+++ b/packages/routing/src/v2/state.ts
@@ -1,4 +1,5 @@
 import type { DataChannelDefinition } from './datachannel.js'
+import { routeKey } from './datachannel.js'
 import { z } from 'zod'
 import { NodeConfigSchema } from '@catalyst/config'
 
@@ -26,17 +27,22 @@ export type InternalRoute = DataChannelDefinition & {
 
 export type RouteTable = {
   local: {
-    routes: DataChannelDefinition[]
+    routes: Map<string, DataChannelDefinition>
   }
   internal: {
-    peers: PeerRecord[]
-    routes: InternalRoute[]
+    peers: Map<string, PeerRecord>
+    routes: Map<string, Map<string, InternalRoute>>
   }
 }
 
 export function newRouteTable(): RouteTable {
   return {
-    local: { routes: [] },
-    internal: { peers: [], routes: [] },
+    local: { routes: new Map() },
+    internal: { peers: new Map(), routes: new Map() },
   }
+}
+
+/** Composite key for internal routes in the nested Map. */
+export function internalRouteKey(route: Pick<InternalRoute, 'name' | 'originNode'>): string {
+  return `${routeKey(route)}:${route.originNode}`
 }

--- a/packages/routing/src/v2/views.ts
+++ b/packages/routing/src/v2/views.ts
@@ -54,11 +54,17 @@ export function internalRouteToDataChannel(route: InternalRoute): DataChannelDef
 
 /** Returns the full route table safe for API exposure. */
 export function routeTableToPublic(state: RouteTable): PublicRouteTable {
+  const internalRoutes: PublicInternalRoute[] = []
+  for (const innerMap of state.internal.routes.values()) {
+    for (const r of innerMap.values()) {
+      internalRoutes.push(internalRouteToPublic(r))
+    }
+  }
   return {
     routes: {
-      local: state.local.routes,
-      internal: state.internal.routes.map(internalRouteToPublic),
+      local: [...state.local.routes.values()],
+      internal: internalRoutes,
     },
-    peers: state.internal.peers.map(peerToPublic),
+    peers: [...state.internal.peers.values()].map(peerToPublic),
   }
 }

--- a/packages/routing/tests/v2/rib-health-update.test.ts
+++ b/packages/routing/tests/v2/rib-health-update.test.ts
@@ -8,18 +8,17 @@ function makeRib(state?: RouteTable) {
 }
 
 function stateWithRoute(overrides: Record<string, unknown> = {}): RouteTable {
+  const route = {
+    name: 'books-api',
+    protocol: 'http:graphql' as const,
+    endpoint: 'http://books:4001/graphql',
+    ...overrides,
+  }
   return {
     local: {
-      routes: [
-        {
-          name: 'books-api',
-          protocol: 'http:graphql' as const,
-          endpoint: 'http://books:4001/graphql',
-          ...overrides,
-        },
-      ],
+      routes: new Map([['books-api', route]]),
     },
-    internal: { peers: [], routes: [] },
+    internal: { peers: new Map(), routes: new Map() },
   }
 }
 
@@ -33,14 +32,14 @@ describe('planLocalRouteHealthUpdate', () => {
           name: 'books-api',
           healthStatus: 'up' as const,
           responseTimeMs: 12,
-          lastChecked: '2026-03-17T00:00:00Z',
+          lastCheckedAt: '2026-03-17T00:00:00Z',
         },
       },
       rib.state
     )
     expect(rib.stateChanged(plan)).toBe(true)
-    expect(plan.newState.local.routes[0].healthStatus).toBe('up')
-    expect(plan.newState.local.routes[0].responseTimeMs).toBe(12)
+    expect(plan.newState.local.routes.get('books-api')!.healthStatus).toBe('up')
+    expect(plan.newState.local.routes.get('books-api')!.responseTimeMs).toBe(12)
     expect(plan.routeChanges).toHaveLength(1)
     expect(plan.routeChanges[0].type).toBe('updated')
   })
@@ -54,7 +53,7 @@ describe('planLocalRouteHealthUpdate', () => {
           name: 'no-such',
           healthStatus: 'up' as const,
           responseTimeMs: 5,
-          lastChecked: '2026-03-17T00:00:00Z',
+          lastCheckedAt: '2026-03-17T00:00:00Z',
         },
       },
       rib.state
@@ -67,7 +66,7 @@ describe('planLocalRouteHealthUpdate', () => {
       stateWithRoute({
         healthStatus: 'up',
         responseTimeMs: 12,
-        lastChecked: '2026-03-17T00:00:00Z',
+        lastCheckedAt: '2026-03-17T00:00:00Z',
       })
     )
     const plan = rib.plan(
@@ -77,7 +76,7 @@ describe('planLocalRouteHealthUpdate', () => {
           name: 'books-api',
           healthStatus: 'up' as const,
           responseTimeMs: 12,
-          lastChecked: '2026-03-17T00:00:00Z',
+          lastCheckedAt: '2026-03-17T00:00:00Z',
         },
       },
       rib.state
@@ -94,12 +93,12 @@ describe('planLocalRouteHealthUpdate', () => {
           name: 'books-api',
           healthStatus: 'down' as const,
           responseTimeMs: null,
-          lastChecked: '2026-03-17T00:00:00Z',
+          lastCheckedAt: '2026-03-17T00:00:00Z',
         },
       },
       rib.state
     )
-    const route = plan.newState.local.routes[0]
+    const route = plan.newState.local.routes.get('books-api')!
     expect(route.region).toBe('us-east')
     expect(route.tags).toEqual(['prod'])
     expect(route.healthStatus).toBe('down')
@@ -114,7 +113,7 @@ describe('planLocalRouteHealthUpdate', () => {
           name: 'books-api',
           healthStatus: 'up' as const,
           responseTimeMs: 5,
-          lastChecked: '2026-03-17T00:00:00Z',
+          lastCheckedAt: '2026-03-17T00:00:00Z',
         },
       },
       rib.state

--- a/packages/routing/tests/v2/rib/rib.test.ts
+++ b/packages/routing/tests/v2/rib/rib.test.ts
@@ -5,7 +5,7 @@ import { newRouteTable } from '../../../src/v2/state.js'
 import { Actions } from '../../../src/v2/action-types.js'
 import { CloseCodes } from '../../../src/v2/close-codes.js'
 import type { Action } from '../../../src/v2/schema.js'
-import type { PeerInfo, RouteTable } from '../../../src/v2/state.js'
+import type { PeerInfo, RouteTable, InternalRoute } from '../../../src/v2/state.js'
 import type { DataChannelDefinition } from '../../../src/v2/datachannel.js'
 
 // ---------------------------------------------------------------------------
@@ -89,6 +89,15 @@ function makeTick(now: number): Action {
   return { action: Actions.Tick, data: { now } }
 }
 
+// Helper: flatten all internal routes from the nested Map structure
+function allInternalRoutes(state: RouteTable): InternalRoute[] {
+  const routes: InternalRoute[] = []
+  for (const innerMap of state.internal.routes.values()) {
+    routes.push(...innerMap.values())
+  }
+  return routes
+}
+
 // Helper: run plan+commit in one shot
 function apply(rib: RoutingInformationBase, action: Action) {
   const plan = rib.plan(action, rib.state)
@@ -119,7 +128,7 @@ describe('Peer lifecycle', () => {
     const plan = apply(rib, makeLocalPeerCreate(peer))
 
     expect(plan.prevState).not.toBe(plan.newState)
-    const added = rib.state.internal.peers.find((p) => p.name === 'peer-b')
+    const added = rib.state.internal.peers.get('peer-b')
     expect(added).toBeDefined()
     expect(added!.connectionStatus).toBe('initializing')
     expect(added!.holdTime).toBe(90_000)
@@ -148,7 +157,7 @@ describe('Peer lifecycle', () => {
     const plan = apply(rib, makeLocalPeerUpdate(updatedPeer))
 
     expect(plan.prevState).not.toBe(plan.newState)
-    const found = rib.state.internal.peers.find((p) => p.name === 'peer-b')
+    const found = rib.state.internal.peers.get('peer-b')
     expect(found!.domains).toEqual(['updated.com'])
     expect(found!.labels).toEqual({ env: 'prod' })
   })
@@ -156,7 +165,7 @@ describe('Peer lifecycle', () => {
   it('LocalPeerUpdate preserves runtime-only fields (connectionStatus, holdTime, lastReceived)', () => {
     const { rib, peer } = ribWithConnectedPeer('node-a', 'peer-b')
     // Peer should now be connected with lastReceived > 0
-    const connectedPeer = rib.state.internal.peers.find((p) => p.name === 'peer-b')!
+    const connectedPeer = rib.state.internal.peers.get('peer-b')!
     const originalStatus = connectedPeer.connectionStatus
     const originalHoldTime = connectedPeer.holdTime
     const originalLastReceived = connectedPeer.lastReceived
@@ -164,7 +173,7 @@ describe('Peer lifecycle', () => {
     const updatedPeer: PeerInfo = { ...peer, domains: ['new.com'] }
     apply(rib, makeLocalPeerUpdate(updatedPeer))
 
-    const after = rib.state.internal.peers.find((p) => p.name === 'peer-b')!
+    const after = rib.state.internal.peers.get('peer-b')!
     expect(after.connectionStatus).toBe(originalStatus)
     expect(after.holdTime).toBe(originalHoldTime)
     expect(after.lastReceived).toBe(originalLastReceived)
@@ -185,7 +194,7 @@ describe('Peer lifecycle', () => {
     const plan = apply(rib, makeLocalPeerDelete('peer-b'))
 
     expect(plan.prevState).not.toBe(plan.newState)
-    expect(rib.state.internal.peers.find((p) => p.name === 'peer-b')).toBeUndefined()
+    expect(rib.state.internal.peers.get('peer-b')).toBeUndefined()
   })
 
   it('LocalPeerDelete removes all routes from that peer', () => {
@@ -197,11 +206,11 @@ describe('Peer lifecycle', () => {
         { action: 'add', route: makeRoute('svc-x'), nodePath: ['peer-b'], originNode: 'peer-b' },
       ])
     )
-    expect(rib.state.internal.routes.some((r) => r.peer.name === 'peer-b')).toBe(true)
+    expect(allInternalRoutes(rib.state).some((r) => r.peer.name === 'peer-b')).toBe(true)
 
     apply(rib, makeLocalPeerDelete('peer-b'))
 
-    expect(rib.state.internal.routes.some((r) => r.peer.name === 'peer-b')).toBe(false)
+    expect(allInternalRoutes(rib.state).some((r) => r.peer.name === 'peer-b')).toBe(false)
   })
 
   it('LocalPeerDelete generates port release ops for routes with envoyPort', () => {
@@ -238,7 +247,7 @@ describe('Route lifecycle', () => {
     const plan = apply(rib, makeLocalRouteCreate(route))
 
     expect(plan.prevState).not.toBe(plan.newState)
-    expect(rib.state.local.routes.find((r) => r.name === 'my-svc')).toBeDefined()
+    expect(rib.state.local.routes.get('my-svc')).toBeDefined()
   })
 
   it('LocalRouteCreate emits added routeChange', () => {
@@ -267,7 +276,7 @@ describe('Route lifecycle', () => {
     const plan = apply(rib, makeLocalRouteDelete(route))
 
     expect(plan.prevState).not.toBe(plan.newState)
-    expect(rib.state.local.routes.find((r) => r.name === 'my-svc')).toBeUndefined()
+    expect(rib.state.local.routes.get('my-svc')).toBeUndefined()
   })
 
   it('LocalRouteDelete generates port release op if route has envoyPort', () => {
@@ -314,7 +323,7 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
       ])
     )
 
-    const stored = rib.state.internal.routes.find((r) => r.name === 'svc-1')
+    const stored = allInternalRoutes(rib.state).find((r) => r.name === 'svc-1')
     expect(stored).toBeDefined()
     expect(stored!.peer.name).toBe('peer-b')
     expect(stored!.nodePath).toEqual(['peer-b'])
@@ -334,7 +343,7 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
       ])
     )
 
-    expect(rib.state.internal.routes.find((r) => r.name === 'svc-loop')).toBeUndefined()
+    expect(allInternalRoutes(rib.state).find((r) => r.name === 'svc-loop')).toBeUndefined()
     // routeChanges should be empty (route was skipped)
     expect(plan.routeChanges).toHaveLength(0)
   })
@@ -349,7 +358,7 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
         { action: 'add', route, nodePath: ['peer-b'], originNode: 'peer-b' },
       ])
     )
-    expect(rib.state.internal.routes.find((r) => r.name === 'svc-1')).toBeDefined()
+    expect(allInternalRoutes(rib.state).find((r) => r.name === 'svc-1')).toBeDefined()
 
     const plan = apply(
       rib,
@@ -358,7 +367,7 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
       ])
     )
 
-    expect(rib.state.internal.routes.find((r) => r.name === 'svc-1')).toBeUndefined()
+    expect(allInternalRoutes(rib.state).find((r) => r.name === 'svc-1')).toBeUndefined()
     expect(plan.routeChanges.some((c) => c.type === 'removed')).toBe(true)
   })
 
@@ -399,7 +408,7 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
       ])
     )
 
-    const found = rib.state.internal.peers.find((p) => p.name === 'peer-b')
+    const found = rib.state.internal.peers.get('peer-b')
     expect(found!.lastReceived).toBe(fixedNow + 5000)
 
     vi.restoreAllMocks()
@@ -416,7 +425,7 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
         { action: 'add', route, nodePath: ['peer-c', 'peer-b'], originNode: 'peer-c' },
       ])
     )
-    const first = rib.state.internal.routes.find((r) => r.name === 'svc-1')
+    const first = allInternalRoutes(rib.state).find((r) => r.name === 'svc-1')
     expect(first!.nodePath).toHaveLength(2)
 
     // Second: shorter path (1 hop) — should replace
@@ -427,7 +436,7 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
       ])
     )
 
-    const updated = rib.state.internal.routes.find((r) => r.name === 'svc-1')
+    const updated = allInternalRoutes(rib.state).find((r) => r.name === 'svc-1')
     expect(updated!.nodePath).toHaveLength(1)
     expect(plan.routeChanges.some((c) => c.type === 'updated')).toBe(true)
   })
@@ -452,7 +461,7 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
       ])
     )
 
-    const stored = rib.state.internal.routes.find((r) => r.name === 'svc-1')
+    const stored = allInternalRoutes(rib.state).find((r) => r.name === 'svc-1')
     expect(stored!.nodePath).toHaveLength(1)
     // No route changes should be emitted for a rejected longer path
     expect(plan.routeChanges).toHaveLength(0)
@@ -472,7 +481,7 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
     const plan = apply(rib, makeProtocolUpdate(peer, updates))
 
     // All 15 routes should be installed
-    const installed = rib.state.internal.routes.filter((r) => r.name.startsWith('batch-svc-'))
+    const installed = allInternalRoutes(rib.state).filter((r) => r.name.startsWith('batch-svc-'))
     expect(installed).toHaveLength(15)
     expect(plan.routeChanges).toHaveLength(15)
     expect(plan.routeChanges.every((c) => c.type === 'added')).toBe(true)
@@ -489,7 +498,7 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
       originNode: 'peer-b',
     }))
     apply(rib, makeProtocolUpdate(peer, seedRoutes))
-    expect(rib.state.internal.routes).toHaveLength(5)
+    expect(allInternalRoutes(rib.state)).toHaveLength(5)
 
     // Single batch: remove 3 existing + add 7 new
     const batchUpdates = [
@@ -510,7 +519,7 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
     const plan = apply(rib, makeProtocolUpdate(peer, batchUpdates))
 
     // 5 existing - 3 removed + 7 new = 9 routes
-    expect(rib.state.internal.routes).toHaveLength(9)
+    expect(allInternalRoutes(rib.state)).toHaveLength(9)
     expect(plan.routeChanges).toHaveLength(10) // 3 removed + 7 added
 
     const removals = plan.routeChanges.filter((c) => c.type === 'removed')
@@ -546,8 +555,8 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
     const plan = apply(rib, makeProtocolUpdate(peer, batchUpdates))
 
     // Only 2 valid routes installed, looped one skipped
-    expect(rib.state.internal.routes).toHaveLength(2)
-    expect(rib.state.internal.routes.map((r) => r.name).sort()).toEqual(['valid-1', 'valid-2'])
+    expect(allInternalRoutes(rib.state)).toHaveLength(2)
+    expect(allInternalRoutes(rib.state).map((r) => r.name).sort()).toEqual(['valid-1', 'valid-2'])
     expect(plan.routeChanges).toHaveLength(2)
   })
 
@@ -573,7 +582,7 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
       ])
     )
 
-    const stored = rib.state.internal.routes.find((r) => r.name === 'svc-1')
+    const stored = allInternalRoutes(rib.state).find((r) => r.name === 'svc-1')
     expect(stored).toBeDefined()
     expect(stored!.isStale).toBe(false)
     expect(plan.routeChanges.some((c) => c.type === 'updated')).toBe(true)
@@ -600,7 +609,7 @@ describe('Peer connection', () => {
     apply(rib, makeLocalPeerCreate(peer))
     apply(rib, makeProtocolOpen(peer))
 
-    const found = rib.state.internal.peers.find((p) => p.name === 'peer-b')!
+    const found = rib.state.internal.peers.get('peer-b')!
     expect(found.connectionStatus).toBe('connected')
     expect(found.lastReceived).toBe(fixedNow)
 
@@ -614,7 +623,7 @@ describe('Peer connection', () => {
     // Default holdTime is 90_000 ms. Remote offers 30_000 ms — should take min.
     apply(rib, makeProtocolOpen(peer, 30_000))
 
-    const found = rib.state.internal.peers.find((p) => p.name === 'peer-b')!
+    const found = rib.state.internal.peers.get('peer-b')!
     expect(found.holdTime).toBe(30_000)
   })
 
@@ -625,7 +634,7 @@ describe('Peer connection', () => {
     // Local default 90_000, remote offers 120_000 — should keep 90_000
     apply(rib, makeProtocolOpen(peer, 120_000))
 
-    const found = rib.state.internal.peers.find((p) => p.name === 'peer-b')!
+    const found = rib.state.internal.peers.get('peer-b')!
     expect(found.holdTime).toBe(90_000)
   })
 
@@ -635,7 +644,7 @@ describe('Peer connection', () => {
     apply(rib, makeLocalPeerCreate(peer))
     apply(rib, makeProtocolOpen(peer, undefined))
 
-    const found = rib.state.internal.peers.find((p) => p.name === 'peer-b')!
+    const found = rib.state.internal.peers.get('peer-b')!
     expect(found.holdTime).toBe(90_000)
   })
 
@@ -648,7 +657,7 @@ describe('Peer connection', () => {
     apply(rib, makeLocalPeerCreate(peer))
     apply(rib, makeProtocolConnected(peer))
 
-    const found = rib.state.internal.peers.find((p) => p.name === 'peer-b')!
+    const found = rib.state.internal.peers.get('peer-b')!
     expect(found.connectionStatus).toBe('connected')
     expect(found.lastConnected).toBe(fixedNow)
     expect(found.lastReceived).toBe(fixedNow)
@@ -666,14 +675,14 @@ describe('Peer connection', () => {
     // Negotiate holdTime down to 30s via Open
     apply(rib, makeProtocolOpen(peer, 30_000))
 
-    const afterOpen = rib.state.internal.peers.find((p) => p.name === 'peer-b')!
+    const afterOpen = rib.state.internal.peers.get('peer-b')!
     expect(afterOpen.holdTime).toBe(30_000)
 
     // Simulate disconnect + reconnect
     apply(rib, makeProtocolClose(peer, CloseCodes.TRANSPORT_ERROR))
     apply(rib, makeProtocolConnected(peer))
 
-    const afterReconnect = rib.state.internal.peers.find((p) => p.name === 'peer-b')!
+    const afterReconnect = rib.state.internal.peers.get('peer-b')!
     // holdTime should be reset to default so it can be re-negotiated
     expect(afterReconnect.holdTime).toBe(90_000)
     expect(afterReconnect.lastSent).toBe(0)
@@ -700,8 +709,8 @@ describe('Peer connection', () => {
 
     apply(rib, makeProtocolClose(peer, CloseCodes.NORMAL))
 
-    expect(rib.state.internal.routes.find((r) => r.name === 'svc-1')).toBeUndefined()
-    expect(rib.state.internal.peers.find((p) => p.name === 'peer-b')!.connectionStatus).toBe(
+    expect(allInternalRoutes(rib.state).find((r) => r.name === 'svc-1')).toBeUndefined()
+    expect(rib.state.internal.peers.get('peer-b')!.connectionStatus).toBe(
       'closed'
     )
   })
@@ -718,7 +727,7 @@ describe('Peer connection', () => {
 
     const plan = apply(rib, makeProtocolClose(peer, CloseCodes.TRANSPORT_ERROR))
 
-    const stale = rib.state.internal.routes.find((r) => r.name === 'svc-1')
+    const stale = allInternalRoutes(rib.state).find((r) => r.name === 'svc-1')
     expect(stale).toBeDefined()
     expect(stale!.isStale).toBe(true)
     // No port ops for graceful restart
@@ -738,7 +747,7 @@ describe('Peer connection', () => {
 
     apply(rib, makeProtocolClose(peer, CloseCodes.HOLD_EXPIRED))
 
-    expect(rib.state.internal.routes.find((r) => r.name === 'svc-2')).toBeUndefined()
+    expect(allInternalRoutes(rib.state).find((r) => r.name === 'svc-2')).toBeUndefined()
   })
 
   it('InternalProtocolClose with ADMIN_SHUTDOWN removes routes', () => {
@@ -753,7 +762,7 @@ describe('Peer connection', () => {
 
     apply(rib, makeProtocolClose(peer, CloseCodes.ADMIN_SHUTDOWN))
 
-    expect(rib.state.internal.routes.find((r) => r.name === 'svc-3')).toBeUndefined()
+    expect(allInternalRoutes(rib.state).find((r) => r.name === 'svc-3')).toBeUndefined()
   })
 
   it('InternalProtocolClose generates port release ops for removed routes', () => {
@@ -830,8 +839,8 @@ describe('Tick', () => {
     const plan = apply(rib, makeTick(baseNow + 11_000))
 
     expect(plan.prevState).not.toBe(plan.newState)
-    expect(rib.state.internal.routes.find((r) => r.name === 'svc-1')).toBeUndefined()
-    expect(rib.state.internal.peers.find((p) => p.name === 'peer-b')!.connectionStatus).toBe(
+    expect(allInternalRoutes(rib.state).find((r) => r.name === 'svc-1')).toBeUndefined()
+    expect(rib.state.internal.peers.get('peer-b')!.connectionStatus).toBe(
       'closed'
     )
   })
@@ -898,7 +907,7 @@ describe('Tick', () => {
     const { rib, peer } = ribWithConnectedPeer('node-a', 'peer-b')
     // Close the peer normally — routes are removed, not stale
     apply(rib, makeProtocolClose(peer, CloseCodes.NORMAL))
-    expect(rib.state.internal.peers.find((p) => p.name === 'peer-b')!.connectionStatus).toBe(
+    expect(rib.state.internal.peers.get('peer-b')!.connectionStatus).toBe(
       'closed'
     )
 
@@ -928,8 +937,8 @@ describe('Tick', () => {
 
     // Transport error — routes become stale, peer set to closed
     apply(rib, makeProtocolClose(peer, CloseCodes.TRANSPORT_ERROR))
-    expect(rib.state.internal.routes.find((r) => r.name === 'svc-1')?.isStale).toBe(true)
-    expect(rib.state.internal.peers.find((p) => p.name === 'peer-b')!.connectionStatus).toBe(
+    expect(allInternalRoutes(rib.state).find((r) => r.name === 'svc-1')?.isStale).toBe(true)
+    expect(rib.state.internal.peers.get('peer-b')!.connectionStatus).toBe(
       'closed'
     )
 
@@ -941,7 +950,7 @@ describe('Tick', () => {
 
     // Tick after holdTime elapses — stale routes should be purged
     const plan = apply(rib, makeTick(baseNow + 11_000))
-    expect(rib.state.internal.routes.find((r) => r.name === 'svc-1')).toBeUndefined()
+    expect(allInternalRoutes(rib.state).find((r) => r.name === 'svc-1')).toBeUndefined()
     expect(plan.routeChanges).toHaveLength(1)
     expect(plan.routeChanges[0].type).toBe('removed')
   })
@@ -982,15 +991,13 @@ describe('Keepalive', () => {
     vi.spyOn(Date, 'now').mockReturnValue(baseNow)
 
     const { rib, peer } = ribWithConnectedPeer('node-a', 'peer-b')
-    const initialLastReceived = rib.state.internal.peers.find(
-      (p) => p.name === 'peer-b'
-    )!.lastReceived
+    const initialLastReceived = rib.state.internal.peers.get('peer-b')!.lastReceived
 
     vi.spyOn(Date, 'now').mockReturnValue(baseNow + 30_000)
     const plan = apply(rib, makeProtocolKeepalive(peer))
 
     expect(plan.prevState).not.toBe(plan.newState)
-    const found = rib.state.internal.peers.find((p) => p.name === 'peer-b')!
+    const found = rib.state.internal.peers.get('peer-b')!
     expect(found.lastReceived).toBe(baseNow + 30_000)
     expect(found.lastReceived).toBeGreaterThan(initialLastReceived)
 
@@ -1036,11 +1043,11 @@ describe('Plan purity', () => {
     // Deep-freeze the state object to catch any mutations
     const frozen = Object.freeze({
       ...state,
-      local: Object.freeze({ ...state.local, routes: Object.freeze([...state.local.routes]) }),
+      local: Object.freeze({ ...state.local, routes: state.local.routes }),
       internal: Object.freeze({
         ...state.internal,
-        peers: Object.freeze([...state.internal.peers]),
-        routes: Object.freeze([...state.internal.routes]),
+        peers: state.internal.peers,
+        routes: state.internal.routes,
       }),
     }) as RouteTable
 
@@ -1058,9 +1065,11 @@ describe('Plan purity', () => {
     const plan2 = rib.plan(action, state)
 
     // Both plans should produce structurally equivalent state
-    expect(plan1.newState.internal.peers[0].name).toBe(plan2.newState.internal.peers[0].name)
-    expect(plan1.newState.internal.peers[0].connectionStatus).toBe(
-      plan2.newState.internal.peers[0].connectionStatus
+    expect(plan1.newState.internal.peers.get('peer-b')?.name).toBe(
+      plan2.newState.internal.peers.get('peer-b')?.name
+    )
+    expect(plan1.newState.internal.peers.get('peer-b')?.connectionStatus).toBe(
+      plan2.newState.internal.peers.get('peer-b')?.connectionStatus
     )
   })
 
@@ -1140,14 +1149,18 @@ describe('Journal integration', () => {
     }
 
     // Local routes should match
-    expect(freshRib.state.local.routes).toHaveLength(rib.state.local.routes.length)
-    expect(freshRib.state.local.routes[0].name).toBe(rib.state.local.routes[0].name)
+    expect(freshRib.state.local.routes.size).toBe(rib.state.local.routes.size)
+    expect(freshRib.state.local.routes.get('svc-1')?.name).toBe(
+      rib.state.local.routes.get('svc-1')?.name
+    )
 
     // Internal peers should match in name and status
-    expect(freshRib.state.internal.peers).toHaveLength(rib.state.internal.peers.length)
-    expect(freshRib.state.internal.peers[0].name).toBe(rib.state.internal.peers[0].name)
-    expect(freshRib.state.internal.peers[0].connectionStatus).toBe(
-      rib.state.internal.peers[0].connectionStatus
+    expect(freshRib.state.internal.peers.size).toBe(rib.state.internal.peers.size)
+    expect(freshRib.state.internal.peers.get('peer-b')?.name).toBe(
+      rib.state.internal.peers.get('peer-b')?.name
+    )
+    expect(freshRib.state.internal.peers.get('peer-b')?.connectionStatus).toBe(
+      rib.state.internal.peers.get('peer-b')?.connectionStatus
     )
   })
 
@@ -1182,8 +1195,8 @@ describe('Journal integration', () => {
 
     apply(rib, makeLocalPeerCreate(peer))
 
-    expect(rib.state.internal.peers).toHaveLength(1)
-    expect(rib.state.internal.peers[0].name).toBe('peer-b')
+    expect(rib.state.internal.peers.size).toBe(1)
+    expect(rib.state.internal.peers.get('peer-b')).toBeDefined()
   })
 })
 
@@ -1215,13 +1228,13 @@ describe('Multi-peer scenarios', () => {
       ])
     )
 
-    expect(rib.state.internal.routes).toHaveLength(2)
+    expect(allInternalRoutes(rib.state)).toHaveLength(2)
 
     // Closing peer-b should only remove svc-b
     apply(rib, makeProtocolClose(peerB, CloseCodes.NORMAL))
 
-    expect(rib.state.internal.routes).toHaveLength(1)
-    expect(rib.state.internal.routes[0].name).toBe('svc-c')
+    expect(allInternalRoutes(rib.state)).toHaveLength(1)
+    expect(allInternalRoutes(rib.state)[0].name).toBe('svc-c')
   })
 
   it('LocalPeerDelete does not affect routes from other peers', () => {
@@ -1249,10 +1262,10 @@ describe('Multi-peer scenarios', () => {
 
     apply(rib, makeLocalPeerDelete('peer-b'))
 
-    expect(rib.state.internal.peers).toHaveLength(1)
-    expect(rib.state.internal.peers[0].name).toBe('peer-c')
-    expect(rib.state.internal.routes).toHaveLength(1)
-    expect(rib.state.internal.routes[0].name).toBe('svc-c')
+    expect(rib.state.internal.peers.size).toBe(1)
+    expect(rib.state.internal.peers.get('peer-c')).toBeDefined()
+    expect(allInternalRoutes(rib.state)).toHaveLength(1)
+    expect(allInternalRoutes(rib.state)[0].name).toBe('svc-c')
   })
 })
 
@@ -1263,11 +1276,12 @@ describe('Multi-peer scenarios', () => {
 describe('initialState option', () => {
   it('uses provided initialState instead of empty table', () => {
     const preset = newRouteTable()
-    preset.local.routes.push(makeRoute('pre-existing'))
+    const route = makeRoute('pre-existing')
+    preset.local.routes.set(route.name, route)
 
     const rib = new RoutingInformationBase({ nodeId: 'node-a', initialState: preset })
 
-    expect(rib.state.local.routes).toHaveLength(1)
-    expect(rib.state.local.routes[0].name).toBe('pre-existing')
+    expect(rib.state.local.routes.size).toBe(1)
+    expect(rib.state.local.routes.get('pre-existing')?.name).toBe('pre-existing')
   })
 })

--- a/packages/routing/tests/v2/views.test.ts
+++ b/packages/routing/tests/v2/views.test.ts
@@ -33,25 +33,32 @@ function makeInternalRoute(overrides: Partial<InternalRoute> = {}): InternalRout
 }
 
 function makeRouteTable(): RouteTable {
+  const routeA = makeInternalRoute()
+  const routeB = makeInternalRoute({
+    name: 'route-b',
+    peer: { name: 'peer-2', domains: ['example.com'] },
+    nodePath: ['peer-2'],
+    originNode: 'peer-2',
+    isStale: true,
+  })
   return {
     local: {
-      routes: [{ name: 'local-route', protocol: 'http' as const, endpoint: 'http://local:8080' }],
+      routes: new Map([
+        [
+          'local-route',
+          { name: 'local-route', protocol: 'http' as const, endpoint: 'http://local:8080' },
+        ],
+      ]),
     },
     internal: {
-      peers: [
-        makePeerRecord({ peerToken: 'secret-1' }),
-        makePeerRecord({ name: 'peer-2', peerToken: 'secret-2' }),
-      ],
-      routes: [
-        makeInternalRoute(),
-        makeInternalRoute({
-          name: 'route-b',
-          peer: { name: 'peer-2', domains: ['example.com'] },
-          nodePath: ['peer-2'],
-          originNode: 'peer-2',
-          isStale: true,
-        }),
-      ],
+      peers: new Map([
+        ['peer-1', makePeerRecord({ peerToken: 'secret-1' })],
+        ['peer-2', makePeerRecord({ name: 'peer-2', peerToken: 'secret-2' })],
+      ]),
+      routes: new Map([
+        ['peer-1', new Map([[`${routeA.name}:${routeA.originNode}`, routeA]])],
+        ['peer-2', new Map([[`${routeB.name}:${routeB.originNode}`, routeB]])],
+      ]),
     },
   }
 }
@@ -128,7 +135,7 @@ describe('routeTableToPublic', () => {
       expect(route).not.toHaveProperty('isStale')
     }
 
-    expect(pub.routes.local).toEqual(makeRouteTable().local.routes)
+    expect(pub.routes.local).toEqual([...makeRouteTable().local.routes.values()])
   })
 
   it('preserves data integrity', () => {


### PR DESCRIPTION
local.routes: DataChannelDefinition[] → Map<string, DataChannelDefinition>
internal.peers: PeerRecord[] → Map<string, PeerRecord>
internal.routes: InternalRoute[] → Map<string, Map<string, InternalRoute>>

RIB planner methods rewritten to use map-helpers (mapWith, mapWithout,
nestedMapGet, nestedMapSet, nestedMapDelete, nestedMapDeleteOuter).
Views updated to iterate Maps.