### PR TITLE
fix(zenoh-router): demo init update to ignore devDependencies

### DIFF
--- a/demo/zenoh-tak/docker-compose.yaml
+++ b/demo/zenoh-tak/docker-compose.yaml
@@ -380,16 +380,18 @@ services:
       # Subscribe to CoT data published by the emulators on Node A
       - ZENOH_SUBSCRIPTIONS=[{"topic":"tak/cot","transform":"identity"}]
       # TAK server connection (optional — uncomment for real TAK integration)
-      # - TAK_HEARTBEAT_INTERVAL=5000
-      # - TAK_HEARTBEAT_CALLSIGN=redweek-tak-publisher
-      # - TAK_HEARTBEAT_CALLSIGN_UID=redweek-zeno-publisher-callsign-1234
-      # - TAK_HEARTBEAT_GROUP_ROLE=Team Member
-      # - TAK_HEARTBEAT_GROUP_NAME=Green Team
-      # - TAK_HOST=tak-server-feb-demo.fly.dev
-      # - TAK_PORT=8089
-      # - TAK_TLS_CERT=/app/certs/catalyst.cert.pem
-      # - TAK_TLS_KEY=/app/certs/catalyst.key.pem
+      - TAK_HEARTBEAT_INTERVAL=5000
+      - TAK_HEARTBEAT_CALLSIGN=redweek-tak-publisher
+      - TAK_HEARTBEAT_CALLSIGN_UID=hackathon-zeno-publisher-callsign-1234
+      - TAK_HEARTBEAT_GROUP_ROLE=Team Member
+      - TAK_HEARTBEAT_GROUP_NAME=Green Team
+      - TAK_HOST=tak-server-feb-demo.fly.dev
+      - TAK_PORT=8089
+      - TAK_TLS_CERT=/app/certs/catalyst.cert.pem
+      - TAK_TLS_KEY=/app/certs/catalyst.key.pem
       - LOG_LEVEL=info
+    volumes:
+      - ./:/app/certs:ro
     labels:
       catalyst.stack: c
     depends_on:

--- a/examples/zeno-tak-adapter-v2/Dockerfile
+++ b/examples/zeno-tak-adapter-v2/Dockerfile
@@ -1,9 +1,16 @@
 FROM node:22-alpine AS builder
 WORKDIR /app
 
-# Install dependencies
+# Strip devDependencies that use pnpm catalog references (catalog:testing)
+# which require the workspace root. We only need runtime deps + build tools.
 COPY package.json ./
-RUN corepack enable && pnpm install
+RUN corepack enable && \
+    node -e " \
+    const pkg = JSON.parse(require('fs').readFileSync('package.json','utf8')); \
+    delete pkg.devDependencies; \
+    require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));" && \
+    pnpm install --no-frozen-lockfile && \
+    pnpm add -D esbuild esbuild-plugin-wasm typescript
 
 # Copy source, build script, and Zenoh configs
 COPY src ./src
@@ -59,7 +66,11 @@ RUN ARCH=$(uname -m) && \
 # Install Node.js runtime dependencies for the bundled app
 RUN corepack enable
 COPY package.json pnpm-lock.yaml* ./
-RUN pnpm install --prod --frozen-lockfile || pnpm install --prod
+RUN node -e " \
+    const pkg = JSON.parse(require('fs').readFileSync('package.json','utf8')); \
+    delete pkg.devDependencies; \
+    require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));" && \
+    pnpm install --prod --no-frozen-lockfile
 
 COPY --from=builder /app/dist /app/dist
 


### PR DESCRIPTION
### TL;DR

Enabled TAK server integration in the zenoh-tak demo and fixed Docker build issues for the zeno-tak-adapter-v2

### What changed?

- Uncommented and activated TAK server environment variables in the docker-compose configuration, including heartbeat settings, server connection details, and TLS certificate paths
- Updated the TAK heartbeat callsign UID from "redweek-zeno-publisher-callsign-1234" to "hackathon-zeno-publisher-callsign-1234"
- Added a volume mount for certificate files in the docker-compose service
- Modified the Dockerfile to handle pnpm catalog references by stripping devDependencies before installation and manually adding required build tools
- Updated both builder and runtime stages to use `--no-frozen-lockfile` flag to avoid lockfile conflicts

### How to test?

1. Run `docker-compose up` in the demo/zenoh-tak directory to verify the TAK server connection is established
2. Check that the service can access TLS certificates from the mounted volume
3. Build the zeno-tak-adapter-v2 Docker image to ensure the build process completes without pnpm catalog reference errors

### Why make this change?

The TAK server integration was previously disabled, limiting the demo's functionality. The Docker build was failing due to pnpm workspace catalog references that aren't available in the container context, preventing successful image creation.