### PR TITLE
feat(orchestrator): fixes

### DIFF
--- a/apps/orchestrator/src/v2/rpc.ts
+++ b/apps/orchestrator/src/v2/rpc.ts
@@ -1,14 +1,14 @@
-import { Actions, PeerView, InternalRouteView } from '@catalyst/routing/v2'
 import type {
-  PeerInfo,
-  PeerRecord,
   DataChannelDefinition,
   InternalRoute,
+  PeerInfo,
+  PublicPeer,
   UpdateMessageSchema,
 } from '@catalyst/routing/v2'
-import type { z } from 'zod'
-import { decodeJwt } from 'jose'
+import { Actions, InternalRouteView, PeerView } from '@catalyst/routing/v2'
 import { getLogger, withWideEvent } from '@catalyst/telemetry'
+import { decodeJwt } from 'jose'
+import type { z } from 'zod'
 import type { OrchestratorBus } from './bus.js'
 
 const logger = getLogger(['catalyst', 'orchestrator', 'rpc'])
@@ -35,7 +35,7 @@ export interface NetworkClient {
   removePeer(
     peer: Pick<PeerInfo, 'name'>
   ): Promise<{ success: true } | { success: false; error: string }>
-  listPeers(): Promise<PeerRecord[]>
+  listPeers(): Promise<PublicPeer[]>
 }
 
 export interface DataChannel {

--- a/apps/orchestrator/src/v2/service.ts
+++ b/apps/orchestrator/src/v2/service.ts
@@ -171,7 +171,10 @@ export class OrchestratorServiceV2 {
 
     // 6b. Recalculate tick interval after peer connection events so keepalive
     //     frequency tracks the minimum negotiated holdTime (BGP: keepalive = holdTime / 3).
-    const peerActions = new Set([Actions.InternalProtocolOpen, Actions.InternalProtocolConnected])
+    const peerActions: Set<string> = new Set([
+      Actions.InternalProtocolOpen,
+      Actions.InternalProtocolConnected,
+    ])
     const originalDispatch = this.bus.dispatch.bind(this.bus)
     this.bus.dispatch = async (action) => {
       const result = await originalDispatch(action)

--- a/apps/orchestrator/tests/routes/api-state.test.ts
+++ b/apps/orchestrator/tests/routes/api-state.test.ts
@@ -20,6 +20,7 @@ function makeRouteTable(): RouteTable {
           domains: ['example.local'],
           connectionStatus: 'connected' as const,
           peerToken: 'secret-token-1',
+          lastConnected: 0,
           holdTime: 90_000,
           lastSent: 100,
           lastReceived: 200,

--- a/apps/orchestrator/tests/routes/dashboard.test.ts
+++ b/apps/orchestrator/tests/routes/dashboard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import type { CatalystConfig } from '@catalyst/config'
+import type { CatalystConfig, OrchestratorConfig } from '@catalyst/config'
 import type { DashboardStateProvider } from '../../src/routes/dashboard.js'
 
 import { createDashboardRoutes } from '../../src/routes/dashboard.js'
@@ -13,7 +13,23 @@ const defaultEnvoyConfig = {
   portRange: [[10000, 10100]] as [number, number][],
 }
 
-function makeConfig(overrides: Partial<CatalystConfig> = {}): CatalystConfig {
+const defaultOrchestratorConfig = {
+  envoyConfig: defaultEnvoyConfig,
+  allowNoAuth: false,
+  journal: {
+    mode: 'memory' as const,
+    compactionIntervalMs: 86_400_000,
+    minEntries: 1000,
+    tailSize: 100,
+  },
+}
+
+function makeConfig(
+  overrides: Omit<Partial<CatalystConfig>, 'orchestrator'> & {
+    orchestrator?: Partial<OrchestratorConfig>
+  } = {}
+): CatalystConfig {
+  const { orchestrator: orchOverrides, ...rest } = overrides
   return {
     node: {
       name: 'test-node',
@@ -22,10 +38,10 @@ function makeConfig(overrides: Partial<CatalystConfig> = {}): CatalystConfig {
     },
     port: 3000,
     orchestrator: {
-      envoyConfig: defaultEnvoyConfig,
-      ...(overrides.orchestrator ?? {}),
+      ...defaultOrchestratorConfig,
+      ...(orchOverrides ?? {}),
     },
-    ...overrides,
+    ...rest,
   }
 }
 


### PR DESCRIPTION
### TL;DR

Updated NetworkClient interface to return PublicPeer instead of PeerRecord and improved type safety across the orchestrator module.

### What changed?

- Changed `NetworkClient.listPeers()` return type from `PeerRecord[]` to `PublicPeer[]`
- Added explicit type annotation for `peerActions` as `Set<string>` in OrchestratorServiceV2
- Added missing `lastConnected: 0` property to test route table peer configuration
- Improved type safety in dashboard test configuration by separating orchestrator config overrides
- Reorganized imports for better consistency

### How to test?

Run the existing test suites to ensure:
- API state tests pass with the new peer configuration
- Dashboard tests work with the updated config structure
- NetworkClient implementations correctly return PublicPeer objects

### Why make this change?

This change improves type safety by using more specific types (PublicPeer vs PeerRecord) and ensures test configurations include all required properties. The explicit type annotations help prevent type inference issues and make the code more maintainable.