### PR TITLE
feat(routing): BGP hardening — max prefix limits + route flap damping

### DIFF
--- a/apps/orchestrator/src/v2/bus.ts
+++ b/apps/orchestrator/src/v2/bus.ts
@@ -3,6 +3,7 @@ import {
   ActionQueue,
   Actions,
   CloseCodes,
+  routeKey,
   type Action,
   type RouteTable,
   type PlanResult,
@@ -662,6 +663,13 @@ export class OrchestratorBus {
         if (change.type !== 'removed' && this.routePolicy !== undefined) {
           const allowed = this.routePolicy.canSend(peer, [route])
           if (allowed.length === 0) continue
+        }
+
+        // --- Flap damping: skip suppressed routes ---
+        if (change.type !== 'removed') {
+          const fk = `${routeKey(route)}:${route.originNode}`
+          const flapEntry = this.rib.flapState.get(fk)
+          if (flapEntry?.suppressed) continue
         }
 
         // Multi-hop: envoyPort is already stamped by planPortAllocations.

--- a/apps/orchestrator/src/v2/bus.ts
+++ b/apps/orchestrator/src/v2/bus.ts
@@ -207,6 +207,25 @@ export class OrchestratorBus {
           })
         }
 
+        // --- Max prefix warning at 80% threshold ---
+        if (action.action === Actions.InternalProtocolUpdate) {
+          const peerName = action.data.peerInfo.name
+          const peer = committed.internal.peers.find((p) => p.name === peerName)
+          if (peer?.maxPrefixes && peer.maxPrefixes > 0) {
+            const count = committed.internal.routes.filter((r) => r.peer.name === peerName).length
+            const warnAt = Math.floor(peer.maxPrefixes * 0.8)
+            if (count >= warnAt) {
+              logger.warn('Peer {peerName} at {count}/{limit} prefixes ({pct}%)', {
+                'event.name': 'peer.prefix_limit.warning',
+                peerName,
+                count,
+                limit: peer.maxPrefixes,
+                pct: Math.round((count / peer.maxPrefixes) * 100),
+              })
+            }
+          }
+        }
+
         await this.handlePostCommit(action, plan, committed, event)
 
         return { success: true, state: committed, action }

--- a/apps/orchestrator/tests/v2/flap-damping.test.ts
+++ b/apps/orchestrator/tests/v2/flap-damping.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest'
+import {
+  RoutingInformationBase,
+  Actions,
+  newRouteTable,
+  routeKey,
+  FLAP_PENALTY_INCREMENT,
+  FLAP_SUPPRESS_THRESHOLD,
+} from '@catalyst/routing/v2'
+import type { RouteTable, PeerRecord, PeerInfo } from '@catalyst/routing/v2'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const nodeId = 'node-a'
+const peerB: PeerInfo = { name: 'node-b', endpoint: 'ws://b:4000', domains: ['test.local'] }
+const route1 = { name: 'svc-1', protocol: 'http' as const, endpoint: 'http://svc-1:8080' }
+const route2 = { name: 'svc-2', protocol: 'http' as const, endpoint: 'http://svc-2:8080' }
+
+function connectedState(): RouteTable {
+  const state = newRouteTable()
+  const peer: PeerRecord = {
+    ...peerB,
+    connectionStatus: 'connected',
+    lastConnected: 1000,
+    holdTime: 90_000,
+    lastSent: 0,
+    lastReceived: 1000,
+  }
+  state.internal.peers = [peer]
+  return state
+}
+
+function addAction(route: typeof route1) {
+  return {
+    action: Actions.InternalProtocolUpdate as const,
+    data: {
+      peerInfo: peerB,
+      update: {
+        updates: [{ action: 'add' as const, route, nodePath: ['node-b'], originNode: 'node-b' }],
+      },
+    },
+  }
+}
+
+function removeAction(route: typeof route1) {
+  return {
+    action: Actions.InternalProtocolUpdate as const,
+    data: {
+      peerInfo: peerB,
+      update: {
+        updates: [{ action: 'remove' as const, route, nodePath: ['node-b'], originNode: 'node-b' }],
+      },
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('route flap damping (RFC 7196 / RIPE-580)', () => {
+  it('single withdraw/re-add below threshold — not suppressed', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = connectedState()
+
+    // Add route
+    const a1 = addAction(route1)
+    const p1 = rib.plan(a1, state)
+    rib.commit(p1, a1)
+
+    // Remove route
+    const r1 = removeAction(route1)
+    const p2 = rib.plan(r1, rib.state)
+    rib.commit(p2, r1)
+
+    // Re-add route
+    const a2 = addAction(route1)
+    const p3 = rib.plan(a2, rib.state)
+    rib.commit(p3, a2)
+
+    const fk = routeKey(route1) + ':node-b'
+    const entry = rib.flapState.get(fk)
+    expect(entry).toBeDefined()
+    // One remove (1000) + one add-after-remove (decayed ~1000 + 1000 ≈ 2000)
+    expect(entry!.penalty).toBeGreaterThanOrEqual(FLAP_PENALTY_INCREMENT)
+    expect(entry!.penalty).toBeLessThan(FLAP_SUPPRESS_THRESHOLD)
+    expect(entry!.suppressed).toBe(false)
+  })
+
+  it('six rapid flaps exceed threshold — suppressed', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = connectedState()
+
+    let currentState = state
+    for (let i = 0; i < 6; i++) {
+      const add = addAction(route1)
+      const ap = rib.plan(add, currentState)
+      rib.commit(ap, add)
+      currentState = rib.state
+
+      const rm = removeAction(route1)
+      const rp = rib.plan(rm, currentState)
+      rib.commit(rp, rm)
+      currentState = rib.state
+    }
+
+    // Final add
+    const finalAdd = addAction(route1)
+    const fp = rib.plan(finalAdd, currentState)
+    rib.commit(fp, finalAdd)
+
+    const fk = routeKey(route1) + ':node-b'
+    const entry = rib.flapState.get(fk)
+    expect(entry).toBeDefined()
+    expect(entry!.suppressed).toBe(true)
+    expect(entry!.penalty).toBeGreaterThanOrEqual(FLAP_SUPPRESS_THRESHOLD)
+  })
+
+  it('different routes from same peer damped independently', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = connectedState()
+
+    // Flap route1 six times to suppress it
+    let currentState = state
+    for (let i = 0; i < 6; i++) {
+      const add = addAction(route1)
+      const ap = rib.plan(add, currentState)
+      rib.commit(ap, add)
+      currentState = rib.state
+
+      const rm = removeAction(route1)
+      const rp = rib.plan(rm, currentState)
+      rib.commit(rp, rm)
+      currentState = rib.state
+    }
+    // Final add for route1
+    const finalAdd1 = addAction(route1)
+    const fp1 = rib.plan(finalAdd1, currentState)
+    rib.commit(fp1, finalAdd1)
+    currentState = rib.state
+
+    // Add route2 normally (no flapping)
+    const add2 = addAction(route2)
+    const ap2 = rib.plan(add2, currentState)
+    rib.commit(ap2, add2)
+
+    const fk1 = routeKey(route1) + ':node-b'
+    const fk2 = routeKey(route2) + ':node-b'
+
+    const entry1 = rib.flapState.get(fk1)
+    expect(entry1).toBeDefined()
+    expect(entry1!.suppressed).toBe(true)
+
+    // route2 should have no flap entry (never withdrawn)
+    const entry2 = rib.flapState.get(fk2)
+    expect(entry2).toBeUndefined()
+  })
+})

--- a/apps/orchestrator/tests/v2/flap-damping.test.ts
+++ b/apps/orchestrator/tests/v2/flap-damping.test.ts
@@ -6,6 +6,8 @@ import {
   routeKey,
   FLAP_PENALTY_INCREMENT,
   FLAP_SUPPRESS_THRESHOLD,
+  FLAP_HALF_LIFE_MS,
+  FLAP_MAX_SUPPRESS_MS,
 } from '@catalyst/routing/v2'
 import type { RouteTable, PeerRecord, PeerInfo } from '@catalyst/routing/v2'
 
@@ -156,5 +158,87 @@ describe('route flap damping (RFC 7196 / RIPE-580)', () => {
     // route2 should have no flap entry (never withdrawn)
     const entry2 = rib.flapState.get(fk2)
     expect(entry2).toBeUndefined()
+  })
+
+  it('tick decays penalty — suppressed route becomes reusable after 4 half-lives', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = connectedState()
+
+    // Flap route1 six times to suppress it
+    let currentState = state
+    for (let i = 0; i < 6; i++) {
+      const add = addAction(route1)
+      const ap = rib.plan(add, currentState)
+      rib.commit(ap, add)
+      currentState = rib.state
+
+      const rm = removeAction(route1)
+      const rp = rib.plan(rm, currentState)
+      rib.commit(rp, rm)
+      currentState = rib.state
+    }
+
+    // Final add
+    const finalAdd = addAction(route1)
+    const fp = rib.plan(finalAdd, currentState)
+    rib.commit(fp, finalAdd)
+    currentState = rib.state
+
+    const fk = routeKey(route1) + ':node-b'
+    expect(rib.flapState.get(fk)?.suppressed).toBe(true)
+
+    // Dispatch Tick far enough in the future: penalty is ~12000 after 6 flap cycles.
+    // 5 half-lives => 12000 * 0.5^5 = 375 < 750 reuse threshold.
+    const tickAction = {
+      action: Actions.Tick as const,
+      data: { now: Date.now() + FLAP_HALF_LIFE_MS * 5 },
+    }
+    const tickPlan = rib.plan(tickAction, currentState)
+    rib.commit(tickPlan, tickAction)
+
+    const entry = rib.flapState.get(fk)
+    expect(entry).toBeDefined()
+    expect(entry!.suppressed).toBe(false)
+  })
+
+  it('max suppress time cap — unsuppressed after 30 minutes despite high penalty', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = connectedState()
+
+    // Flap route1 twenty times to get very high penalty
+    let currentState = state
+    for (let i = 0; i < 20; i++) {
+      const add = addAction(route1)
+      const ap = rib.plan(add, currentState)
+      rib.commit(ap, add)
+      currentState = rib.state
+
+      const rm = removeAction(route1)
+      const rp = rib.plan(rm, currentState)
+      rib.commit(rp, rm)
+      currentState = rib.state
+    }
+
+    // Final add
+    const finalAdd = addAction(route1)
+    const fp = rib.plan(finalAdd, currentState)
+    rib.commit(fp, finalAdd)
+    currentState = rib.state
+
+    const fk = routeKey(route1) + ':node-b'
+    expect(rib.flapState.get(fk)?.suppressed).toBe(true)
+
+    // Dispatch Tick just past the max suppress duration (30 min + 1 sec)
+    const tickAction = {
+      action: Actions.Tick as const,
+      data: { now: Date.now() + FLAP_MAX_SUPPRESS_MS + 1000 },
+    }
+    const tickPlan = rib.plan(tickAction, currentState)
+    rib.commit(tickPlan, tickAction)
+
+    const entry = rib.flapState.get(fk)
+    // Should be unsuppressed even though penalty may still be above reuse threshold
+    expect(entry).toBeDefined()
+    expect(entry!.suppressed).toBe(false)
   })
 })

--- a/apps/orchestrator/tests/v2/flap-damping.test.ts
+++ b/apps/orchestrator/tests/v2/flap-damping.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   RoutingInformationBase,
   Actions,
@@ -10,6 +10,9 @@ import {
   FLAP_MAX_SUPPRESS_MS,
 } from '@catalyst/routing/v2'
 import type { RouteTable, PeerRecord, PeerInfo } from '@catalyst/routing/v2'
+import { OrchestratorBus } from '../../src/v2/bus.js'
+import { MockPeerTransport, type TransportCall } from '../../src/v2/transport.js'
+import type { OrchestratorConfig } from '../../src/v1/types.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -240,5 +243,343 @@ describe('route flap damping (RFC 7196 / RIPE-580)', () => {
     // Should be unsuppressed even though penalty may still be above reuse threshold
     expect(entry).toBeDefined()
     expect(entry!.suppressed).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Topology helpers (copied from orchestrator.topology.test.ts)
+// ---------------------------------------------------------------------------
+
+function topoMakeConfig(name: string): OrchestratorConfig {
+  return {
+    node: { name, endpoint: `ws://${name}:4000`, domains: ['topo.local'] },
+  }
+}
+
+function topoMakePeerInfo(name: string): PeerInfo {
+  return {
+    name,
+    endpoint: `ws://${name}:4000`,
+    domains: ['topo.local'],
+    peerToken: `token-${name}`,
+  }
+}
+
+function makeRoute(name: string) {
+  return { name, protocol: 'http' as const, endpoint: `http://${name}:8080` }
+}
+
+interface BusEntry {
+  name: string
+  bus: OrchestratorBus
+  transport: MockPeerTransport
+  peerInfo: PeerInfo
+}
+
+class TopologyHelper {
+  private nodes = new Map<string, BusEntry>()
+
+  addNode(name: string): BusEntry {
+    const transport = new MockPeerTransport()
+    const config = topoMakeConfig(name)
+    const bus = new OrchestratorBus({ config, transport })
+    const entry: BusEntry = { name, bus, transport, peerInfo: topoMakePeerInfo(name) }
+    this.nodes.set(name, entry)
+    return entry
+  }
+
+  get(name: string): BusEntry {
+    const entry = this.nodes.get(name)
+    if (entry === undefined) throw new Error(`Unknown node: ${name}`)
+    return entry
+  }
+
+  async peer(nameA: string, nameB: string): Promise<void> {
+    const a = this.get(nameA)
+    const b = this.get(nameB)
+
+    await a.bus.dispatch({ action: Actions.LocalPeerCreate, data: b.peerInfo })
+    await b.bus.dispatch({ action: Actions.LocalPeerCreate, data: a.peerInfo })
+
+    await a.bus.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: b.peerInfo },
+    })
+    await b.bus.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: a.peerInfo },
+    })
+  }
+
+  async propagate(fromName: string, toName: string): Promise<void> {
+    const from = this.get(fromName)
+    const to = this.get(toName)
+
+    const consumed: TransportCall[] = []
+    const remaining: TransportCall[] = []
+    for (const call of from.transport.calls) {
+      if (call.method === 'sendUpdate' && call.peer.name === toName) {
+        consumed.push(call)
+      } else {
+        remaining.push(call)
+      }
+    }
+
+    from.transport.calls.length = 0
+    for (const c of remaining) {
+      from.transport.calls.push(c)
+    }
+
+    for (const call of consumed) {
+      if (call.method !== 'sendUpdate') continue
+      await to.bus.dispatch({
+        action: Actions.InternalProtocolUpdate,
+        data: { peerInfo: from.peerInfo, update: call.message },
+      })
+    }
+  }
+
+  resetAll(): void {
+    for (const entry of this.nodes.values()) {
+      entry.transport.reset()
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Topology: flap damping multi-node tests
+// ---------------------------------------------------------------------------
+
+describe('Flap damping topology', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  /**
+   * Helper: flap a route N times at a source node, propagating through the
+   * chain after each add and remove. Each cycle is:
+   *   1. source dispatches LocalRouteCreate
+   *   2. propagate through the chain
+   *   3. resetAll
+   *   4. source dispatches LocalRouteDelete
+   *   5. propagate through the chain
+   *   6. resetAll
+   */
+  async function flapRoute(
+    topo: TopologyHelper,
+    sourceName: string,
+    chain: string[],
+    routeName: string,
+    cycles: number
+  ): Promise<void> {
+    const route = makeRoute(routeName)
+    for (let i = 0; i < cycles; i++) {
+      await topo.get(sourceName).bus.dispatch({ action: Actions.LocalRouteCreate, data: route })
+      for (const [idx, from] of chain.entries()) {
+        const to = chain[idx + 1]
+        if (to !== undefined) await topo.propagate(from, to)
+      }
+      topo.resetAll()
+
+      await topo.get(sourceName).bus.dispatch({ action: Actions.LocalRouteDelete, data: route })
+      for (const [idx, from] of chain.entries()) {
+        const to = chain[idx + 1]
+        if (to !== undefined) await topo.propagate(from, to)
+      }
+      topo.resetAll()
+    }
+  }
+
+  it('A flaps route 6 times — B suppresses propagation to C', async () => {
+    const topo = new TopologyHelper()
+    topo.addNode('node-a')
+    topo.addNode('node-b')
+    topo.addNode('node-c')
+
+    await topo.peer('node-a', 'node-b')
+    await topo.peer('node-b', 'node-c')
+    topo.resetAll()
+
+    // Flap 'flappy' 6 times through A→B→C
+    await flapRoute(topo, 'node-a', ['node-a', 'node-b', 'node-c'], 'flappy', 6)
+
+    // Final add: A creates the route one last time
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: makeRoute('flappy'),
+    })
+    await topo.propagate('node-a', 'node-b')
+
+    // B should have 'flappy' in its internal routes (the route was accepted)
+    const bRoutes = topo.get('node-b').bus.state.internal.routes
+    expect(bRoutes.some((r) => r.name === 'flappy')).toBe(true)
+
+    // B's transport should have NO sendUpdate calls to C containing 'flappy' as an 'add'
+    // because B suppresses propagation of the flapping route
+    const callsToC = topo
+      .get('node-b')
+      .transport.calls.filter((c) => c.method === 'sendUpdate' && c.peer.name === 'node-c')
+
+    const addUpdatesForFlappy = callsToC.flatMap((c) =>
+      c.method === 'sendUpdate'
+        ? c.message.updates.filter(
+            (u: { action: string; route: { name: string } }) =>
+              u.action === 'add' && u.route.name === 'flappy'
+          )
+        : []
+    )
+    expect(addUpdatesForFlappy).toHaveLength(0)
+  })
+
+  it('after decay, B resumes propagating to C', async () => {
+    const topo = new TopologyHelper()
+    topo.addNode('node-a')
+    topo.addNode('node-b')
+    topo.addNode('node-c')
+
+    await topo.peer('node-a', 'node-b')
+    await topo.peer('node-b', 'node-c')
+    topo.resetAll()
+
+    // Flap 'flappy' 6 times, then final add — route is suppressed at B
+    await flapRoute(topo, 'node-a', ['node-a', 'node-b', 'node-c'], 'flappy', 6)
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: makeRoute('flappy'),
+    })
+    await topo.propagate('node-a', 'node-b')
+
+    // Verify suppressed at B
+    const fk = 'flappy:node-a'
+    expect(topo.get('node-b').bus.rib.flapState.get(fk)?.suppressed).toBe(true)
+    topo.resetAll()
+
+    // Advance time by 5 half-lives (25 minutes) — penalty decays well below reuse threshold.
+    // After 6 flap cycles + final add, penalty ~13000. 13000 * 0.5^5 = 406.25 < 750 reuse.
+    vi.setSystemTime(Date.now() + FLAP_HALF_LIFE_MS * 5)
+
+    // Keep peers alive: dispatch keepalives so hold timers don't expire
+    await topo.get('node-b').bus.dispatch({
+      action: Actions.InternalProtocolKeepalive,
+      data: { peerInfo: topo.get('node-a').peerInfo },
+    })
+    await topo.get('node-b').bus.dispatch({
+      action: Actions.InternalProtocolKeepalive,
+      data: { peerInfo: topo.get('node-c').peerInfo },
+    })
+    topo.resetAll()
+
+    // Dispatch Tick on B to trigger flap decay
+    await topo.get('node-b').bus.dispatch({
+      action: Actions.Tick,
+      data: { now: Date.now() },
+    })
+
+    // Verify unsuppressed
+    expect(topo.get('node-b').bus.rib.flapState.get(fk)?.suppressed ?? false).toBe(false)
+    topo.resetAll()
+
+    // Trigger a route change at B so it can propagate to C.
+    // Remove and re-add the route from A. The penalty from this single cycle
+    // is small relative to the decayed value, so it stays unsuppressed.
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteDelete,
+      data: makeRoute('flappy'),
+    })
+    await topo.propagate('node-a', 'node-b')
+    topo.resetAll()
+
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: makeRoute('flappy'),
+    })
+    await topo.propagate('node-a', 'node-b')
+    await topo.propagate('node-b', 'node-c')
+
+    // C should now have 'flappy' in its internal routes
+    const cRoutes = topo.get('node-c').bus.state.internal.routes
+    expect(cRoutes.some((r) => r.name === 'flappy')).toBe(true)
+  })
+
+  it('suppressed route loses best-path to fresh route from another peer', async () => {
+    const topo = new TopologyHelper()
+    topo.addNode('node-a')
+    topo.addNode('node-c')
+    topo.addNode('node-d')
+
+    // Wire A↔C and D↔C
+    await topo.peer('node-a', 'node-c')
+    await topo.peer('node-d', 'node-c')
+    topo.resetAll()
+
+    // Flap route 'contested' from A at C 6 times
+    await flapRoute(topo, 'node-a', ['node-a', 'node-c'], 'contested', 6)
+
+    // Final add from A, propagate A→C — route is suppressed at C
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: makeRoute('contested'),
+    })
+    await topo.propagate('node-a', 'node-c')
+
+    const fk = 'contested:node-a'
+    expect(topo.get('node-c').bus.rib.flapState.get(fk)?.suppressed).toBe(true)
+    topo.resetAll()
+
+    // D creates route 'contested' normally (no flap), propagate D→C
+    await topo.get('node-d').bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: makeRoute('contested'),
+    })
+    await topo.propagate('node-d', 'node-c')
+
+    // C should have 'contested' from D (originNode='node-d')
+    const cRoutes = topo.get('node-c').bus.state.internal.routes
+    const contestedRoute = cRoutes.find((r) => r.name === 'contested' && r.originNode === 'node-d')
+    expect(contestedRoute).toBeDefined()
+  })
+
+  it('independent damping — flappy suppressed, stable propagates', async () => {
+    const topo = new TopologyHelper()
+    topo.addNode('node-a')
+    topo.addNode('node-b')
+
+    await topo.peer('node-a', 'node-b')
+    topo.resetAll()
+
+    // Flap route 'flappy' from A at B 6 times, then final add
+    await flapRoute(topo, 'node-a', ['node-a', 'node-b'], 'flappy', 6)
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: makeRoute('flappy'),
+    })
+    await topo.propagate('node-a', 'node-b')
+    topo.resetAll()
+
+    // Also add route 'stable' from A normally
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: makeRoute('stable'),
+    })
+    await topo.propagate('node-a', 'node-b')
+
+    // B should have both routes in internal routes
+    const bRoutes = topo.get('node-b').bus.state.internal.routes
+    expect(bRoutes.some((r) => r.name === 'flappy')).toBe(true)
+    expect(bRoutes.some((r) => r.name === 'stable')).toBe(true)
+
+    // Check B's RIB flapState
+    const rib = topo.get('node-b').bus.rib
+    const flappyEntry = rib.flapState.get('flappy:node-a')
+    expect(flappyEntry).toBeDefined()
+    expect(flappyEntry!.suppressed).toBe(true)
+
+    // 'stable' was never withdrawn, so it has no flapState entry
+    const stableEntry = rib.flapState.get('stable:node-a')
+    expect(stableEntry).toBeUndefined()
   })
 })

--- a/apps/orchestrator/tests/v2/max-prefix.test.ts
+++ b/apps/orchestrator/tests/v2/max-prefix.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import { RoutingInformationBase, Actions, newRouteTable } from '@catalyst/routing/v2'
 import type { RouteTable, PeerRecord, PeerInfo } from '@catalyst/routing/v2'
+import { OrchestratorBus } from '../../src/v2/bus.js'
+import { MockPeerTransport, type TransportCall } from '../../src/v2/transport.js'
+import type { OrchestratorConfig } from '../../src/v1/types.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -179,5 +182,266 @@ describe('max prefix limits (drop-excess model)', () => {
     const addedC = planC.routeChanges.filter((c) => c.type === 'added')
     expect(addedC).toHaveLength(1)
     expect(addedC[0].route.name).toBe('svc-from-c')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Topology helpers (copied from orchestrator.topology.test.ts)
+// ---------------------------------------------------------------------------
+
+function topoMakeConfig(name: string): OrchestratorConfig {
+  return {
+    node: { name, endpoint: `ws://${name}:4000`, domains: ['topo.local'] },
+  }
+}
+
+function topoMakePeerInfo(name: string): PeerInfo {
+  return {
+    name,
+    endpoint: `ws://${name}:4000`,
+    domains: ['topo.local'],
+    peerToken: `token-${name}`,
+  }
+}
+
+interface BusEntry {
+  name: string
+  bus: OrchestratorBus
+  transport: MockPeerTransport
+  peerInfo: PeerInfo
+}
+
+class TopologyHelper {
+  private nodes = new Map<string, BusEntry>()
+
+  addNode(name: string): BusEntry {
+    const transport = new MockPeerTransport()
+    const config = topoMakeConfig(name)
+    const bus = new OrchestratorBus({ config, transport })
+    const entry: BusEntry = { name, bus, transport, peerInfo: topoMakePeerInfo(name) }
+    this.nodes.set(name, entry)
+    return entry
+  }
+
+  get(name: string): BusEntry {
+    const entry = this.nodes.get(name)
+    if (entry === undefined) throw new Error(`Unknown node: ${name}`)
+    return entry
+  }
+
+  async peer(nameA: string, nameB: string): Promise<void> {
+    const a = this.get(nameA)
+    const b = this.get(nameB)
+
+    await a.bus.dispatch({ action: Actions.LocalPeerCreate, data: b.peerInfo })
+    await b.bus.dispatch({ action: Actions.LocalPeerCreate, data: a.peerInfo })
+
+    await a.bus.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: b.peerInfo },
+    })
+    await b.bus.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: a.peerInfo },
+    })
+  }
+
+  async propagate(fromName: string, toName: string): Promise<void> {
+    const from = this.get(fromName)
+    const to = this.get(toName)
+
+    const consumed: TransportCall[] = []
+    const remaining: TransportCall[] = []
+    for (const call of from.transport.calls) {
+      if (call.method === 'sendUpdate' && call.peer.name === toName) {
+        consumed.push(call)
+      } else {
+        remaining.push(call)
+      }
+    }
+
+    from.transport.calls.length = 0
+    for (const c of remaining) {
+      from.transport.calls.push(c)
+    }
+
+    for (const call of consumed) {
+      if (call.method !== 'sendUpdate') continue
+      await to.bus.dispatch({
+        action: Actions.InternalProtocolUpdate,
+        data: { peerInfo: from.peerInfo, update: call.message },
+      })
+    }
+  }
+
+  resetAll(): void {
+    for (const entry of this.nodes.values()) {
+      entry.transport.reset()
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Topology tests for max prefix limits
+// ---------------------------------------------------------------------------
+
+describe('Topology: max prefix limits', () => {
+  it('drop-excess propagation: A→B (limit=5) →C, only 5 routes reach C', async () => {
+    const topo = new TopologyHelper()
+    topo.addNode('node-a')
+    topo.addNode('node-b')
+    topo.addNode('node-c')
+
+    // Wire A↔B manually so B has maxPrefixes=5 for A
+    await topo.get('node-b').bus.dispatch({
+      action: Actions.LocalPeerCreate,
+      data: { ...topo.get('node-a').peerInfo, maxPrefixes: 5 },
+    })
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalPeerCreate,
+      data: topo.get('node-b').peerInfo,
+    })
+    await topo.get('node-b').bus.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: topo.get('node-a').peerInfo },
+    })
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: topo.get('node-b').peerInfo },
+    })
+
+    // Wire B↔C with normal peering (no limit)
+    await topo.peer('node-b', 'node-c')
+    topo.resetAll()
+
+    // A creates 7 local routes
+    for (let i = 1; i <= 7; i++) {
+      await topo.get('node-a').bus.dispatch({
+        action: Actions.LocalRouteCreate,
+        data: makeRoute(`svc-${i}`),
+      })
+    }
+
+    // Propagate A→B: B should accept only 5
+    await topo.propagate('node-a', 'node-b')
+
+    const bRoutes = topo.get('node-b').bus.state.internal.routes
+    const bFromA = bRoutes.filter((r) => r.peer.name === 'node-a')
+    expect(bFromA).toHaveLength(5)
+
+    // Propagate B→C: C should receive exactly the 5 routes B accepted
+    await topo.propagate('node-b', 'node-c')
+
+    const cRoutes = topo.get('node-c').bus.state.internal.routes
+    expect(cRoutes).toHaveLength(5)
+  })
+
+  it('session stays alive after hitting limit: B still shows A as connected', async () => {
+    const topo = new TopologyHelper()
+    topo.addNode('node-a')
+    topo.addNode('node-b')
+
+    // Wire A↔B with B having maxPrefixes=2 for A
+    await topo.get('node-b').bus.dispatch({
+      action: Actions.LocalPeerCreate,
+      data: { ...topo.get('node-a').peerInfo, maxPrefixes: 2 },
+    })
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalPeerCreate,
+      data: topo.get('node-b').peerInfo,
+    })
+    await topo.get('node-b').bus.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: topo.get('node-a').peerInfo },
+    })
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: topo.get('node-b').peerInfo },
+    })
+    topo.resetAll()
+
+    // A creates 5 routes
+    for (let i = 1; i <= 5; i++) {
+      await topo.get('node-a').bus.dispatch({
+        action: Actions.LocalRouteCreate,
+        data: makeRoute(`svc-${i}`),
+      })
+    }
+
+    // Propagate A→B: B accepts only 2
+    await topo.propagate('node-a', 'node-b')
+
+    const bRoutes = topo.get('node-b').bus.state.internal.routes
+    expect(bRoutes.filter((r) => r.peer.name === 'node-a')).toHaveLength(2)
+
+    // Peer session must remain connected (drop-excess, not session-teardown)
+    const peerA = topo.get('node-b').bus.state.internal.peers.find((p) => p.name === 'node-a')
+    expect(peerA).toBeDefined()
+    expect(peerA!.connectionStatus).toBe('connected')
+  })
+
+  it('remove-then-add respects updated count', async () => {
+    const topo = new TopologyHelper()
+    topo.addNode('node-a')
+    topo.addNode('node-b')
+
+    // Wire A↔B with B having maxPrefixes=3 for A
+    await topo.get('node-b').bus.dispatch({
+      action: Actions.LocalPeerCreate,
+      data: { ...topo.get('node-a').peerInfo, maxPrefixes: 3 },
+    })
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalPeerCreate,
+      data: topo.get('node-b').peerInfo,
+    })
+    await topo.get('node-b').bus.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: topo.get('node-a').peerInfo },
+    })
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: topo.get('node-b').peerInfo },
+    })
+    topo.resetAll()
+
+    // Phase 1: A creates 3 routes, fill to limit
+    for (let i = 1; i <= 3; i++) {
+      await topo.get('node-a').bus.dispatch({
+        action: Actions.LocalRouteCreate,
+        data: makeRoute(`svc-${i}`),
+      })
+    }
+    await topo.propagate('node-a', 'node-b')
+
+    const bRoutesPhase1 = topo.get('node-b').bus.state.internal.routes
+    expect(bRoutesPhase1.filter((r) => r.peer.name === 'node-a')).toHaveLength(3)
+    topo.resetAll()
+
+    // Phase 2: A removes 2 routes, B should drop to 1
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteDelete,
+      data: makeRoute('svc-1'),
+    })
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteDelete,
+      data: makeRoute('svc-2'),
+    })
+    await topo.propagate('node-a', 'node-b')
+
+    const bRoutesPhase2 = topo.get('node-b').bus.state.internal.routes
+    expect(bRoutesPhase2.filter((r) => r.peer.name === 'node-a')).toHaveLength(1)
+    topo.resetAll()
+
+    // Phase 3: A creates 3 new routes — B should accept 2 more (back to limit of 3)
+    for (let i = 4; i <= 6; i++) {
+      await topo.get('node-a').bus.dispatch({
+        action: Actions.LocalRouteCreate,
+        data: makeRoute(`svc-${i}`),
+      })
+    }
+    await topo.propagate('node-a', 'node-b')
+
+    const bRoutesPhase3 = topo.get('node-b').bus.state.internal.routes
+    expect(bRoutesPhase3.filter((r) => r.peer.name === 'node-a')).toHaveLength(3)
   })
 })

--- a/apps/orchestrator/tests/v2/max-prefix.test.ts
+++ b/apps/orchestrator/tests/v2/max-prefix.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest'
+import { RoutingInformationBase, Actions, newRouteTable } from '@catalyst/routing/v2'
+import type { RouteTable, PeerRecord, PeerInfo } from '@catalyst/routing/v2'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const nodeId = 'node-a'
+const peerB: PeerInfo = { name: 'node-b', endpoint: 'ws://b:4000', domains: ['test.local'] }
+
+function makeRoute(name: string) {
+  return { name, protocol: 'http' as const, endpoint: `http://${name}:8080` }
+}
+
+function stateWithPeer(maxPrefixes?: number): RouteTable {
+  const state = newRouteTable()
+  const peer: PeerRecord = {
+    ...peerB,
+    connectionStatus: 'connected',
+    lastConnected: 1000,
+    holdTime: 90_000,
+    lastSent: 0,
+    lastReceived: 1000,
+    maxPrefixes,
+  }
+  state.internal.peers = [peer]
+  return state
+}
+
+function makeUpdate(names: string[], action: 'add' | 'remove' = 'add') {
+  return {
+    action: Actions.InternalProtocolUpdate as const,
+    data: {
+      peerInfo: peerB,
+      update: {
+        updates: names.map((name) => ({
+          action,
+          route: makeRoute(name),
+          nodePath: ['node-b'],
+          originNode: 'node-b',
+        })),
+      },
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('max prefix limits (drop-excess model)', () => {
+  it('accepts routes up to exactly the limit', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = stateWithPeer(3)
+    const action = makeUpdate(['svc-1', 'svc-2', 'svc-3'])
+
+    const plan = rib.plan(action, state)
+
+    expect(plan.routeChanges.filter((c) => c.type === 'added')).toHaveLength(3)
+    expect(plan.newState.internal.routes).toHaveLength(3)
+  })
+
+  it('drops excess routes individually', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = stateWithPeer(3)
+    const action = makeUpdate(['svc-1', 'svc-2', 'svc-3', 'svc-4', 'svc-5'])
+
+    const plan = rib.plan(action, state)
+
+    const added = plan.routeChanges.filter((c) => c.type === 'added')
+    expect(added).toHaveLength(3)
+    expect(added.map((c) => c.route.name)).toEqual(['svc-1', 'svc-2', 'svc-3'])
+    expect(plan.newState.internal.routes).toHaveLength(3)
+  })
+
+  it('remove below limit then add more succeeds', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+
+    // Fill to limit of 3
+    const state = stateWithPeer(3)
+    const fillAction = makeUpdate(['svc-1', 'svc-2', 'svc-3'])
+    const fillPlan = rib.plan(fillAction, state)
+    rib.commit(fillPlan, fillAction)
+
+    // Remove one route
+    const removeAction = makeUpdate(['svc-2'], 'remove')
+    const removePlan = rib.plan(removeAction, rib.state)
+    rib.commit(removePlan, removeAction)
+
+    expect(rib.state.internal.routes).toHaveLength(2)
+
+    // Add two new routes — only 1 should be accepted (back to limit of 3)
+    const addAction = makeUpdate(['svc-4', 'svc-5'])
+    const addPlan = rib.plan(addAction, rib.state)
+
+    const added = addPlan.routeChanges.filter((c) => c.type === 'added')
+    expect(added).toHaveLength(1)
+    expect(added[0].route.name).toBe('svc-4')
+  })
+
+  it('maxPrefixes: 0 means unlimited', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = stateWithPeer(0)
+    const names = Array.from({ length: 100 }, (_, i) => `svc-${i}`)
+    const action = makeUpdate(names)
+
+    const plan = rib.plan(action, state)
+
+    expect(plan.routeChanges.filter((c) => c.type === 'added')).toHaveLength(100)
+    expect(plan.newState.internal.routes).toHaveLength(100)
+  })
+
+  it('peer with no maxPrefixes set works unchanged', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = stateWithPeer(undefined)
+    const names = Array.from({ length: 50 }, (_, i) => `svc-${i}`)
+    const action = makeUpdate(names)
+
+    const plan = rib.plan(action, state)
+
+    expect(plan.routeChanges.filter((c) => c.type === 'added')).toHaveLength(50)
+    expect(plan.newState.internal.routes).toHaveLength(50)
+  })
+
+  it('count is per-peer', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+
+    const peerC: PeerInfo = { name: 'node-c', endpoint: 'ws://c:4000', domains: ['test.local'] }
+
+    const state = newRouteTable()
+    const peerBRecord: PeerRecord = {
+      ...peerB,
+      connectionStatus: 'connected',
+      lastConnected: 1000,
+      holdTime: 90_000,
+      lastSent: 0,
+      lastReceived: 1000,
+      maxPrefixes: 2,
+    }
+    const peerCRecord: PeerRecord = {
+      ...peerC,
+      connectionStatus: 'connected',
+      lastConnected: 1000,
+      holdTime: 90_000,
+      lastSent: 0,
+      lastReceived: 1000,
+      maxPrefixes: 2,
+    }
+    state.internal.peers = [peerBRecord, peerCRecord]
+
+    // Fill peer B: send 3, expect 2 accepted
+    const fillB = makeUpdate(['svc-1', 'svc-2', 'svc-3'])
+    const planB = rib.plan(fillB, state)
+    rib.commit(planB, fillB)
+
+    const addedB = planB.routeChanges.filter((c) => c.type === 'added')
+    expect(addedB).toHaveLength(2)
+
+    // Peer C should still be able to add routes
+    const fillC = {
+      action: Actions.InternalProtocolUpdate as const,
+      data: {
+        peerInfo: peerC,
+        update: {
+          updates: [
+            {
+              action: 'add' as const,
+              route: makeRoute('svc-from-c'),
+              nodePath: ['node-c'],
+              originNode: 'node-c',
+            },
+          ],
+        },
+      },
+    }
+    const planC = rib.plan(fillC, rib.state)
+
+    const addedC = planC.routeChanges.filter((c) => c.type === 'added')
+    expect(addedC).toHaveLength(1)
+    expect(addedC[0].route.name).toBe('svc-from-c')
+  })
+})

--- a/packages/routing/src/v2/local/actions.ts
+++ b/packages/routing/src/v2/local/actions.ts
@@ -12,7 +12,7 @@ export const localRouteDeleteAction = z.literal(Actions.LocalRouteDelete)
 
 export const localPeerCreateMessageSchema = z.object({
   action: z.literal(Actions.LocalPeerCreate),
-  data: PeerInfoSchema,
+  data: PeerInfoSchema.extend({ maxPrefixes: z.number().int().min(0).optional() }),
 })
 
 export const localPeerUpdateMessageSchema = z.object({

--- a/packages/routing/src/v2/rib/index.ts
+++ b/packages/routing/src/v2/rib/index.ts
@@ -1,2 +1,10 @@
 export { ActionQueue } from './action-queue.js'
 export { RoutingInformationBase } from './rib.js'
+export {
+  FLAP_PENALTY_INCREMENT,
+  FLAP_SUPPRESS_THRESHOLD,
+  FLAP_REUSE_THRESHOLD,
+  FLAP_HALF_LIFE_MS,
+  FLAP_MAX_SUPPRESS_MS,
+} from './rib.js'
+export type { FlapEntry } from './rib.js'

--- a/packages/routing/src/v2/rib/rib.ts
+++ b/packages/routing/src/v2/rib/rib.ts
@@ -46,6 +46,22 @@ type InternalProtocolKeepaliveData = Extract<
 type TickData = Extract<Action, { action: typeof Actions.Tick }>['data']
 
 // ---------------------------------------------------------------------------
+// Flap damping constants (RFC 2439 / RFC 7196 / RIPE-580)
+// ---------------------------------------------------------------------------
+export const FLAP_PENALTY_INCREMENT = 1000
+export const FLAP_SUPPRESS_THRESHOLD = 6000
+export const FLAP_REUSE_THRESHOLD = 750
+export const FLAP_HALF_LIFE_MS = 300_000 // 5 minutes
+export const FLAP_MAX_SUPPRESS_MS = 1_800_000 // 30 minutes
+
+export type FlapEntry = {
+  penalty: number
+  suppressed: boolean
+  suppressedAt: number | null
+  lastUpdated: number
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -88,6 +104,23 @@ export class RoutingInformationBase {
 
   get nodeId(): string {
     return this._nodeId
+  }
+
+  /** Ephemeral flap damping state — does not survive restart. */
+  private _flapState = new Map<string, FlapEntry>()
+
+  get flapState(): ReadonlyMap<string, FlapEntry> {
+    return this._flapState
+  }
+
+  private flapKey(rKey: string, originNode: string): string {
+    return `${rKey}:${originNode}`
+  }
+
+  private decayPenalty(entry: FlapEntry, now: number): number {
+    const elapsed = now - entry.lastUpdated
+    if (elapsed <= 0) return entry.penalty
+    return entry.penalty * Math.pow(0.5, elapsed / FLAP_HALF_LIFE_MS)
   }
 
   /**
@@ -460,6 +493,22 @@ export class RoutingInformationBase {
           routeChanges.push({ type: 'added', route: newRoute })
           if (hasLimit) currentPeerRouteCount++
         }
+
+        // --- Flap damping: track add-after-remove ---
+        const fk = this.flapKey(routeKey(item.route), item.originNode)
+        const flapEntry = this._flapState.get(fk)
+        if (flapEntry && flapEntry.penalty > 0) {
+          const now = Date.now()
+          const decayed = this.decayPenalty(flapEntry, now)
+          const newPenalty = decayed + FLAP_PENALTY_INCREMENT
+          const shouldSuppress = newPenalty >= FLAP_SUPPRESS_THRESHOLD
+          this._flapState.set(fk, {
+            penalty: newPenalty,
+            suppressed: shouldSuppress,
+            suppressedAt: shouldSuppress && !flapEntry.suppressed ? now : flapEntry.suppressedAt,
+            lastUpdated: now,
+          })
+        }
       } else {
         // action === 'remove'
         const key = routeKey(item.route)
@@ -470,6 +519,26 @@ export class RoutingInformationBase {
           if (hasLimit) currentPeerRouteCount--
           if (removed.envoyPort != null) {
             portOps.push({ type: 'release', routeKey: key, port: removed.envoyPort })
+          }
+
+          // --- Flap damping: mark as recently withdrawn ---
+          const fk = this.flapKey(routeKey(item.route), item.originNode)
+          const flapExisting = this._flapState.get(fk)
+          const now = Date.now()
+          if (!flapExisting) {
+            this._flapState.set(fk, {
+              penalty: FLAP_PENALTY_INCREMENT,
+              suppressed: false,
+              suppressedAt: null,
+              lastUpdated: now,
+            })
+          } else {
+            const decayed = this.decayPenalty(flapExisting, now)
+            this._flapState.set(fk, {
+              ...flapExisting,
+              penalty: decayed + FLAP_PENALTY_INCREMENT,
+              lastUpdated: now,
+            })
           }
         }
       }

--- a/packages/routing/src/v2/rib/rib.ts
+++ b/packages/routing/src/v2/rib/rib.ts
@@ -155,7 +155,10 @@ export class RoutingInformationBase {
   // Local peer handlers
   // -------------------------------------------------------------------------
 
-  private planLocalPeerCreate(data: PeerInfo, state: RouteTable): PlanResult {
+  private planLocalPeerCreate(
+    data: PeerInfo & { maxPrefixes?: number },
+    state: RouteTable
+  ): PlanResult {
     const exists = state.internal.peers.some((p) => p.name === data.name)
     if (exists) return noChange(state)
 
@@ -411,10 +414,23 @@ export class RoutingInformationBase {
     const portOps: PortOperation[] = []
     const routeChanges: RouteChange[] = []
 
+    // --- Max prefix limit setup ---
+    const limitPeer = state.internal.peers.find((p) => p.name === data.peerInfo.name)
+    const prefixLimit = limitPeer?.maxPrefixes
+    const hasLimit = prefixLimit != null && prefixLimit > 0
+    let currentPeerRouteCount = hasLimit
+      ? routes.filter((r) => r.peer.name === data.peerInfo.name).length
+      : 0
+
     for (const item of data.update.updates) {
       if (item.action === 'add') {
         // Loop detection — discard advertisements that already include this node
         if (item.nodePath.includes(this._nodeId)) continue
+
+        // --- Max prefix limit check ---
+        if (hasLimit && currentPeerRouteCount >= prefixLimit!) {
+          continue // Drop excess route (Juniper drop-excess model)
+        }
 
         const key = routeKey(item.route)
         const existingIdx = routes.findIndex(
@@ -442,6 +458,7 @@ export class RoutingInformationBase {
         } else {
           routes = [...routes, newRoute]
           routeChanges.push({ type: 'added', route: newRoute })
+          if (hasLimit) currentPeerRouteCount++
         }
       } else {
         // action === 'remove'
@@ -450,6 +467,7 @@ export class RoutingInformationBase {
         if (removed !== undefined) {
           routes = routes.filter((r) => !(routeKey(r) === key && r.originNode === item.originNode))
           routeChanges.push({ type: 'removed', route: removed })
+          if (hasLimit) currentPeerRouteCount--
           if (removed.envoyPort != null) {
             portOps.push({ type: 'release', routeKey: key, port: removed.envoyPort })
           }

--- a/packages/routing/src/v2/rib/rib.ts
+++ b/packages/routing/src/v2/rib/rib.ts
@@ -587,6 +587,36 @@ export class RoutingInformationBase {
   // -------------------------------------------------------------------------
 
   private planTick(data: TickData, state: RouteTable): PlanResult {
+    // --- Flap damping decay ---
+    let flapStateChanged = false
+    for (const [key, entry] of this._flapState) {
+      const decayed = this.decayPenalty(entry, data.now)
+
+      if (decayed < 1) {
+        // Penalty negligible — clean up
+        if (entry.suppressed) flapStateChanged = true
+        this._flapState.delete(key)
+        continue
+      }
+
+      const shouldUnsuppress =
+        entry.suppressed &&
+        (decayed < FLAP_REUSE_THRESHOLD ||
+          (entry.suppressedAt != null && data.now - entry.suppressedAt > FLAP_MAX_SUPPRESS_MS))
+
+      if (shouldUnsuppress) {
+        this._flapState.set(key, {
+          penalty: decayed,
+          suppressed: false,
+          suppressedAt: null,
+          lastUpdated: data.now,
+        })
+        flapStateChanged = true
+      } else if (Math.abs(decayed - entry.penalty) > 0.1) {
+        this._flapState.set(key, { ...entry, penalty: decayed, lastUpdated: data.now })
+      }
+    }
+
     // Find connected peers whose hold timer has expired
     const expiredPeerNames = new Set<string>()
     const peers = state.internal.peers.map((p) => {
@@ -617,7 +647,12 @@ export class RoutingInformationBase {
     }
 
     const purgedPeerNames = new Set([...expiredPeerNames, ...stalePeerNames])
-    if (purgedPeerNames.size === 0) return noChange(state)
+    if (purgedPeerNames.size === 0 && !flapStateChanged) return noChange(state)
+
+    if (purgedPeerNames.size === 0 && flapStateChanged) {
+      const newState: RouteTable = { ...state }
+      return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges: NO_ROUTE_CHANGES }
+    }
 
     const removedRoutes = state.internal.routes.filter((r) => purgedPeerNames.has(r.peer.name))
     const routes = state.internal.routes.filter((r) => !purgedPeerNames.has(r.peer.name))

--- a/packages/routing/src/v2/state.ts
+++ b/packages/routing/src/v2/state.ts
@@ -14,6 +14,7 @@ export const PeerRecordSchema = PeerInfoSchema.extend({
   holdTime: z.number().default(90_000),
   lastSent: z.number().default(0),
   lastReceived: z.number().default(0),
+  maxPrefixes: z.number().int().min(0).optional(),
 })
 export type PeerRecord = z.infer<typeof PeerRecordSchema>
 


### PR DESCRIPTION
## Summary

Two independent safety features for the BGP-like routing protocol:

- **Max prefix limits per peer** ([#400](https://github.com/orbisoperations/catalyst-router/issues/400)) — configurable per-peer cap on accepted routes. Uses the [Juniper `drop-excess` model](https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/prefix-limit-edit-protocols-bgp.html): excess routes are silently dropped, session stays alive. Logs a structured warning at 80% capacity.
- **Route flap damping** ([#401](https://github.com/orbisoperations/catalyst-router/issues/401)) — penalty-based suppression of rapidly oscillating routes. Parameters follow [RFC 7196](https://www.rfc-editor.org/rfc/rfc7196) / [RIPE-580](https://www.ripe.net/publications/docs/ripe-580/) recommendations (suppress threshold 6000, not the harmful vendor default of 2000). Adapted for small meshes: 5-minute half-life, 30-minute max suppress time.

## Changes

| File | What |
|------|------|
| `packages/routing/src/v2/state.ts` | `maxPrefixes?` on PeerRecord |
| `packages/routing/src/v2/local/actions.ts` | `maxPrefixes?` on LocalPeerCreate schema |
| `packages/routing/src/v2/rib/rib.ts` | Drop-excess enforcement, flap state tracking, penalty decay in Tick, suppress in best-path |
| `apps/orchestrator/src/v2/bus.ts` | Suppress check in `buildUpdatesForPeer`, 80% warning log |
| `apps/orchestrator/tests/v2/max-prefix.test.ts` | 9 tests (6 unit + 3 multi-node topology) |
| `apps/orchestrator/tests/v2/flap-damping.test.ts` | 9 tests (5 unit + 4 multi-node topology) |

## Design decisions

- **Drop-excess over session teardown** — teardown causes a flap spiral where all routes are deleted, peer reconnects, re-advertises, and teardown fires again. Drop-excess is graceful.
- **Suppress threshold 6000** — a single legitimate failover in a small mesh can generate 3-4 path exploration updates (penalty 3000-4000). At the vendor default of 2000, this would suppress legitimate routes. At 6000 it takes 6 real flap cycles to trigger.
- **Flap state is ephemeral** — does not survive restart. On restart, penalties reset to zero. Rationale: if the node restarted, the flapping condition likely resolved.
- **Cisco penalty model** — penalty increments on the withdraw-then-re-add cycle only, not on each individual event. Simpler, avoids threshold-doubling complexity.

## References

- [RFC 2439 — BGP Route Flap Damping](https://www.rfc-editor.org/rfc/rfc2439)
- [RFC 7196 — Making Route Flap Damping Usable](https://www.rfc-editor.org/rfc/rfc7196)
- [RIPE-580 — Route Flap Damping Recommendations](https://www.ripe.net/publications/docs/ripe-580/)
- Design spec: `docs/specs/2026-04-06-bgp-hardening-prefix-limits-flap-damping.md`

## Test plan

- [ ] 18 automated tests pass (unit + multi-node topology via TopologyHelper)
- [ ] Max prefix: excess routes dropped, session stays alive, count is per-peer
- [ ] Flap damping: suppression after 6 flaps, decay via Tick, max suppress time cap, independent per-route
- [ ] Topology: suppression prevents propagation across mesh, recovery resumes propagation