### PR TITLE
refactor(orchestrator): update consumers for Map-based RouteTable

### DIFF
--- a/apps/orchestrator/src/v2/adapter-health.ts
+++ b/apps/orchestrator/src/v2/adapter-health.ts
@@ -6,34 +6,23 @@ const logger = getLogger(['catalyst', 'orchestrator', 'health'])
 export interface AdapterHealth {
   healthStatus: 'up' | 'down'
   responseTimeMs: number | null
-  lastChecked: string
+  lastCheckedAt: string
 }
 
-/** Defaults match the Zod schema in @catalyst/config (single source of truth). */
-const DEFAULT_INTERVAL_MS = 30_000
-const DEFAULT_TIMEOUT_MS = 3_000
-
 interface AdapterHealthCheckerOptions {
-  intervalMs?: number
-  timeoutMs?: number
+  intervalMs: number
+  timeoutMs: number
   dispatchFn?: (action: { action: string; data: Record<string, unknown> }) => Promise<unknown>
 }
 
 export class AdapterHealthChecker {
-  private readonly options: Required<
-    Pick<AdapterHealthCheckerOptions, 'intervalMs' | 'timeoutMs'>
-  > &
-    Pick<AdapterHealthCheckerOptions, 'dispatchFn'>
+  private readonly options: AdapterHealthCheckerOptions
   private readonly healthMap = new Map<string, AdapterHealth>()
   private interval: ReturnType<typeof setInterval> | undefined
   private running = false
 
   constructor(options: AdapterHealthCheckerOptions) {
-    this.options = {
-      intervalMs: options.intervalMs ?? DEFAULT_INTERVAL_MS,
-      timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-      dispatchFn: options.dispatchFn,
-    }
+    this.options = options
   }
 
   /** Start periodic health checks against the provided route source. */
@@ -71,7 +60,7 @@ export class AdapterHealthChecker {
       if (health) {
         route.healthStatus = health.healthStatus
         route.responseTimeMs = health.responseTimeMs
-        route.lastChecked = health.lastChecked
+        route.lastCheckedAt = health.lastCheckedAt
       }
     }
     return routes
@@ -143,7 +132,7 @@ export class AdapterHealthChecker {
     this.healthMap.set(name, {
       healthStatus,
       responseTimeMs,
-      lastChecked: new Date().toISOString(),
+      lastCheckedAt: new Date().toISOString(),
     })
   }
 
@@ -159,7 +148,7 @@ export class AdapterHealthChecker {
           name,
           healthStatus: newHealth.healthStatus,
           responseTimeMs: newHealth.responseTimeMs,
-          lastChecked: newHealth.lastChecked,
+          lastCheckedAt: newHealth.lastCheckedAt,
         },
       })
       .catch((error) => {

--- a/apps/orchestrator/src/v2/bus.ts
+++ b/apps/orchestrator/src/v2/bus.ts
@@ -180,7 +180,7 @@ export class OrchestratorBus {
           'catalyst.orchestrator.action.state_changed': true,
           'catalyst.orchestrator.route.change_count': plan.routeChanges.length,
           'catalyst.orchestrator.route.total':
-            committed.local.routes.length + committed.internal.routes.length,
+            committed.local.routes.size + [...committed.internal.routes.values()].reduce((n, m) => n + m.size, 0),
         })
 
         if (plan.routeChanges.length > 0) {
@@ -202,7 +202,7 @@ export class OrchestratorBus {
             'catalyst.orchestrator.route.modified': counts.modified,
             'catalyst.orchestrator.route.trigger': action.action,
             'catalyst.orchestrator.route.total':
-              committed.local.routes.length + committed.internal.routes.length,
+              committed.local.routes.size + [...committed.internal.routes.values()].reduce((n, m) => n + m.size, 0),
           })
         }
 
@@ -227,7 +227,7 @@ export class OrchestratorBus {
     if (action.action !== Actions.InternalProtocolUpdate) return action
     if (this.routePolicy === undefined) return action
 
-    const peer = this.rib.state.internal.peers.find((p) => p.name === action.data.peerInfo.name)
+    const peer = this.rib.state.internal.peers.get(action.data.peerInfo.name)
     if (peer === undefined) return action
 
     const updates = action.data.update.updates
@@ -284,7 +284,9 @@ export class OrchestratorBus {
     plan: PlanResult,
     state: RouteTable
   ): Promise<void> {
-    const connectedPeers = state.internal.peers.filter((p) => p.connectionStatus === 'connected')
+    const connectedPeers = [...state.internal.peers.values()].filter(
+      (p) => p.connectionStatus === 'connected'
+    )
 
     // Initial sync: when a peer connects (outbound dial succeeded), send all
     // known routes so the session starts with a full table dump.
@@ -310,7 +312,7 @@ export class OrchestratorBus {
     // Close notification: when a peer is deleted, notify it before withdrawals.
     // Uses prevState because the peer is already removed from committed state.
     if (action.action === Actions.LocalPeerDelete) {
-      const deletedPeer = plan.prevState.internal.peers.find((p) => p.name === action.data.name)
+      const deletedPeer = plan.prevState.internal.peers.get(action.data.name)
       if (deletedPeer !== undefined) {
         try {
           await this.transport.closePeer(deletedPeer, CloseCodes.NORMAL, 'Peer removed')
@@ -364,7 +366,11 @@ export class OrchestratorBus {
     const client = this.gatewayClient
     if (client === undefined) return
 
-    const graphqlRoutes = [...state.local.routes, ...state.internal.routes].filter(
+    const allRoutes = [
+      ...state.local.routes.values(),
+      ...[...state.internal.routes.values()].flatMap((m) => [...m.values()]),
+    ]
+    const graphqlRoutes = allRoutes.filter(
       (r) => r.protocol === 'http:graphql' || r.protocol === 'http:gql'
     )
 
@@ -438,27 +444,42 @@ export class OrchestratorBus {
     // Phase 2 — Allocate local: assign ingress ports to local routes.
     //          Builds a lookup map for Phase 5 (routeChange stamping).
     const localPortMap = new Map<string, number>()
-    const localRoutes = plan.newState.local.routes.map((route) => {
-      if (route.envoyPort) return route
+    const localRoutes = new Map<string, DataChannelDefinition>()
+    for (const [key, route] of plan.newState.local.routes) {
+      if (route.envoyPort) {
+        localRoutes.set(key, route)
+        continue
+      }
       const result = this.portAllocator!.allocate(route.name)
-      if (!result.success) return route
+      if (!result.success) {
+        localRoutes.set(key, route)
+        continue
+      }
       portOps.push({ type: 'allocate', routeKey: route.name, port: result.port })
       localPortMap.set(route.name, result.port)
-      return { ...route, envoyPort: result.port }
-    })
+      localRoutes.set(key, { ...route, envoyPort: result.port })
+    }
 
     // Phase 3 — Allocate egress: assign egress ports to internal routes.
     const egressPortMap = new Map<string, number>()
-    const internalRoutes = plan.newState.internal.routes.map((route) => {
-      const egressKey = `egress_${route.name}_via_${route.peer.name}`
-      const result = this.portAllocator!.allocate(egressKey)
-      if (!result.success) return route
-      if (route.envoyPort !== result.port) {
-        portOps.push({ type: 'allocate', routeKey: egressKey, port: result.port })
+    const internalRoutes = new Map<string, Map<string, InternalRoute>>()
+    for (const [peerName, innerMap] of plan.newState.internal.routes) {
+      const newInner = new Map<string, InternalRoute>()
+      for (const [irKey, route] of innerMap) {
+        const egressKey = `egress_${route.name}_via_${route.peer.name}`
+        const result = this.portAllocator!.allocate(egressKey)
+        if (!result.success) {
+          newInner.set(irKey, route)
+          continue
+        }
+        if (route.envoyPort !== result.port) {
+          portOps.push({ type: 'allocate', routeKey: egressKey, port: result.port })
+        }
+        egressPortMap.set(egressKey, result.port)
+        newInner.set(irKey, { ...route, envoyPort: result.port })
       }
-      egressPortMap.set(egressKey, result.port)
-      return { ...route, envoyPort: result.port }
-    })
+      internalRoutes.set(peerName, newInner)
+    }
 
     // Phase 4 — Stamp: build enriched state with ports applied.
     const newState: RouteTable = {
@@ -509,13 +530,14 @@ export class OrchestratorBus {
 
     try {
       await withWideEvent('orchestrator.envoy_sync', logger, async (event) => {
+        const allInternalRoutes = [...state.internal.routes.values()].flatMap((m) => [...m.values()])
         event.set({
-          'catalyst.orchestrator.envoy.local_count': state.local.routes.length,
-          'catalyst.orchestrator.envoy.internal_count': state.internal.routes.length,
+          'catalyst.orchestrator.envoy.local_count': state.local.routes.size,
+          'catalyst.orchestrator.envoy.internal_count': allInternalRoutes.length,
         })
         await client.updateRoutes({
-          local: state.local.routes,
-          internal: state.internal.routes,
+          local: [...state.local.routes.values()],
+          internal: allInternalRoutes,
           portAllocations: this.portAllocator
             ? Object.fromEntries(this.portAllocator.getAllocations())
             : undefined,
@@ -536,7 +558,7 @@ export class OrchestratorBus {
     const localEnvoyAddress = this.config.node.envoyAddress
 
     // Advertise all local routes to the new peer.
-    for (const route of state.local.routes) {
+    for (const route of state.local.routes.values()) {
       updates.push({
         action: 'add',
         route: BusTransforms.toDataChannel(route, { envoyAddress: localEnvoyAddress }),
@@ -546,28 +568,30 @@ export class OrchestratorBus {
     }
 
     // Advertise internal routes the peer doesn't already know.
-    for (const route of state.internal.routes) {
-      // Exclude stale routes — they may no longer be valid.
-      if (route.isStale === true) continue
-      // Don't reflect a peer's own routes back at them.
-      if (route.peer.name === peer.name) continue
-      // Loop guard: don't advertise paths that already pass through this peer.
-      if (route.nodePath.includes(peer.name)) continue
+    for (const innerMap of state.internal.routes.values()) {
+      for (const route of innerMap.values()) {
+        // Exclude stale routes — they may no longer be valid.
+        if (route.isStale === true) continue
+        // Don't reflect a peer's own routes back at them.
+        if (route.peer.name === peer.name) continue
+        // Loop guard: don't advertise paths that already pass through this peer.
+        if (route.nodePath.includes(peer.name)) continue
 
-      // Apply route policy if configured.
-      if (this.routePolicy !== undefined) {
-        const allowed = this.routePolicy.canSend(peer, [route])
-        if (allowed.length === 0) continue
+        // Apply route policy if configured.
+        if (this.routePolicy !== undefined) {
+          const allowed = this.routePolicy.canSend(peer, [route])
+          if (allowed.length === 0) continue
+        }
+
+        // Multi-hop: envoyPort is already stamped by planPortAllocations.
+        // Rewrite envoyAddress to this node's envoy so downstream peers route through us.
+        updates.push({
+          action: 'add',
+          route: BusTransforms.toDataChannel(route, { envoyAddress: localEnvoyAddress }),
+          nodePath: [this.config.node.name, ...route.nodePath],
+          originNode: route.originNode,
+        })
       }
-
-      // Multi-hop: envoyPort is already stamped by planPortAllocations.
-      // Rewrite envoyAddress to this node's envoy so downstream peers route through us.
-      updates.push({
-        action: 'add',
-        route: BusTransforms.toDataChannel(route, { envoyAddress: localEnvoyAddress }),
-        nodePath: [this.config.node.name, ...route.nodePath],
-        originNode: route.originNode,
-      })
     }
 
     if (updates.length === 0) {
@@ -610,7 +634,7 @@ export class OrchestratorBus {
     now: number
   ): Promise<{ needed: number; sent: number }> {
     let sent = 0
-    const peersNeeding = state.internal.peers.filter((p) => {
+    const peersNeeding = [...state.internal.peers.values()].filter((p) => {
       if (p.connectionStatus !== 'connected' || p.holdTime <= 0) return false
       const lastSent = this.lastKeepaliveSent.get(p.name) ?? 0
       return now - lastSent > p.holdTime / 3
@@ -720,7 +744,7 @@ export const BusTransforms = {
       envoyAddress: overrides?.envoyAddress ?? route.envoyAddress,
       healthStatus: route.healthStatus,
       responseTimeMs: route.responseTimeMs,
-      lastChecked: route.lastChecked,
+      lastCheckedAt: route.lastCheckedAt,
     }
   },
 }

--- a/apps/orchestrator/src/v2/catalyst-service.ts
+++ b/apps/orchestrator/src/v2/catalyst-service.ts
@@ -165,7 +165,7 @@ export class OrchestratorService extends CatalystService {
       // Health checks read a snapshot of routes (safe). Status changes are
       // dispatched into the bus via dispatchFn, which updates the RIB and
       // triggers iBGP propagation to peers.
-      this._healthChecker.start(() => this._v2.bus.getStateSnapshot().local.routes)
+      this._healthChecker.start(() => [...this._v2.bus.getStateSnapshot().local.routes.values()])
     }
 
     // Build the token validator
@@ -194,7 +194,7 @@ export class OrchestratorService extends CatalystService {
     this.handler.get('/api/state', (c) => {
       const snapshot = bus.getStateSnapshot()
       if (this._healthChecker) {
-        this._healthChecker.applyHealth(snapshot.local.routes)
+        this._healthChecker.applyHealth([...snapshot.local.routes.values()])
       }
       return c.json(routeTableToPublic(snapshot))
     })

--- a/apps/orchestrator/src/v2/rpc.ts
+++ b/apps/orchestrator/src/v2/rpc.ts
@@ -112,7 +112,7 @@ export async function createNetworkClient(
         },
 
         async listPeers() {
-          return bus.state.internal.peers.map(peerToPublic)
+          return [...bus.state.internal.peers.values()].map(peerToPublic)
         },
       },
     }
@@ -154,8 +154,10 @@ export async function createDataChannelClient(
 
         async listRoutes() {
           return {
-            local: bus.state.local.routes,
-            internal: bus.state.internal.routes.map(internalRouteToPublic),
+            local: [...bus.state.local.routes.values()],
+            internal: [...bus.state.internal.routes.values()]
+              .flatMap((innerMap) => [...innerMap.values()])
+              .map(internalRouteToPublic),
           }
         },
       },

--- a/apps/orchestrator/src/v2/service.ts
+++ b/apps/orchestrator/src/v2/service.ts
@@ -183,7 +183,7 @@ export class OrchestratorServiceV2 {
       }
       // GAP-001: auto-dial on LocalPeerCreate
       if (result.success && action.action === Actions.LocalPeerCreate) {
-        const peerRecord = result.state.internal.peers.find((p) => p.name === action.data.name)
+        const peerRecord = result.state.internal.peers.get(action.data.name)
         if (peerRecord) {
           await this.dialPeer(peerRecord)
         }
@@ -211,7 +211,7 @@ export class OrchestratorServiceV2 {
    * the minimum negotiated holdTime per BGP spec (keepalive = holdTime / 3).
    */
   recalculateTickInterval(): void {
-    const holdTimes = this.bus.state.internal.peers.map((p) => p.holdTime)
+    const holdTimes = [...this.bus.state.internal.peers.values()].map((p) => p.holdTime)
     this.tickManager.recalculate(holdTimes)
   }
 

--- a/apps/orchestrator/tests/routes/api-state.test.ts
+++ b/apps/orchestrator/tests/routes/api-state.test.ts
@@ -8,40 +8,46 @@ import type { RouteTable } from '@catalyst/routing/v2'
 // ---------------------------------------------------------------------------
 
 function makeRouteTable(): RouteTable {
+  const localRoutes = new Map([
+    ['local-svc', { name: 'local-svc', protocol: 'http' as const, endpoint: 'http://local:8080' }],
+  ])
+
+  const peers = new Map([
+    [
+      'peer-1',
+      {
+        name: 'peer-1',
+        endpoint: 'ws://peer-1:4000',
+        domains: ['example.local'],
+        connectionStatus: 'connected' as const,
+        peerToken: 'secret-token-1',
+        holdTime: 90_000,
+        lastSent: 100,
+        lastReceived: 200,
+      },
+    ],
+  ])
+
+  const internalRoute = {
+    name: 'remote-svc',
+    protocol: 'http' as const,
+    endpoint: 'http://remote:8080',
+    peer: {
+      name: 'peer-1',
+      domains: ['example.local'],
+      peerToken: 'secret-peer-token',
+    },
+    nodePath: ['peer-1'],
+    originNode: 'peer-1',
+    isStale: false,
+  }
+  const internalRoutes = new Map([
+    ['peer-1', new Map([['remote-svc:peer-1', internalRoute]])],
+  ])
+
   return {
-    local: {
-      routes: [{ name: 'local-svc', protocol: 'http' as const, endpoint: 'http://local:8080' }],
-    },
-    internal: {
-      peers: [
-        {
-          name: 'peer-1',
-          endpoint: 'ws://peer-1:4000',
-          domains: ['example.local'],
-          connectionStatus: 'connected' as const,
-          peerToken: 'secret-token-1',
-          lastConnected: 0,
-          holdTime: 90_000,
-          lastSent: 100,
-          lastReceived: 200,
-        },
-      ],
-      routes: [
-        {
-          name: 'remote-svc',
-          protocol: 'http' as const,
-          endpoint: 'http://remote:8080',
-          peer: {
-            name: 'peer-1',
-            domains: ['example.local'],
-            peerToken: 'secret-peer-token',
-          },
-          nodePath: ['peer-1'],
-          originNode: 'peer-1',
-          isStale: false,
-        },
-      ],
-    },
+    local: { routes: localRoutes },
+    internal: { peers, routes: internalRoutes, locRib: new Map([['remote-svc:peer-1', 'peer-1']]) },
   }
 }
 

--- a/apps/orchestrator/tests/v1/orchestrator.topology.test.ts
+++ b/apps/orchestrator/tests/v1/orchestrator.topology.test.ts
@@ -298,9 +298,7 @@ describe('Orchestrator Topology Tests', () => {
 
     // A should have it in local
     expect(
-      (nodeA as unknown as { state: RouteTable }).state.local.routes.some(
-        (r) => r.name === 'loop-test'
-      )
+      (nodeA as unknown as { state: RouteTable }).state.local.routes.some((r) => r.name === 'loop-test')
     ).toBe(true)
 
     // A should NOT have it in internal (despite C offering it)

--- a/apps/orchestrator/tests/v2/adapter-health-propagation.test.ts
+++ b/apps/orchestrator/tests/v2/adapter-health-propagation.test.ts
@@ -60,17 +60,17 @@ describe('adapter health propagation', () => {
         endpoint: 'http://svc-alpha:8080',
         healthStatus: 'up',
         responseTimeMs: 42,
-        lastChecked: now,
+        lastCheckedAt: now,
       },
     })
 
     const snapshot = bus.getStateSnapshot()
-    const route = snapshot.local.routes.find((r) => r.name === 'svc-alpha')
+    const route = snapshot.local.routes.get('svc-alpha')
 
     expect(route).toBeDefined()
     expect(route?.healthStatus).toBe('up')
     expect(route?.responseTimeMs).toBe(42)
-    expect(route?.lastChecked).toBe(now)
+    expect(route?.lastCheckedAt).toBe(now)
   })
 
   it('health fields propagate to peer via iBGP update', async () => {
@@ -87,7 +87,7 @@ describe('adapter health propagation', () => {
         endpoint: 'http://svc-beta:8080',
         healthStatus: 'down',
         responseTimeMs: null,
-        lastChecked: now,
+        lastCheckedAt: now,
       },
     })
 
@@ -102,7 +102,7 @@ describe('adapter health propagation', () => {
     expect(update.route.name).toBe('svc-beta')
     expect(update.route.healthStatus).toBe('down')
     expect(update.route.responseTimeMs).toBeNull()
-    expect(update.route.lastChecked).toBe(now)
+    expect(update.route.lastCheckedAt).toBe(now)
   })
 
   it('route without health fields defaults to undefined (backward compat)', async () => {
@@ -116,12 +116,12 @@ describe('adapter health propagation', () => {
     })
 
     const snapshot = bus.getStateSnapshot()
-    const route = snapshot.local.routes.find((r) => r.name === 'svc-legacy')
+    const route = snapshot.local.routes.get('svc-legacy')
 
     expect(route).toBeDefined()
     expect(route?.healthStatus).toBeUndefined()
     expect(route?.responseTimeMs).toBeUndefined()
-    expect(route?.lastChecked).toBeUndefined()
+    expect(route?.lastCheckedAt).toBeUndefined()
   })
 
   it('health status update propagates to connected peer', async () => {
@@ -146,13 +146,13 @@ describe('adapter health propagation', () => {
         name: 'books',
         healthStatus: 'down' as const,
         responseTimeMs: null,
-        lastChecked: '2026-03-17T02:20:00Z',
+        lastCheckedAt: '2026-03-17T02:20:00Z',
       },
     })
 
     // Verify the local state reflects the health update
     const state = bus.getStateSnapshot()
-    expect(state.local.routes[0].healthStatus).toBe('down')
+    expect(state.local.routes.get('books')?.healthStatus).toBe('down')
 
     // Verify the peer received the health update via iBGP
     const updateCalls = transport.getCallsFor('sendUpdate')
@@ -166,6 +166,6 @@ describe('adapter health propagation', () => {
     expect(update.route.name).toBe('books')
     expect(update.route.healthStatus).toBe('down')
     expect(update.route.responseTimeMs).toBeNull()
-    expect(update.route.lastChecked).toBe('2026-03-17T02:20:00Z')
+    expect(update.route.lastCheckedAt).toBe('2026-03-17T02:20:00Z')
   })
 })

--- a/apps/orchestrator/tests/v2/adapter-health.test.ts
+++ b/apps/orchestrator/tests/v2/adapter-health.test.ts
@@ -50,7 +50,7 @@ describe('AdapterHealthChecker', () => {
     expect(health?.healthStatus).toBe('up')
     expect(health?.responseTimeMs).toBeTypeOf('number')
     expect(health?.responseTimeMs).toBeGreaterThanOrEqual(0)
-    expect(health?.lastChecked).toBeTypeOf('string')
+    expect(health?.lastCheckedAt).toBeTypeOf('string')
   })
 
   // -------------------------------------------------------------------------
@@ -224,7 +224,7 @@ describe('AdapterHealthChecker', () => {
     expect(result).toBe(routes) // same array reference
     expect(routes[0].healthStatus).toBe('up')
     expect(routes[0].responseTimeMs).toBeTypeOf('number')
-    expect(routes[0].lastChecked).toBeTypeOf('string')
+    expect(routes[0].lastCheckedAt).toBeTypeOf('string')
   })
 
   // -------------------------------------------------------------------------

--- a/apps/orchestrator/tests/v2/auto-dial.test.ts
+++ b/apps/orchestrator/tests/v2/auto-dial.test.ts
@@ -71,7 +71,7 @@ describe('auto-dial on LocalPeerCreate', () => {
 
     await svc.bus.dispatch({ action: Actions.LocalPeerCreate, data: peerB })
 
-    const peer = svc.bus.state.internal.peers.find((p) => p.name === 'node-b')
+    const peer = svc.bus.state.internal.peers.get('node-b')
     expect(peer).toBeDefined()
     expect(peer!.connectionStatus).toBe('connected')
   })
@@ -153,7 +153,7 @@ describe('auto-dial on LocalPeerCreate', () => {
     })
 
     // The peer is in state from replay
-    expect(bus.state.internal.peers.find((p) => p.name === 'node-b')).toBeDefined()
+    expect(bus.state.internal.peers.get('node-b')).toBeDefined()
 
     // But no openPeer call was made — replay does not trigger auto-dial
     const openCalls = transport2.getCallsFor('openPeer')

--- a/apps/orchestrator/tests/v2/bidirectional-keepalive.integration.test.ts
+++ b/apps/orchestrator/tests/v2/bidirectional-keepalive.integration.test.ts
@@ -133,7 +133,7 @@ describe('Bidirectional keepalive exchange', () => {
   })
 
   it('keepalive from A resets B hold timer for A — preventing expiry', async () => {
-    const peerAonB = b.bus.state.internal.peers.find((p) => p.name === 'node-a')!
+    const peerAonB = b.bus.state.internal.peers.get('node-a')!
     expect(peerAonB.holdTime).toBe(HOLD_TIME)
     expect(peerAonB.lastReceived).toBe(T0)
 
@@ -145,7 +145,7 @@ describe('Bidirectional keepalive exchange', () => {
     // Deliver A's keepalive to B — this updates B's lastReceived for A to Date.now() = t1
     await propagateKeepalives(a, b)
 
-    const peerAonBUpdated = b.bus.state.internal.peers.find((p) => p.name === 'node-a')!
+    const peerAonBUpdated = b.bus.state.internal.peers.get('node-a')!
     expect(peerAonBUpdated.lastReceived).toBe(t1)
 
     // Tick B at original expiry time (T0 + holdTime + 1).
@@ -154,19 +154,19 @@ describe('Bidirectional keepalive exchange', () => {
     const wouldExpireOriginal = T0 + HOLD_TIME + 1
     await b.bus.dispatch({ action: Actions.Tick, data: { now: wouldExpireOriginal } })
 
-    const peerAonBAfter = b.bus.state.internal.peers.find((p) => p.name === 'node-a')
+    const peerAonBAfter = b.bus.state.internal.peers.get('node-a')
     expect(peerAonBAfter?.connectionStatus).toBe('connected')
   })
 
   it('hold timer expires when keepalives stop flowing', async () => {
-    const peerAonB = b.bus.state.internal.peers.find((p) => p.name === 'node-a')!
+    const peerAonB = b.bus.state.internal.peers.get('node-a')!
     expect(peerAonB.holdTime).toBe(HOLD_TIME)
 
     // Tick past hold timer without any keepalives
     const expiryTime = T0 + HOLD_TIME + 1
     await b.bus.dispatch({ action: Actions.Tick, data: { now: expiryTime } })
 
-    const peerAonBAfter = b.bus.state.internal.peers.find((p) => p.name === 'node-a')
+    const peerAonBAfter = b.bus.state.internal.peers.get('node-a')
     expect(peerAonBAfter?.connectionStatus).toBe('closed')
   })
 
@@ -192,8 +192,8 @@ describe('Bidirectional keepalive exchange', () => {
     const totalElapsed = interval * 4
     expect(totalElapsed).toBeGreaterThan(HOLD_TIME) // sanity: we're past expiry window
 
-    const peerBonAFinal = a.bus.state.internal.peers.find((p) => p.name === 'node-b')
-    const peerAonBFinal = b.bus.state.internal.peers.find((p) => p.name === 'node-a')
+    const peerBonAFinal = a.bus.state.internal.peers.get('node-b')
+    const peerAonBFinal = b.bus.state.internal.peers.get('node-a')
 
     expect(peerBonAFinal?.connectionStatus).toBe('connected')
     expect(peerAonBFinal?.connectionStatus).toBe('connected')

--- a/apps/orchestrator/tests/v2/bus.test.ts
+++ b/apps/orchestrator/tests/v2/bus.test.ts
@@ -91,7 +91,7 @@ describe('OrchestratorBus — basic dispatch behaviour', () => {
 
     // The state after both commits must contain both routes
     const state = bus.state
-    const names = state.local.routes.map((r) => r.name)
+    const names = [...state.local.routes.values()].map((r) => r.name)
     expect(names).toContain('alpha')
     expect(names).toContain('beta')
   })
@@ -141,8 +141,8 @@ describe('OrchestratorBus — basic dispatch behaviour', () => {
 
     expect(result.success).toBe(true)
     if (result.success) {
-      expect(result.state.local.routes).toHaveLength(1)
-      expect(result.state.local.routes[0].name).toBe('alpha')
+      expect(result.state.local.routes.size).toBe(1)
+      expect(result.state.local.routes.get('alpha')?.name).toBe('alpha')
     }
   })
 
@@ -159,7 +159,7 @@ describe('OrchestratorBus — basic dispatch behaviour', () => {
 
     // The committed state must reflect the route
     const state = bus.state
-    expect(state.local.routes.some((r) => r.name === 'alpha')).toBe(true)
+    expect(state.local.routes.has('alpha')).toBe(true)
 
     // The update message must contain the correct route
     expect(call.message.updates).toHaveLength(1)
@@ -185,20 +185,21 @@ describe('OrchestratorBus — getStateSnapshot() immutability', () => {
     const snapshot = bus.getStateSnapshot()
 
     // 3. Mutate the snapshot (push a fake route and modify existing route name)
-    snapshot.local.routes.push({
+    snapshot.local.routes.set('injected', {
       name: 'injected',
       protocol: 'http' as const,
       endpoint: 'http://injected:9999',
     })
-    snapshot.local.routes[0].name = 'mutated-alpha'
+    const alphaRoute = snapshot.local.routes.get('alpha')!
+    alphaRoute.name = 'mutated-alpha'
 
     // 4. Verify bus.state is unchanged (the mutation did not propagate)
     const liveState = bus.state
-    const liveNames = liveState.local.routes.map((r) => r.name)
+    const liveNames = [...liveState.local.routes.values()].map((r) => r.name)
     expect(liveNames).toContain('alpha')
     expect(liveNames).not.toContain('injected')
     expect(liveNames).not.toContain('mutated-alpha')
-    expect(liveState.local.routes).toHaveLength(1)
+    expect(liveState.local.routes.size).toBe(1)
   })
 
   it('getStateSnapshot() reflects current state at call time', async () => {
@@ -212,8 +213,8 @@ describe('OrchestratorBus — getStateSnapshot() immutability', () => {
     const snapshotAfter = bus.getStateSnapshot()
 
     // 4. Verify they differ (second has the new route)
-    expect(snapshotBefore.local.routes).toHaveLength(0)
-    expect(snapshotAfter.local.routes).toHaveLength(1)
-    expect(snapshotAfter.local.routes[0].name).toBe('alpha')
+    expect(snapshotBefore.local.routes.size).toBe(0)
+    expect(snapshotAfter.local.routes.size).toBe(1)
+    expect(snapshotAfter.local.routes.get('alpha')?.name).toBe('alpha')
   })
 })

--- a/apps/orchestrator/tests/v2/graceful-restart.topology.test.ts
+++ b/apps/orchestrator/tests/v2/graceful-restart.topology.test.ts
@@ -61,7 +61,7 @@ describe('Graceful restart: TRANSPORT_ERROR marks routes stale', () => {
       },
     })
 
-    expect(bus.state.internal.routes.some((r) => r.name === 'service-x')).toBe(true)
+    expect([...bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-x')).toBe(true)
 
     // Transport error (e.g. WebSocket dropped)
     await bus.dispatch({
@@ -70,7 +70,7 @@ describe('Graceful restart: TRANSPORT_ERROR marks routes stale', () => {
     })
 
     // Route must still exist but flagged as stale
-    const route = bus.state.internal.routes.find((r) => r.name === 'service-x')
+    const route = [...bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).find((r) => r.name === 'service-x')
     expect(route).toBeDefined()
     expect(route?.isStale).toBe(true)
   })
@@ -129,7 +129,7 @@ describe('Graceful restart: TRANSPORT_ERROR marks routes stale', () => {
     })
 
     // Route must be gone completely
-    expect(bus.state.internal.routes.some((r) => r.name === 'service-x')).toBe(false)
+    expect([...bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-x')).toBe(false)
   })
 })
 
@@ -165,7 +165,7 @@ describe('Graceful restart: reconnect clears stale routes', () => {
       action: Actions.InternalProtocolClose,
       data: { peerInfo: peerB, code: CloseCodes.TRANSPORT_ERROR },
     })
-    expect(bus.state.internal.routes.find((r) => r.name === 'service-x')?.isStale).toBe(true)
+    expect([...bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).find((r) => r.name === 'service-x')?.isStale).toBe(true)
 
     // Reconnect
     await bus.dispatch({ action: Actions.LocalPeerCreate, data: peerB })
@@ -183,7 +183,7 @@ describe('Graceful restart: reconnect clears stale routes', () => {
     })
 
     // Stale flag must be cleared
-    const route = bus.state.internal.routes.find((r) => r.name === 'service-x')
+    const route = [...bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).find((r) => r.name === 'service-x')
     expect(route).toBeDefined()
     expect(route?.isStale).toBe(false)
   })
@@ -216,7 +216,7 @@ describe('Graceful restart: stale routes excluded from initial sync', () => {
       data: { peerInfo: makePeer('node-c'), code: CloseCodes.TRANSPORT_ERROR },
     })
 
-    const staleRoute = bus.state.internal.routes.find((r) => r.name === 'service-x')
+    const staleRoute = [...bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).find((r) => r.name === 'service-x')
     expect(staleRoute?.isStale).toBe(true)
 
     // Now B connects — stale route must NOT appear in the initial sync

--- a/apps/orchestrator/tests/v2/inbound-route-policy.test.ts
+++ b/apps/orchestrator/tests/v2/inbound-route-policy.test.ts
@@ -75,7 +75,7 @@ describe('Inbound route policy', () => {
 
     expect(result.success).toBe(true)
     if (!result.success) return
-    expect(result.state.internal.routes).toHaveLength(2)
+    expect([...result.state.internal.routes.values()].flatMap((m) => [...m.values()])).toHaveLength(2)
   })
 
   it('rejects all routes when canReceive returns empty', async () => {
@@ -142,8 +142,8 @@ describe('Inbound route policy', () => {
 
     expect(result.success).toBe(true)
     if (!result.success) return
-    expect(result.state.internal.routes).toHaveLength(1)
-    expect(result.state.internal.routes[0].name).toBe('svc-alpha')
+    expect([...result.state.internal.routes.values()].flatMap((m) => [...m.values()])).toHaveLength(1)
+    expect([...result.state.internal.routes.values()].flatMap((m) => [...m.values()])[0].name).toBe('svc-alpha')
   })
 
   it('does not filter non-update actions', async () => {
@@ -188,6 +188,6 @@ describe('Inbound route policy', () => {
 
     expect(result.success).toBe(true)
     if (!result.success) return
-    expect(result.state.internal.routes).toHaveLength(1)
+    expect([...result.state.internal.routes.values()].flatMap((m) => [...m.values()])).toHaveLength(1)
   })
 })

--- a/apps/orchestrator/tests/v2/journal-compaction.test.ts
+++ b/apps/orchestrator/tests/v2/journal-compaction.test.ts
@@ -11,16 +11,20 @@ import { CompactionManager } from '../../src/v2/compaction.js'
 const NODE_ID = 'node-a'
 
 function makeState(routeCount: number): RouteTable {
-  return {
-    local: {
-      routes: Array.from({ length: routeCount }, (_, i) => ({
+  const routes = new Map(
+    Array.from({ length: routeCount }, (_, i) => [
+      `route-${i}`,
+      {
         name: `route-${i}`,
         protocol: 'http' as const,
         endpoint: `http://route-${i}:8080`,
-      })),
-    },
-    internal: { peers: [], routes: [] },
-  } as unknown as RouteTable
+      },
+    ] as const)
+  )
+  return {
+    local: { routes },
+    internal: { peers: new Map(), routes: new Map() },
+  }
 }
 
 function appendN(journal: ActionLog, count: number): void {
@@ -67,9 +71,7 @@ describe('InMemoryActionLog snapshot', () => {
 
     const snap = journal.getSnapshot()
     expect(snap!.atSeq).toBe(10)
-    expect((snap!.state as unknown as { local: { routes: unknown[] } }).local.routes).toHaveLength(
-      2
-    )
+    expect((snap!.state as unknown as { local: { routes: Map<string, unknown> } }).local.routes.size).toBe(2)
   })
 
   it('prune removes entries before the given seq', () => {

--- a/apps/orchestrator/tests/v2/journal-replay.test.ts
+++ b/apps/orchestrator/tests/v2/journal-replay.test.ts
@@ -34,9 +34,9 @@ describe('journal replay', () => {
 
     const state = replayJournal(journal)
 
-    expect(state.local.routes).toHaveLength(0)
-    expect(state.internal.peers).toHaveLength(0)
-    expect(state.internal.routes).toHaveLength(0)
+    expect(state.local.routes.size).toBe(0)
+    expect(state.internal.peers.size).toBe(0)
+    expect([...state.internal.routes.values()].flatMap((m) => [...m.values()])).toHaveLength(0)
   })
 
   it('replays a single LocalRouteCreate', () => {
@@ -51,8 +51,8 @@ describe('journal replay', () => {
 
     const state = replayJournal(journal)
 
-    expect(state.local.routes).toHaveLength(1)
-    expect(state.local.routes[0].name).toBe('alpha')
+    expect(state.local.routes.size).toBe(1)
+    expect(state.local.routes.get('alpha')?.name).toBe('alpha')
   })
 
   it('replays multiple actions in sequence — create and delete', () => {
@@ -78,8 +78,8 @@ describe('journal replay', () => {
 
     const state = replayJournal(journal)
 
-    expect(state.local.routes).toHaveLength(1)
-    expect(state.local.routes[0].name).toBe('beta')
+    expect(state.local.routes.size).toBe(1)
+    expect(state.local.routes.get('beta')?.name).toBe('beta')
   })
 
   it('replays peer lifecycle — create peer', () => {
@@ -93,9 +93,9 @@ describe('journal replay', () => {
 
     const state = replayJournal(journal)
 
-    expect(state.internal.peers).toHaveLength(1)
-    expect(state.internal.peers[0].name).toBe('node-b')
-    expect(state.internal.peers[0].connectionStatus).toBe('initializing')
+    expect(state.internal.peers.size).toBe(1)
+    expect(state.internal.peers.get('node-b')?.name).toBe('node-b')
+    expect(state.internal.peers.get("node-b")?.connectionStatus).toBe('initializing')
   })
 
   it('replays connected status after InternalProtocolConnected', () => {
@@ -110,7 +110,7 @@ describe('journal replay', () => {
 
     const state = replayJournal(journal)
 
-    const peer = state.internal.peers.find((p) => p.name === 'node-b')
+    const peer = state.internal.peers.get('node-b')
     expect(peer?.connectionStatus).toBe('connected')
   })
 
@@ -126,7 +126,7 @@ describe('journal replay', () => {
 
     const state = replayJournal(journal)
 
-    expect(state.internal.peers).toHaveLength(0)
+    expect(state.internal.peers.size).toBe(0)
   })
 
   it('skips duplicate (rejected) actions gracefully — second create for same route is a no-op', () => {
@@ -150,7 +150,7 @@ describe('journal replay', () => {
     const state = replayJournal(journal)
 
     // Should have exactly one route, not two
-    expect(state.local.routes).toHaveLength(1)
+    expect(state.local.routes.size).toBe(1)
   })
 
   it('correctly replays a mixed sequence of peers and routes', () => {
@@ -180,8 +180,8 @@ describe('journal replay', () => {
 
     const state = replayJournal(journal)
 
-    expect(state.local.routes).toHaveLength(2)
-    expect(state.internal.peers).toHaveLength(1)
-    expect(state.internal.peers[0].connectionStatus).toBe('connected')
+    expect(state.local.routes.size).toBe(2)
+    expect(state.internal.peers.size).toBe(1)
+    expect(state.internal.peers.get("node-b")?.connectionStatus).toBe('connected')
   })
 })

--- a/apps/orchestrator/tests/v2/journal-snapshot-recovery.test.ts
+++ b/apps/orchestrator/tests/v2/journal-snapshot-recovery.test.ts
@@ -139,9 +139,9 @@ describe('snapshot-based recovery', () => {
     // Recovery should work from snapshot + tail
     const recovered = recoverFromJournal(journal)
 
-    expect(recovered.local.routes).toHaveLength(21)
-    expect(recovered.local.routes.map((r) => r.name)).toContain('post-compact')
-    expect(recovered.local.routes.map((r) => r.name)).toContain('route-0')
+    expect(recovered.local.routes.size).toBe(21)
+    expect([...recovered.local.routes.values()].map((r) => r.name)).toContain('post-compact')
+    expect([...recovered.local.routes.values()].map((r) => r.name)).toContain('route-0')
   })
 
   it('recovery from snapshot alone (no tail entries)', () => {
@@ -160,8 +160,8 @@ describe('snapshot-based recovery', () => {
     journal.prune(2) // prune everything
 
     const recovered = recoverFromJournal(journal)
-    expect(recovered.local.routes).toHaveLength(1)
-    expect(recovered.local.routes[0].name).toBe('alpha')
+    expect(recovered.local.routes.size).toBe(1)
+    expect(recovered.local.routes.get('alpha')?.name).toBe('alpha')
   })
 
   it('recovery without snapshot replays from beginning', () => {
@@ -177,7 +177,7 @@ describe('snapshot-based recovery', () => {
 
     // No snapshot — full replay from beginning
     const recovered = recoverFromJournal(journal)
-    expect(recovered.local.routes).toHaveLength(1)
-    expect(recovered.local.routes[0].name).toBe('alpha')
+    expect(recovered.local.routes.size).toBe(1)
+    expect(recovered.local.routes.get('alpha')?.name).toBe('alpha')
   })
 })

--- a/apps/orchestrator/tests/v2/journal-sqlite-replay.integration.test.ts
+++ b/apps/orchestrator/tests/v2/journal-sqlite-replay.integration.test.ts
@@ -104,7 +104,7 @@ describe('SQLite journal: durability and restart reconstruction', () => {
     await svc1.bus.dispatch({ action: Actions.LocalRouteCreate, data: routeAlpha })
     await svc1.bus.dispatch({ action: Actions.LocalRouteCreate, data: routeBeta })
 
-    expect(svc1.bus.state.local.routes).toHaveLength(2)
+    expect(svc1.bus.state.local.routes.size).toBe(2)
     await svc1.stop()
 
     // Session 2: fresh service with same journal
@@ -114,8 +114,8 @@ describe('SQLite journal: durability and restart reconstruction', () => {
       journalPath: jp,
     })
 
-    expect(svc2.bus.state.local.routes).toHaveLength(2)
-    const names = svc2.bus.state.local.routes.map((r) => r.name).sort()
+    expect(svc2.bus.state.local.routes.size).toBe(2)
+    const names = [...svc2.bus.state.local.routes.values()].map((r) => r.name).sort()
     expect(names).toEqual(['alpha', 'beta'])
 
     await svc2.stop()
@@ -132,7 +132,7 @@ describe('SQLite journal: durability and restart reconstruction', () => {
     })
 
     await svc1.bus.dispatch({ action: Actions.LocalPeerCreate, data: peerB })
-    expect(svc1.bus.state.internal.peers).toHaveLength(1)
+    expect(svc1.bus.state.internal.peers.size).toBe(1)
     await svc1.stop()
 
     // Session 2: peer should be restored
@@ -142,10 +142,10 @@ describe('SQLite journal: durability and restart reconstruction', () => {
       journalPath: jp,
     })
 
-    expect(svc2.bus.state.internal.peers).toHaveLength(1)
-    expect(svc2.bus.state.internal.peers[0].name).toBe('node-b')
+    expect(svc2.bus.state.internal.peers.size).toBe(1)
+    expect(svc2.bus.state.internal.peers.get('node-b')?.name).toBe('node-b')
     // After journal replay, auto-dial fires (GAP-001) and connects the peer
-    expect(svc2.bus.state.internal.peers[0].connectionStatus).toBe('connected')
+    expect(svc2.bus.state.internal.peers.get("node-b")?.connectionStatus).toBe('connected')
 
     await svc2.stop()
   })
@@ -168,9 +168,9 @@ describe('SQLite journal: durability and restart reconstruction', () => {
       transport: new MockPeerTransport(),
       journalPath: jp,
     })
-    expect(svc2.bus.state.local.routes).toHaveLength(1)
+    expect(svc2.bus.state.local.routes.size).toBe(1)
     await svc2.bus.dispatch({ action: Actions.LocalRouteCreate, data: routeBeta })
-    expect(svc2.bus.state.local.routes).toHaveLength(2)
+    expect(svc2.bus.state.local.routes.size).toBe(2)
     await svc2.stop()
 
     // Session 3: should have exactly 2 routes (not 3+ from double-appended alpha)
@@ -179,7 +179,7 @@ describe('SQLite journal: durability and restart reconstruction', () => {
       transport: new MockPeerTransport(),
       journalPath: jp,
     })
-    expect(svc3.bus.state.local.routes).toHaveLength(2)
+    expect(svc3.bus.state.local.routes.size).toBe(2)
     await svc3.stop()
   })
 
@@ -194,7 +194,7 @@ describe('SQLite journal: durability and restart reconstruction', () => {
     })
     await svc1.bus.dispatch({ action: Actions.LocalRouteCreate, data: routeAlpha })
     await svc1.bus.dispatch({ action: Actions.LocalRouteDelete, data: routeAlpha })
-    expect(svc1.bus.state.local.routes).toHaveLength(0)
+    expect(svc1.bus.state.local.routes.size).toBe(0)
     await svc1.stop()
 
     // Session 2: replay should produce empty state
@@ -203,7 +203,7 @@ describe('SQLite journal: durability and restart reconstruction', () => {
       transport: new MockPeerTransport(),
       journalPath: jp,
     })
-    expect(svc2.bus.state.local.routes).toHaveLength(0)
+    expect(svc2.bus.state.local.routes.size).toBe(0)
     await svc2.stop()
   })
 })

--- a/apps/orchestrator/tests/v2/keepalive.topology.test.ts
+++ b/apps/orchestrator/tests/v2/keepalive.topology.test.ts
@@ -51,7 +51,7 @@ describe('Keepalive: outbound keepalive sending', () => {
   })
 
   it('sends keepalive to a connected peer when Tick fires and lastSent is stale', async () => {
-    const peer = bus.state.internal.peers.find((p) => p.name === 'node-b')
+    const peer = bus.state.internal.peers.get('node-b')
     expect(peer).toBeDefined()
     const holdTime = peer!.holdTime
     const lastReceived = peer!.lastReceived
@@ -66,7 +66,7 @@ describe('Keepalive: outbound keepalive sending', () => {
   })
 
   it('does not send keepalive again before holdTime / 3 elapses', async () => {
-    const peer = bus.state.internal.peers.find((p) => p.name === 'node-b')!
+    const peer = bus.state.internal.peers.get('node-b')!
     const holdTime = peer.holdTime
     const lastReceived = peer.lastReceived
     // t1 is past holdTime/3 (triggers keepalive) but well before holdTime (no expiry)
@@ -84,7 +84,7 @@ describe('Keepalive: outbound keepalive sending', () => {
   })
 
   it('sends keepalive again after holdTime / 3 elapses from last send', async () => {
-    const peer = bus.state.internal.peers.find((p) => p.name === 'node-b')!
+    const peer = bus.state.internal.peers.get('node-b')!
     const holdTime = peer.holdTime
     const lastReceived = peer.lastReceived
     // t1 is past holdTime/3 but NOT past holdTime (avoids expiry)
@@ -141,7 +141,7 @@ describe('Keepalive: outbound keepalive sending', () => {
 
   it('keepalive transport failure is swallowed (fire-and-forget)', async () => {
     transport.setShouldFail(true)
-    const holdTime = bus.state.internal.peers.find((p) => p.name === 'node-b')?.holdTime ?? 90_000
+    const holdTime = bus.state.internal.peers.get('node-b')?.holdTime ?? 90_000
 
     // Should not throw even when transport fails
     await expect(
@@ -161,14 +161,14 @@ describe('Keepalive: incoming keepalive updates lastReceived', () => {
   })
 
   it('dispatching InternalProtocolKeepalive updates lastReceived on the peer', async () => {
-    const before = bus.state.internal.peers.find((p) => p.name === 'node-b')?.lastReceived ?? 0
+    const before = bus.state.internal.peers.get('node-b')?.lastReceived ?? 0
 
     await bus.dispatch({
       action: Actions.InternalProtocolKeepalive,
       data: { peerInfo: peerBInfo },
     })
 
-    const after = bus.state.internal.peers.find((p) => p.name === 'node-b')?.lastReceived ?? 0
+    const after = bus.state.internal.peers.get('node-b')?.lastReceived ?? 0
     expect(after).toBeGreaterThanOrEqual(before)
   })
 
@@ -201,7 +201,7 @@ describe('Keepalive: hold timer expiry on missed keepalives', () => {
   })
 
   it('peer expires when Tick fires after holdTime has elapsed since lastReceived', async () => {
-    const peer = bus.state.internal.peers.find((p) => p.name === 'node-b')
+    const peer = bus.state.internal.peers.get('node-b')
     expect(peer).toBeDefined()
     const holdTime = peer!.holdTime // 90_000 by default
     const lastReceived = peer!.lastReceived
@@ -212,19 +212,19 @@ describe('Keepalive: hold timer expiry on missed keepalives', () => {
 
     expect(result.success).toBe(true)
     // Peer should now be closed
-    const peerAfter = bus.state.internal.peers.find((p) => p.name === 'node-b')
+    const peerAfter = bus.state.internal.peers.get('node-b')
     expect(peerAfter?.connectionStatus).toBe('closed')
   })
 
   it('peer does NOT expire when Tick fires before holdTime has elapsed', async () => {
-    const peer = bus.state.internal.peers.find((p) => p.name === 'node-b')!
+    const peer = bus.state.internal.peers.get('node-b')!
     const now = peer.lastReceived + peer.holdTime - 1 // 1ms before expiry
 
     const result = await bus.dispatch({ action: Actions.Tick, data: { now } })
 
     // No state change — peer is still alive
     expect(result.success).toBe(false)
-    const peerAfter = bus.state.internal.peers.find((p) => p.name === 'node-b')
+    const peerAfter = bus.state.internal.peers.get('node-b')
     expect(peerAfter?.connectionStatus).toBe('connected')
   })
 
@@ -266,14 +266,14 @@ describe('Keepalive: hold timer expiry on missed keepalives', () => {
     transport.reset()
 
     // Expire B's short hold timer (3_000ms). C has 90_000ms holdTime → still alive.
-    const peerB = bus.state.internal.peers.find((p) => p.name === 'node-b')!
+    const peerB = bus.state.internal.peers.get('node-b')!
     expect(peerB.holdTime).toBe(3_000)
     const expiryNow = peerB.lastReceived + 3_001
 
     await bus.dispatch({ action: Actions.Tick, data: { now: expiryNow } })
 
     // B's route should be gone
-    expect(bus.state.internal.routes.some((r) => r.name === 'svc-b')).toBe(false)
+    expect([...bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'svc-b')).toBe(false)
 
     // Withdrawal should have been sent to C
     const updateCalls = transport
@@ -302,13 +302,13 @@ describe('Keepalive: hold timer expiry on missed keepalives', () => {
     })
 
     // Confirm holdTime is 0
-    const peer = bus.state.internal.peers.find((p) => p.name === 'node-c')
+    const peer = bus.state.internal.peers.get('node-c')
     expect(peer?.holdTime).toBe(0)
 
     // Tick far in the future — peer should not expire
     await bus.dispatch({ action: Actions.Tick, data: { now: Date.now() + 999_999_999 } })
 
-    const peerAfter = bus.state.internal.peers.find((p) => p.name === 'node-c')
+    const peerAfter = bus.state.internal.peers.get('node-c')
     expect(peerAfter?.connectionStatus).toBe('connected')
   })
 })

--- a/apps/orchestrator/tests/v2/orchestrator.topology.test.ts
+++ b/apps/orchestrator/tests/v2/orchestrator.topology.test.ts
@@ -166,7 +166,7 @@ describe('Topology: Linear A↔B↔C', () => {
     await topo.propagate('node-a', 'node-b')
 
     const stateB = topo.get('node-b').bus.state
-    expect(stateB.internal.routes.some((r) => r.name === 'service-x')).toBe(true)
+    expect([...stateB.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-x')).toBe(true)
   })
 
   it('route created at A propagates B→C with nodePath [node-b, node-a]', async () => {
@@ -178,7 +178,7 @@ describe('Topology: Linear A↔B↔C', () => {
     await topo.propagate('node-b', 'node-c')
 
     const stateC = topo.get('node-c').bus.state
-    const route = stateC.internal.routes.find((r) => r.name === 'service-x')
+    const route = [...stateC.internal.routes.values()].flatMap((m) => [...m.values()]).find((r) => r.name === 'service-x')
     expect(route).toBeDefined()
     // node-b prepends itself when forwarding: ['node-b', 'node-a']
     expect(route?.nodePath).toEqual(['node-b', 'node-a'])
@@ -198,8 +198,8 @@ describe('Topology: Linear A↔B↔C', () => {
 
     const stateB = topo.get('node-b').bus.state
     const stateC = topo.get('node-c').bus.state
-    expect(stateB.internal.routes.some((r) => r.name === 'service-x')).toBe(false)
-    expect(stateC.internal.routes.some((r) => r.name === 'service-x')).toBe(false)
+    expect([...stateB.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-x')).toBe(false)
+    expect([...stateC.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-x')).toBe(false)
   })
 
   it('route withdrawal reaches C with action=remove', async () => {
@@ -243,10 +243,10 @@ describe('Topology: Triangle A↔B, A↔C, B↔C', () => {
     await topo.propagate('node-a', 'node-b')
     await topo.propagate('node-a', 'node-c')
 
-    expect(topo.get('node-b').bus.state.internal.routes.some((r) => r.name === 'service-x')).toBe(
+    expect([...topo.get('node-b').bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-x')).toBe(
       true
     )
-    expect(topo.get('node-c').bus.state.internal.routes.some((r) => r.name === 'service-x')).toBe(
+    expect([...topo.get('node-c').bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-x')).toBe(
       true
     )
   })
@@ -258,18 +258,18 @@ describe('Topology: Triangle A↔B, A↔C, B↔C', () => {
     await topo.propagate('node-a', 'node-c')
 
     // Record C's current nodePath (direct from A: ['node-a'])
-    const directRoute = topo
+    const directRoute = [...topo
       .get('node-c')
-      .bus.state.internal.routes.find((r) => r.name === 'service-x')
+      .bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).find((r) => r.name === 'service-x')
     expect(directRoute?.nodePath).toEqual(['node-a'])
 
     // B now forwards to C — longer path ['node-b', 'node-a']
     // C should keep the shorter existing path
     await topo.propagate('node-b', 'node-c')
 
-    const routeAtC = topo
+    const routeAtC = [...topo
       .get('node-c')
-      .bus.state.internal.routes.find((r) => r.name === 'service-x')
+      .bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).find((r) => r.name === 'service-x')
     expect(routeAtC).toBeDefined()
     // Best-path selection: existing ['node-a'] is shorter — unchanged
     expect(routeAtC?.nodePath).toEqual(['node-a'])
@@ -295,7 +295,7 @@ describe('Topology: Triangle A↔B, A↔C, B↔C', () => {
       data: { peerInfo: makePeerInfo('node-a'), code: CloseCodes.NORMAL },
     })
 
-    expect(topo.get('node-c').bus.state.internal.routes.some((r) => r.name === 'service-x')).toBe(
+    expect([...topo.get('node-c').bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-x')).toBe(
       false
     )
   })
@@ -334,7 +334,7 @@ describe('Topology: Initial sync — retroactive route learning', () => {
     await topo.propagate('node-b', 'node-a')
 
     const stateA = topo.get('node-a').bus.state
-    const routeNames = stateA.internal.routes.map((r) => r.name)
+    const routeNames = [...stateA.internal.routes.values()].flatMap((m) => [...m.values()]).map((r) => r.name)
     expect(routeNames).toContain('service-x')
     expect(routeNames).toContain('service-y')
   })
@@ -369,8 +369,8 @@ describe('Topology: Loop prevention', () => {
 
     // A must have service-x only in local, not in internal
     const stateA = topo.get('node-a').bus.state
-    expect(stateA.local.routes.some((r) => r.name === 'service-x')).toBe(true)
-    expect(stateA.internal.routes.some((r) => r.name === 'service-x')).toBe(false)
+    expect(stateA.local.routes.has('service-x')).toBe(true)
+    expect([...stateA.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-x')).toBe(false)
   })
 })
 

--- a/apps/orchestrator/tests/v2/peer-token-validation.test.ts
+++ b/apps/orchestrator/tests/v2/peer-token-validation.test.ts
@@ -48,7 +48,7 @@ describe('OrchestratorBus — peerToken validation on LocalPeerCreate', () => {
     }
 
     // Peer must NOT be added to state
-    expect(bus.state.internal.peers).toHaveLength(0)
+    expect(bus.state.internal.peers.size).toBe(0)
   })
 
   it('rejects LocalPeerCreate with empty string peerToken', async () => {
@@ -69,7 +69,7 @@ describe('OrchestratorBus — peerToken validation on LocalPeerCreate', () => {
       expect(result.error).toContain('peerToken')
     }
 
-    expect(bus.state.internal.peers).toHaveLength(0)
+    expect(bus.state.internal.peers.size).toBe(0)
   })
 
   it('accepts LocalPeerCreate with valid peerToken', async () => {
@@ -87,8 +87,8 @@ describe('OrchestratorBus — peerToken validation on LocalPeerCreate', () => {
 
     expect(result.success).toBe(true)
     if (result.success) {
-      expect(result.state.internal.peers).toHaveLength(1)
-      expect(result.state.internal.peers[0].name).toBe('node-b')
+      expect(result.state.internal.peers.size).toBe(1)
+      expect(result.state.internal.peers.get('node-b')?.name).toBe('node-b')
     }
   })
 })

--- a/apps/orchestrator/tests/v2/port-allocation-plan.test.ts
+++ b/apps/orchestrator/tests/v2/port-allocation-plan.test.ts
@@ -83,7 +83,7 @@ describe('Port allocation planning', () => {
     if (!result.success) return
 
     // Port should be stamped directly on the route in committed state
-    const route = result.state.local.routes.find((r) => r.name === 'svc-alpha')
+    const route = result.state.local.routes.get('svc-alpha')
     expect(route).toBeDefined()
     expect(route!.envoyPort).toBe(10000)
   })
@@ -127,7 +127,7 @@ describe('Port allocation planning', () => {
     if (!result.success) return
 
     // Egress port should be stamped on the internal route
-    const internalRoute = result.state.internal.routes.find((r) => r.name === 'svc-remote')
+    const internalRoute = [...result.state.internal.routes.values()].flatMap((m) => [...m.values()]).find((r) => r.name === 'svc-remote')
     expect(internalRoute).toBeDefined()
     expect(internalRoute!.envoyPort).toBeDefined()
 
@@ -183,11 +183,11 @@ describe('Port allocation planning', () => {
     if (!result.success) return
 
     // svc-alpha keeps its original port
-    const alpha = result.state.local.routes.find((r) => r.name === 'svc-alpha')
+    const alpha = result.state.local.routes.get('svc-alpha')
     expect(alpha!.envoyPort).toBe(10000)
 
     // svc-beta gets the next port
-    const beta = result.state.local.routes.find((r) => r.name === 'svc-beta')
+    const beta = result.state.local.routes.get('svc-beta')
     expect(beta!.envoyPort).toBe(10001)
   })
 
@@ -207,7 +207,7 @@ describe('Port allocation planning', () => {
     if (!result.success) return
 
     // No port stamped when no allocator is configured
-    const route = result.state.local.routes.find((r) => r.name === 'svc-alpha')
+    const route = result.state.local.routes.get('svc-alpha')
     expect(route!.envoyPort).toBeUndefined()
   })
 })

--- a/apps/orchestrator/tests/v2/post-commit.test.ts
+++ b/apps/orchestrator/tests/v2/post-commit.test.ts
@@ -423,7 +423,7 @@ describe('Post-commit BGP notification — initial sync on InternalProtocolConne
     })
 
     // Verify route is stale
-    const staleRoute = bus.state.internal.routes.find((r) => r.name === 'alpha')
+    const staleRoute = [...bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).find((r) => r.name === 'alpha')
     expect(staleRoute?.isStale).toBe(true)
 
     // Now B connects — stale route must NOT be synced

--- a/apps/orchestrator/tests/v2/reconnect-sync.integration.test.ts
+++ b/apps/orchestrator/tests/v2/reconnect-sync.integration.test.ts
@@ -76,7 +76,7 @@ describe('ReconnectManager → Bus → initial sync chain', () => {
     transport.reset()
 
     // Get the peer record for scheduling reconnect
-    const peerRecord = svc.bus.state.internal.peers.find((p) => p.name === 'node-b')!
+    const peerRecord = svc.bus.state.internal.peers.get('node-b')!
     expect(peerRecord.connectionStatus).toBe('closed')
 
     // Schedule reconnect
@@ -110,7 +110,7 @@ describe('ReconnectManager → Bus → initial sync chain', () => {
       data: { peerInfo: peerB, code: CloseCodes.TRANSPORT_ERROR },
     })
 
-    const peerRecord = svc.bus.state.internal.peers.find((p) => p.name === 'node-b')!
+    const peerRecord = svc.bus.state.internal.peers.get('node-b')!
     svc.reconnectManager.scheduleReconnect(peerRecord)
 
     // Advance past backoff
@@ -133,7 +133,7 @@ describe('ReconnectManager → Bus → initial sync chain', () => {
       data: { peerInfo: peerB, code: CloseCodes.TRANSPORT_ERROR },
     })
 
-    const peerRecord = svc2.bus.state.internal.peers.find((p) => p.name === 'node-b')!
+    const peerRecord = svc2.bus.state.internal.peers.get('node-b')!
     svc2.reconnectManager.scheduleReconnect(peerRecord)
 
     // Advance past backoff

--- a/apps/orchestrator/tests/v2/rpc.test.ts
+++ b/apps/orchestrator/tests/v2/rpc.test.ts
@@ -187,8 +187,8 @@ describe('createNetworkClient', () => {
 
     const addResult = await result.client.addPeer(peerInfo)
     expect(addResult.success).toBe(true)
-    expect(bus.state.internal.peers).toHaveLength(1)
-    expect(bus.state.internal.peers[0].name).toBe('node-b')
+    expect(bus.state.internal.peers.size).toBe(1)
+    expect(bus.state.internal.peers.get('node-b')?.name).toBe('node-b')
   })
 
   it('addPeer returns error when peer already exists', async () => {
@@ -232,12 +232,12 @@ describe('createNetworkClient', () => {
     if (!result.success) return
 
     await result.client.addPeer(peerInfo)
-    expect(bus.state.internal.peers).toHaveLength(1)
+    expect(bus.state.internal.peers.size).toBe(1)
 
     const removeResult = await result.client.removePeer({ name: peerInfo.name })
 
     expect(removeResult.success).toBe(true)
-    expect(bus.state.internal.peers).toHaveLength(0)
+    expect(bus.state.internal.peers.size).toBe(0)
   })
 
   it('removePeer returns error when peer does not exist', async () => {
@@ -284,8 +284,8 @@ describe('createDataChannelClient', () => {
 
     const addResult = await result.client.addRoute(routeAlpha)
     expect(addResult.success).toBe(true)
-    expect(bus.state.local.routes).toHaveLength(1)
-    expect(bus.state.local.routes[0].name).toBe('alpha')
+    expect(bus.state.local.routes.size).toBe(1)
+    expect(bus.state.local.routes.get('alpha')?.name).toBe('alpha')
   })
 
   it('addRoute returns error when route already exists', async () => {
@@ -306,12 +306,12 @@ describe('createDataChannelClient', () => {
     if (!result.success) return
 
     await result.client.addRoute(routeAlpha)
-    expect(bus.state.local.routes).toHaveLength(1)
+    expect(bus.state.local.routes.size).toBe(1)
 
     const removeResult = await result.client.removeRoute({ name: 'alpha' })
 
     expect(removeResult.success).toBe(true)
-    expect(bus.state.local.routes).toHaveLength(0)
+    expect(bus.state.local.routes.size).toBe(0)
   })
 
   it('removeRoute returns error when route does not exist', async () => {
@@ -391,7 +391,7 @@ describe('createIBGPClient', () => {
     const openResult = await result.client.open({ peerInfo })
     expect(openResult.success).toBe(true)
 
-    const peer = bus.state.internal.peers.find((p) => p.name === 'node-b')
+    const peer = bus.state.internal.peers.get('node-b')
     expect(peer?.connectionStatus).toBe('connected')
   })
 
@@ -446,7 +446,7 @@ describe('createIBGPClient', () => {
     })
 
     expect(updateResult.success).toBe(true)
-    expect(bus.state.internal.routes).toHaveLength(1)
+    expect([...bus.state.internal.routes.values()].flatMap((m) => [...m.values()])).toHaveLength(1)
   })
 
   it('keepalive dispatches InternalProtocolKeepalive', async () => {

--- a/apps/orchestrator/tests/v2/service.test.ts
+++ b/apps/orchestrator/tests/v2/service.test.ts
@@ -56,8 +56,8 @@ describe('OrchestratorServiceV2', () => {
   it('starts with empty state on a fresh journal', () => {
     const svc = new OrchestratorServiceV2({ config, transport })
 
-    expect(svc.bus.state.local.routes).toHaveLength(0)
-    expect(svc.bus.state.internal.peers).toHaveLength(0)
+    expect(svc.bus.state.local.routes.size).toBe(0)
+    expect(svc.bus.state.internal.peers.size).toBe(0)
   })
 
   it('start() begins tick dispatch', async () => {
@@ -127,7 +127,7 @@ describe('OrchestratorServiceV2', () => {
     await svc.bus.dispatch({ action: Actions.LocalPeerCreate, data: peerInfo })
     // Bus holds the token internally — we can't directly inspect it, but the
     // setNodeToken call should not throw and the bus should function correctly.
-    expect(svc.bus.state.internal.peers).toHaveLength(1)
+    expect(svc.bus.state.internal.peers.size).toBe(1)
 
     await svc.stop()
   })
@@ -189,9 +189,9 @@ describe('OrchestratorServiceV2', () => {
         initialState: tempRib.state,
       })
 
-      expect(restoredBus.state.local.routes).toHaveLength(2)
-      expect(restoredBus.state.local.routes.map((r) => r.name)).toContain('alpha')
-      expect(restoredBus.state.local.routes.map((r) => r.name)).toContain('beta')
+      expect(restoredBus.state.local.routes.size).toBe(2)
+      expect([...restoredBus.state.local.routes.values()].map((r) => r.name)).toContain('alpha')
+      expect([...restoredBus.state.local.routes.values()].map((r) => r.name)).toContain('beta')
 
       // Cleanup
       void svc1.stop()

--- a/apps/orchestrator/tests/v2/tick-recalculate.integration.test.ts
+++ b/apps/orchestrator/tests/v2/tick-recalculate.integration.test.ts
@@ -148,14 +148,14 @@ describe('Hold-timer expiry does NOT auto-reconnect (documents intentional desig
   })
 
   it('expired peer closes but reconnectManager has no pending reconnects', async () => {
-    const peer = svc.bus.state.internal.peers.find((p) => p.name === 'node-b')!
+    const peer = svc.bus.state.internal.peers.get('node-b')!
     expect(peer.connectionStatus).toBe('connected')
 
     // Expire the peer via Tick
     const expiryNow = peer.lastReceived + 3_001
     await svc.bus.dispatch({ action: Actions.Tick, data: { now: expiryNow } })
 
-    const peerAfter = svc.bus.state.internal.peers.find((p) => p.name === 'node-b')
+    const peerAfter = svc.bus.state.internal.peers.get('node-b')
     expect(peerAfter?.connectionStatus).toBe('closed')
 
     // ReconnectManager should NOT have auto-scheduled a reconnect

--- a/apps/orchestrator/tests/v2/ws-peering.integration.test.ts
+++ b/apps/orchestrator/tests/v2/ws-peering.integration.test.ts
@@ -153,7 +153,7 @@ async function peerNodes(a: TestNode, b: TestNode): Promise<void> {
 
   // Wait for B to see A as connected (via InternalProtocolOpen from A's dial)
   await waitFor(() => {
-    const p = b.bus.state.internal.peers.find((pp) => pp.name === a.name)
+    const p = b.bus.state.internal.peers.get(a.name)
     return p?.connectionStatus === 'connected'
   })
 
@@ -178,7 +178,7 @@ async function peerNodes(a: TestNode, b: TestNode): Promise<void> {
 
   // Wait for A to see B's inbound dial
   await waitFor(() => {
-    const p = a.bus.state.internal.peers.find((pp) => pp.name === b.name)
+    const p = a.bus.state.internal.peers.get(b.name)
     return p?.connectionStatus === 'connected'
   })
 
@@ -231,11 +231,11 @@ describe('WebSocketPeerTransport: connection lifecycle', () => {
     await transportA.openPeer(peerRecord, tokenA)
 
     await waitFor(() => {
-      const peer = serverNode.bus.state.internal.peers.find((p) => p.name === 'node-a')
+      const peer = serverNode.bus.state.internal.peers.get('node-a')
       return peer?.connectionStatus === 'connected'
     })
 
-    const peerOnB = serverNode.bus.state.internal.peers.find((p) => p.name === 'node-a')
+    const peerOnB = serverNode.bus.state.internal.peers.get('node-a')
     expect(peerOnB?.connectionStatus).toBe('connected')
   })
 
@@ -293,23 +293,23 @@ describe('Two-node WebSocket peering', () => {
 
     // Wait for routes to propagate via delta fan-out (post-commit side effect)
     await waitFor(() => {
-      const bHasA = nodeB.bus.state.internal.routes.some((r) => r.name === 'service-alpha')
-      const aHasB = nodeA.bus.state.internal.routes.some((r) => r.name === 'service-beta')
+      const bHasA = [...nodeB.bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-alpha')
+      const aHasB = [...nodeA.bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-beta')
       return bHasA && aHasB
     })
 
-    expect(nodeB.bus.state.internal.routes.some((r) => r.name === 'service-alpha')).toBe(true)
-    expect(nodeA.bus.state.internal.routes.some((r) => r.name === 'service-beta')).toBe(true)
+    expect([...nodeB.bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-alpha')).toBe(true)
+    expect([...nodeA.bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-beta')).toBe(true)
 
     // Verify route attribution
-    const routeOnB = nodeB.bus.state.internal.routes.find((r) => r.name === 'service-alpha')!
+    const routeOnB = [...nodeB.bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).find((r) => r.name === 'service-alpha')!
     expect(routeOnB.originNode).toBe('node-alpha')
     expect(routeOnB.nodePath).toContain('node-alpha')
   })
 
   it('route withdrawal propagates over WebSocket — no zombie routes', async () => {
     // Verify service-alpha exists on B
-    expect(nodeB.bus.state.internal.routes.some((r) => r.name === 'service-alpha')).toBe(true)
+    expect([...nodeB.bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-alpha')).toBe(true)
 
     // Delete service-alpha from node-alpha
     await nodeA.bus.dispatch({
@@ -319,17 +319,17 @@ describe('Two-node WebSocket peering', () => {
 
     // Wait for withdrawal to reach node-beta
     await waitFor(() => {
-      return !nodeB.bus.state.internal.routes.some((r) => r.name === 'service-alpha')
+      return ![...nodeB.bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-alpha')
     })
 
-    expect(nodeB.bus.state.internal.routes.some((r) => r.name === 'service-alpha')).toBe(false)
+    expect([...nodeB.bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-alpha')).toBe(false)
     // node-beta's own route should still be there
-    expect(nodeA.bus.state.internal.routes.some((r) => r.name === 'service-beta')).toBe(true)
+    expect([...nodeA.bus.state.internal.routes.values()].flatMap((m) => [...m.values()]).some((r) => r.name === 'service-beta')).toBe(true)
   })
 
   it('sendKeepalive succeeds over WebSocket and updates lastReceived', async () => {
     // Get B's peer record for alpha on beta
-    const peerOnB = nodeB.bus.state.internal.peers.find((p) => p.name === 'node-alpha')!
+    const peerOnB = nodeB.bus.state.internal.peers.get('node-alpha')!
     const beforeKeepalive = peerOnB.lastReceived
 
     // Small delay to ensure Date.now() advances
@@ -337,16 +337,16 @@ describe('Two-node WebSocket peering', () => {
 
     // Node-alpha sends keepalive to node-beta
     // Need the peer record from alpha's side WITH peerToken
-    const peerBetaOnAlpha = nodeA.bus.state.internal.peers.find((p) => p.name === 'node-beta')!
+    const peerBetaOnAlpha = nodeA.bus.state.internal.peers.get('node-beta')!
     await nodeA.transport.sendKeepalive(peerBetaOnAlpha)
 
     // Wait for lastReceived to update on beta's side
     await waitFor(() => {
-      const p = nodeB.bus.state.internal.peers.find((pp) => pp.name === 'node-alpha')
+      const p = nodeB.bus.state.internal.peers.get('node-alpha')
       return p !== undefined && p.lastReceived > beforeKeepalive
     })
 
-    const peerAfter = nodeB.bus.state.internal.peers.find((p) => p.name === 'node-alpha')!
+    const peerAfter = nodeB.bus.state.internal.peers.get('node-alpha')!
     expect(peerAfter.lastReceived).toBeGreaterThan(beforeKeepalive)
   })
 }, 15_000)

--- a/apps/web-ui/frontend/src/components/AdaptersTab.tsx
+++ b/apps/web-ui/frontend/src/components/AdaptersTab.tsx
@@ -60,8 +60,8 @@ function formatResponseTime(ms?: number | null): string {
 function oldestLastChecked(rows: AdapterRow[]): string | null {
   let oldest: string | null = null
   for (const row of rows) {
-    if (row.lastChecked) {
-      if (!oldest || row.lastChecked < oldest) oldest = row.lastChecked
+    if (row.lastCheckedAt) {
+      if (!oldest || row.lastCheckedAt < oldest) oldest = row.lastCheckedAt
     }
   }
   return oldest

--- a/apps/web-ui/frontend/src/hooks/useRouterState.ts
+++ b/apps/web-ui/frontend/src/hooks/useRouterState.ts
@@ -9,7 +9,7 @@ export interface DataChannelDefinition {
   envoyPort?: number
   healthStatus?: 'up' | 'down'
   responseTimeMs?: number | null
-  lastChecked?: string
+  lastCheckedAt?: string
 }
 
 export interface PeerRecord {

--- a/apps/web-ui/tests/e2e/dashboard.spec.ts
+++ b/apps/web-ui/tests/e2e/dashboard.spec.ts
@@ -70,7 +70,7 @@ test.describe('Dashboard E2E', () => {
     expect(bodyText).not.toContain('isStale')
   })
 
-  test('Adapters tab shows local routes', async ({ page }) => {
+  test('Adapters tab shows data channels table', async ({ page }) => {
     await page.goto('/')
 
     // Click on Adapters tab
@@ -79,10 +79,10 @@ test.describe('Dashboard E2E', () => {
     // Wait for adapters to load
     await expect(page.getByText('loading adapters...')).toBeHidden({ timeout: 10000 })
 
-    // Should show local routes section
-    await expect(page.getByText('Local Routes')).toBeVisible()
+    // Should show table with data channel headers and route data
+    await expect(page.getByText('Data channel')).toBeVisible()
     await expect(page.getByText('books-api')).toBeVisible()
-    await expect(page.getByText('http:graphql')).toBeVisible()
+    await expect(page.getByText('http:graphql').first()).toBeVisible()
   })
 
   test('tab switching works correctly', async ({ page }) => {
@@ -95,7 +95,7 @@ test.describe('Dashboard E2E', () => {
     // Switch to Adapters
     await page.getByRole('button', { name: 'Adapters' }).click()
     await expect(page.getByText('loading adapters...')).toBeHidden({ timeout: 10000 })
-    await expect(page.getByText('Local Routes')).toBeVisible()
+    await expect(page.getByText('Data channel')).toBeVisible()
 
     // Switch back to Services
     await page.getByRole('button', { name: 'Services' }).click()


### PR DESCRIPTION
(this stack replaces https://app.graphite.com/github/pr/orbisoperations/catalyst-router/582?mode=tour,  https://app.graphite.com/github/pr/orbisoperations/catalyst-router/566?mode=tour, https://app.graphite.com/github/pr/orbisoperations/catalyst-router/572?mode=tour )

This stack locally tested with this:

`Unit Tests (450 total)`

- `157 routing package tests — all pass`
- `293 orchestrator tests — all pass`

`Playwright E2E Tests (7 total)`

- `System Status header renders`
- `Service groups with health status display`
- `Service cards show names`
- `Peers section with connected peer`
- `No credential fields leak in page content`
- `Adapters tab shows data channels table`
- `Tab switching works correctly`

`V1 Topology Tests (7 total)`

- `Linear topology propagation + withdrawal`
- `Initial sync (C learns A's routes via B)`
- `Loop prevention`
- `Bidirectional peering propagation`
- `Simple peering A<->B`
- `Peer token validation`

`Live Docker Cluster (two-node)`

- `Rebuilt images from current branch`
- `All containers healthy (orchestrator, auth, envoy, gateway, books, movies, web-ui)`
- `Registered books-api on node-a via WebSocket RPC`
- `Registered movies-api on node-b via WebSocket RPC`
- `API verification:`
    - `GET /api/state returns proper arrays (Map→array serialization working)`
    - `Health checker live: healthStatus: "up", responseTimeMs: 6, lastCheckedAt updating`
    - `No credentials in API response (no peerToken, holdTime, etc.)`
- `Direct adapter queries:`
    - `books-api (port 8081): returns 3 books (Tolkien, Austen)`
    - `movies-api (port 8082): returns 3 movies (Jackson, Morton, Wright)`
- `UI verification (Playwright browser):`
    - `Services tab: 4/4 operational with response times and UP badges`
    - `Adapters tab: books-api row with protocol, endpoint, origin "local", status "Up", 11ms response, "Last checked: 26s ago"`



---

---

Convert all RouteTable access from array operations (.find, .filter,
.length, [0]) to Map operations (.get, .has, .size, .values()).

bus.ts, rpc.ts, catalyst-service.ts, and all test files updated.