### PR TITLE
feat(routing): add route flap damping (RFC 7196 / RIPE-580)

### DIFF
--- a/apps/orchestrator/src/v2/bus.ts
+++ b/apps/orchestrator/src/v2/bus.ts
@@ -3,6 +3,7 @@ import {
   ActionQueue,
   Actions,
   CloseCodes,
+  routeKey,
   type Action,
   type RouteTable,
   type PlanResult,
@@ -684,6 +685,13 @@ export class OrchestratorBus {
         if (change.type !== 'removed' && this.routePolicy !== undefined) {
           const allowed = this.routePolicy.canSend(peer, [route])
           if (allowed.length === 0) continue
+        }
+
+        // --- Flap damping: skip suppressed routes ---
+        if (change.type !== 'removed') {
+          const fk = `${routeKey(route)}:${route.originNode}`
+          const flapEntry = this.rib.flapState.get(fk)
+          if (flapEntry?.suppressed) continue
         }
 
         // Multi-hop: envoyPort is already stamped by planPortAllocations.

--- a/apps/orchestrator/src/v2/bus.ts
+++ b/apps/orchestrator/src/v2/bus.ts
@@ -4,6 +4,7 @@ import {
   Actions,
   CloseCodes,
   routeKey,
+  flapKey,
   type Action,
   type RouteTable,
   type PlanResult,
@@ -146,7 +147,7 @@ export class OrchestratorBus {
         }
 
         // Step 2: Plan — pure state transition, no side effects.
-        const ribPlan = this.rib.plan(filteredAction, this.rib.state)
+        const ribPlan = this.rib.plan(filteredAction, this.rib.state, Date.now())
 
         if (!this.rib.stateChanged(ribPlan)) {
           // Tick with no expired peers: keepalives still need to fire.
@@ -689,7 +690,7 @@ export class OrchestratorBus {
 
         // --- Flap damping: skip suppressed routes ---
         if (change.type !== 'removed') {
-          const fk = `${routeKey(route)}:${route.originNode}`
+          const fk = flapKey(routeKey(route), route.originNode)
           const flapEntry = this.rib.flapState.get(fk)
           if (flapEntry?.suppressed) continue
         }

--- a/apps/orchestrator/tests/v2/flap-damping.test.ts
+++ b/apps/orchestrator/tests/v2/flap-damping.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest'
+import {
+  RoutingInformationBase,
+  Actions,
+  newRouteTable,
+  routeKey,
+  FLAP_PENALTY_INCREMENT,
+  FLAP_SUPPRESS_THRESHOLD,
+} from '@catalyst/routing/v2'
+import type { RouteTable, PeerRecord, PeerInfo } from '@catalyst/routing/v2'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const nodeId = 'node-a'
+const peerB: PeerInfo = { name: 'node-b', endpoint: 'ws://b:4000', domains: ['test.local'] }
+const route1 = { name: 'svc-1', protocol: 'http' as const, endpoint: 'http://svc-1:8080' }
+const route2 = { name: 'svc-2', protocol: 'http' as const, endpoint: 'http://svc-2:8080' }
+
+function connectedState(): RouteTable {
+  const state = newRouteTable()
+  const peer: PeerRecord = {
+    ...peerB,
+    connectionStatus: 'connected',
+    lastConnected: 1000,
+    holdTime: 90_000,
+    lastSent: 0,
+    lastReceived: 1000,
+  }
+  state.internal.peers = [peer]
+  return state
+}
+
+function addAction(route: typeof route1) {
+  return {
+    action: Actions.InternalProtocolUpdate as const,
+    data: {
+      peerInfo: peerB,
+      update: {
+        updates: [{ action: 'add' as const, route, nodePath: ['node-b'], originNode: 'node-b' }],
+      },
+    },
+  }
+}
+
+function removeAction(route: typeof route1) {
+  return {
+    action: Actions.InternalProtocolUpdate as const,
+    data: {
+      peerInfo: peerB,
+      update: {
+        updates: [{ action: 'remove' as const, route, nodePath: ['node-b'], originNode: 'node-b' }],
+      },
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('route flap damping (RFC 7196 / RIPE-580)', () => {
+  it('single withdraw/re-add below threshold — not suppressed', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = connectedState()
+
+    // Add route
+    const a1 = addAction(route1)
+    const p1 = rib.plan(a1, state)
+    rib.commit(p1, a1)
+
+    // Remove route
+    const r1 = removeAction(route1)
+    const p2 = rib.plan(r1, rib.state)
+    rib.commit(p2, r1)
+
+    // Re-add route
+    const a2 = addAction(route1)
+    const p3 = rib.plan(a2, rib.state)
+    rib.commit(p3, a2)
+
+    const fk = routeKey(route1) + ':node-b'
+    const entry = rib.flapState.get(fk)
+    expect(entry).toBeDefined()
+    // One remove (1000) + one add-after-remove (decayed ~1000 + 1000 ≈ 2000)
+    expect(entry!.penalty).toBeGreaterThanOrEqual(FLAP_PENALTY_INCREMENT)
+    expect(entry!.penalty).toBeLessThan(FLAP_SUPPRESS_THRESHOLD)
+    expect(entry!.suppressed).toBe(false)
+  })
+
+  it('six rapid flaps exceed threshold — suppressed', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = connectedState()
+
+    let currentState = state
+    for (let i = 0; i < 6; i++) {
+      const add = addAction(route1)
+      const ap = rib.plan(add, currentState)
+      rib.commit(ap, add)
+      currentState = rib.state
+
+      const rm = removeAction(route1)
+      const rp = rib.plan(rm, currentState)
+      rib.commit(rp, rm)
+      currentState = rib.state
+    }
+
+    // Final add
+    const finalAdd = addAction(route1)
+    const fp = rib.plan(finalAdd, currentState)
+    rib.commit(fp, finalAdd)
+
+    const fk = routeKey(route1) + ':node-b'
+    const entry = rib.flapState.get(fk)
+    expect(entry).toBeDefined()
+    expect(entry!.suppressed).toBe(true)
+    expect(entry!.penalty).toBeGreaterThanOrEqual(FLAP_SUPPRESS_THRESHOLD)
+  })
+
+  it('different routes from same peer damped independently', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = connectedState()
+
+    // Flap route1 six times to suppress it
+    let currentState = state
+    for (let i = 0; i < 6; i++) {
+      const add = addAction(route1)
+      const ap = rib.plan(add, currentState)
+      rib.commit(ap, add)
+      currentState = rib.state
+
+      const rm = removeAction(route1)
+      const rp = rib.plan(rm, currentState)
+      rib.commit(rp, rm)
+      currentState = rib.state
+    }
+    // Final add for route1
+    const finalAdd1 = addAction(route1)
+    const fp1 = rib.plan(finalAdd1, currentState)
+    rib.commit(fp1, finalAdd1)
+    currentState = rib.state
+
+    // Add route2 normally (no flapping)
+    const add2 = addAction(route2)
+    const ap2 = rib.plan(add2, currentState)
+    rib.commit(ap2, add2)
+
+    const fk1 = routeKey(route1) + ':node-b'
+    const fk2 = routeKey(route2) + ':node-b'
+
+    const entry1 = rib.flapState.get(fk1)
+    expect(entry1).toBeDefined()
+    expect(entry1!.suppressed).toBe(true)
+
+    // route2 should have no flap entry (never withdrawn)
+    const entry2 = rib.flapState.get(fk2)
+    expect(entry2).toBeUndefined()
+  })
+})

--- a/apps/orchestrator/tests/v2/flap-damping.test.ts
+++ b/apps/orchestrator/tests/v2/flap-damping.test.ts
@@ -4,15 +4,14 @@ import {
   Actions,
   newRouteTable,
   routeKey,
+  flapKey,
   FLAP_PENALTY_INCREMENT,
   FLAP_SUPPRESS_THRESHOLD,
   FLAP_HALF_LIFE_MS,
   FLAP_MAX_SUPPRESS_MS,
 } from '@catalyst/routing/v2'
 import type { RouteTable, PeerRecord, PeerInfo, Action } from '@catalyst/routing/v2'
-import { OrchestratorBus } from '../../src/v2/bus.js'
-import { MockPeerTransport, type TransportCall } from '../../src/v2/transport.js'
-import type { OrchestratorConfig } from '../../src/v1/types.js'
+import { TopologyHelper } from './helpers/topology-helper.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -65,6 +64,8 @@ function removeAction(route: typeof route1): Action {
 // Tests
 // ---------------------------------------------------------------------------
 
+const T0 = 1_700_000_000_000 // deterministic base timestamp
+
 describe('route flap damping (RFC 7196 / RIPE-580)', () => {
   it('single withdraw/re-add below threshold — not suppressed', () => {
     const rib = new RoutingInformationBase({ nodeId })
@@ -72,20 +73,20 @@ describe('route flap damping (RFC 7196 / RIPE-580)', () => {
 
     // Add route
     const a1 = addAction(route1)
-    const p1 = rib.plan(a1, state)
+    const p1 = rib.plan(a1, state, T0)
     rib.commit(p1, a1)
 
     // Remove route
     const r1 = removeAction(route1)
-    const p2 = rib.plan(r1, rib.state)
+    const p2 = rib.plan(r1, rib.state, T0 + 1)
     rib.commit(p2, r1)
 
     // Re-add route
     const a2 = addAction(route1)
-    const p3 = rib.plan(a2, rib.state)
+    const p3 = rib.plan(a2, rib.state, T0 + 2)
     rib.commit(p3, a2)
 
-    const fk = routeKey(route1) + ':node-b'
+    const fk = flapKey(routeKey(route1), 'node-b')
     const entry = rib.flapState.get(fk)
     expect(entry).toBeDefined()
     // One remove (1000) + one add-after-remove (decayed ~1000 + 1000 ≈ 2000)
@@ -101,22 +102,22 @@ describe('route flap damping (RFC 7196 / RIPE-580)', () => {
     let currentState = state
     for (let i = 0; i < 6; i++) {
       const add = addAction(route1)
-      const ap = rib.plan(add, currentState)
+      const ap = rib.plan(add, currentState, T0 + i * 2)
       rib.commit(ap, add)
       currentState = rib.state
 
       const rm = removeAction(route1)
-      const rp = rib.plan(rm, currentState)
+      const rp = rib.plan(rm, currentState, T0 + i * 2 + 1)
       rib.commit(rp, rm)
       currentState = rib.state
     }
 
     // Final add
     const finalAdd = addAction(route1)
-    const fp = rib.plan(finalAdd, currentState)
+    const fp = rib.plan(finalAdd, currentState, T0 + 12)
     rib.commit(fp, finalAdd)
 
-    const fk = routeKey(route1) + ':node-b'
+    const fk = flapKey(routeKey(route1), 'node-b')
     const entry = rib.flapState.get(fk)
     expect(entry).toBeDefined()
     expect(entry!.suppressed).toBe(true)
@@ -131,28 +132,28 @@ describe('route flap damping (RFC 7196 / RIPE-580)', () => {
     let currentState = state
     for (let i = 0; i < 6; i++) {
       const add = addAction(route1)
-      const ap = rib.plan(add, currentState)
+      const ap = rib.plan(add, currentState, T0 + i * 2)
       rib.commit(ap, add)
       currentState = rib.state
 
       const rm = removeAction(route1)
-      const rp = rib.plan(rm, currentState)
+      const rp = rib.plan(rm, currentState, T0 + i * 2 + 1)
       rib.commit(rp, rm)
       currentState = rib.state
     }
     // Final add for route1
     const finalAdd1 = addAction(route1)
-    const fp1 = rib.plan(finalAdd1, currentState)
+    const fp1 = rib.plan(finalAdd1, currentState, T0 + 12)
     rib.commit(fp1, finalAdd1)
     currentState = rib.state
 
     // Add route2 normally (no flapping)
     const add2 = addAction(route2)
-    const ap2 = rib.plan(add2, currentState)
+    const ap2 = rib.plan(add2, currentState, T0 + 13)
     rib.commit(ap2, add2)
 
-    const fk1 = routeKey(route1) + ':node-b'
-    const fk2 = routeKey(route2) + ':node-b'
+    const fk1 = flapKey(routeKey(route1), 'node-b')
+    const fk2 = flapKey(routeKey(route2), 'node-b')
 
     const entry1 = rib.flapState.get(fk1)
     expect(entry1).toBeDefined()
@@ -171,30 +172,30 @@ describe('route flap damping (RFC 7196 / RIPE-580)', () => {
     let currentState = state
     for (let i = 0; i < 6; i++) {
       const add = addAction(route1)
-      const ap = rib.plan(add, currentState)
+      const ap = rib.plan(add, currentState, T0 + i * 2)
       rib.commit(ap, add)
       currentState = rib.state
 
       const rm = removeAction(route1)
-      const rp = rib.plan(rm, currentState)
+      const rp = rib.plan(rm, currentState, T0 + i * 2 + 1)
       rib.commit(rp, rm)
       currentState = rib.state
     }
 
     // Final add
     const finalAdd = addAction(route1)
-    const fp = rib.plan(finalAdd, currentState)
+    const fp = rib.plan(finalAdd, currentState, T0 + 12)
     rib.commit(fp, finalAdd)
     currentState = rib.state
 
-    const fk = routeKey(route1) + ':node-b'
+    const fk = flapKey(routeKey(route1), 'node-b')
     expect(rib.flapState.get(fk)?.suppressed).toBe(true)
 
     // Dispatch Tick far enough in the future: penalty is ~12000 after 6 flap cycles.
     // 5 half-lives => 12000 * 0.5^5 = 375 < 750 reuse threshold.
     const tickAction: Action = {
       action: Actions.Tick,
-      data: { now: Date.now() + FLAP_HALF_LIFE_MS * 5 },
+      data: { now: T0 + FLAP_HALF_LIFE_MS * 5 },
     }
     const tickPlan = rib.plan(tickAction, currentState)
     rib.commit(tickPlan, tickAction)
@@ -212,29 +213,29 @@ describe('route flap damping (RFC 7196 / RIPE-580)', () => {
     let currentState = state
     for (let i = 0; i < 20; i++) {
       const add = addAction(route1)
-      const ap = rib.plan(add, currentState)
+      const ap = rib.plan(add, currentState, T0 + i * 2)
       rib.commit(ap, add)
       currentState = rib.state
 
       const rm = removeAction(route1)
-      const rp = rib.plan(rm, currentState)
+      const rp = rib.plan(rm, currentState, T0 + i * 2 + 1)
       rib.commit(rp, rm)
       currentState = rib.state
     }
 
     // Final add
     const finalAdd = addAction(route1)
-    const fp = rib.plan(finalAdd, currentState)
+    const fp = rib.plan(finalAdd, currentState, T0 + 40)
     rib.commit(fp, finalAdd)
     currentState = rib.state
 
-    const fk = routeKey(route1) + ':node-b'
+    const fk = flapKey(routeKey(route1), 'node-b')
     expect(rib.flapState.get(fk)?.suppressed).toBe(true)
 
     // Dispatch Tick just past the max suppress duration (30 min + 1 sec)
     const tickAction: Action = {
       action: Actions.Tick,
-      data: { now: Date.now() + FLAP_MAX_SUPPRESS_MS + 1000 },
+      data: { now: T0 + FLAP_MAX_SUPPRESS_MS + 1000 },
     }
     const tickPlan = rib.plan(tickAction, currentState)
     rib.commit(tickPlan, tickAction)
@@ -247,103 +248,11 @@ describe('route flap damping (RFC 7196 / RIPE-580)', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Topology helpers (copied from orchestrator.topology.test.ts)
+// Topology helpers
 // ---------------------------------------------------------------------------
-
-function topoMakeConfig(name: string): OrchestratorConfig {
-  return {
-    node: { name, endpoint: `ws://${name}:4000`, domains: ['topo.local'] },
-  }
-}
-
-function topoMakePeerInfo(name: string): PeerInfo {
-  return {
-    name,
-    endpoint: `ws://${name}:4000`,
-    domains: ['topo.local'],
-    peerToken: `token-${name}`,
-  }
-}
 
 function makeRoute(name: string) {
   return { name, protocol: 'http' as const, endpoint: `http://${name}:8080` }
-}
-
-interface BusEntry {
-  name: string
-  bus: OrchestratorBus
-  transport: MockPeerTransport
-  peerInfo: PeerInfo
-}
-
-class TopologyHelper {
-  private nodes = new Map<string, BusEntry>()
-
-  addNode(name: string): BusEntry {
-    const transport = new MockPeerTransport()
-    const config = topoMakeConfig(name)
-    const bus = new OrchestratorBus({ config, transport })
-    const entry: BusEntry = { name, bus, transport, peerInfo: topoMakePeerInfo(name) }
-    this.nodes.set(name, entry)
-    return entry
-  }
-
-  get(name: string): BusEntry {
-    const entry = this.nodes.get(name)
-    if (entry === undefined) throw new Error(`Unknown node: ${name}`)
-    return entry
-  }
-
-  async peer(nameA: string, nameB: string): Promise<void> {
-    const a = this.get(nameA)
-    const b = this.get(nameB)
-
-    await a.bus.dispatch({ action: Actions.LocalPeerCreate, data: b.peerInfo })
-    await b.bus.dispatch({ action: Actions.LocalPeerCreate, data: a.peerInfo })
-
-    await a.bus.dispatch({
-      action: Actions.InternalProtocolConnected,
-      data: { peerInfo: b.peerInfo },
-    })
-    await b.bus.dispatch({
-      action: Actions.InternalProtocolConnected,
-      data: { peerInfo: a.peerInfo },
-    })
-  }
-
-  async propagate(fromName: string, toName: string): Promise<void> {
-    const from = this.get(fromName)
-    const to = this.get(toName)
-
-    const consumed: TransportCall[] = []
-    const remaining: TransportCall[] = []
-    for (const call of from.transport.calls) {
-      if (call.method === 'sendUpdate' && call.peer.name === toName) {
-        consumed.push(call)
-      } else {
-        remaining.push(call)
-      }
-    }
-
-    from.transport.calls.length = 0
-    for (const c of remaining) {
-      from.transport.calls.push(c)
-    }
-
-    for (const call of consumed) {
-      if (call.method !== 'sendUpdate') continue
-      await to.bus.dispatch({
-        action: Actions.InternalProtocolUpdate,
-        data: { peerInfo: from.peerInfo, update: call.message },
-      })
-    }
-  }
-
-  resetAll(): void {
-    for (const entry of this.nodes.values()) {
-      entry.transport.reset()
-    }
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/orchestrator/tests/v2/flap-damping.test.ts
+++ b/apps/orchestrator/tests/v2/flap-damping.test.ts
@@ -6,6 +6,8 @@ import {
   routeKey,
   FLAP_PENALTY_INCREMENT,
   FLAP_SUPPRESS_THRESHOLD,
+  FLAP_HALF_LIFE_MS,
+  FLAP_MAX_SUPPRESS_MS,
 } from '@catalyst/routing/v2'
 import type { RouteTable, PeerRecord, PeerInfo } from '@catalyst/routing/v2'
 
@@ -156,5 +158,87 @@ describe('route flap damping (RFC 7196 / RIPE-580)', () => {
     // route2 should have no flap entry (never withdrawn)
     const entry2 = rib.flapState.get(fk2)
     expect(entry2).toBeUndefined()
+  })
+
+  it('tick decays penalty — suppressed route becomes reusable after 4 half-lives', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = connectedState()
+
+    // Flap route1 six times to suppress it
+    let currentState = state
+    for (let i = 0; i < 6; i++) {
+      const add = addAction(route1)
+      const ap = rib.plan(add, currentState)
+      rib.commit(ap, add)
+      currentState = rib.state
+
+      const rm = removeAction(route1)
+      const rp = rib.plan(rm, currentState)
+      rib.commit(rp, rm)
+      currentState = rib.state
+    }
+
+    // Final add
+    const finalAdd = addAction(route1)
+    const fp = rib.plan(finalAdd, currentState)
+    rib.commit(fp, finalAdd)
+    currentState = rib.state
+
+    const fk = routeKey(route1) + ':node-b'
+    expect(rib.flapState.get(fk)?.suppressed).toBe(true)
+
+    // Dispatch Tick far enough in the future: penalty is ~12000 after 6 flap cycles.
+    // 5 half-lives => 12000 * 0.5^5 = 375 < 750 reuse threshold.
+    const tickAction = {
+      action: Actions.Tick as const,
+      data: { now: Date.now() + FLAP_HALF_LIFE_MS * 5 },
+    }
+    const tickPlan = rib.plan(tickAction, currentState)
+    rib.commit(tickPlan, tickAction)
+
+    const entry = rib.flapState.get(fk)
+    expect(entry).toBeDefined()
+    expect(entry!.suppressed).toBe(false)
+  })
+
+  it('max suppress time cap — unsuppressed after 30 minutes despite high penalty', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = connectedState()
+
+    // Flap route1 twenty times to get very high penalty
+    let currentState = state
+    for (let i = 0; i < 20; i++) {
+      const add = addAction(route1)
+      const ap = rib.plan(add, currentState)
+      rib.commit(ap, add)
+      currentState = rib.state
+
+      const rm = removeAction(route1)
+      const rp = rib.plan(rm, currentState)
+      rib.commit(rp, rm)
+      currentState = rib.state
+    }
+
+    // Final add
+    const finalAdd = addAction(route1)
+    const fp = rib.plan(finalAdd, currentState)
+    rib.commit(fp, finalAdd)
+    currentState = rib.state
+
+    const fk = routeKey(route1) + ':node-b'
+    expect(rib.flapState.get(fk)?.suppressed).toBe(true)
+
+    // Dispatch Tick just past the max suppress duration (30 min + 1 sec)
+    const tickAction = {
+      action: Actions.Tick as const,
+      data: { now: Date.now() + FLAP_MAX_SUPPRESS_MS + 1000 },
+    }
+    const tickPlan = rib.plan(tickAction, currentState)
+    rib.commit(tickPlan, tickAction)
+
+    const entry = rib.flapState.get(fk)
+    // Should be unsuppressed even though penalty may still be above reuse threshold
+    expect(entry).toBeDefined()
+    expect(entry!.suppressed).toBe(false)
   })
 })

--- a/apps/orchestrator/tests/v2/flap-damping.test.ts
+++ b/apps/orchestrator/tests/v2/flap-damping.test.ts
@@ -9,7 +9,7 @@ import {
   FLAP_HALF_LIFE_MS,
   FLAP_MAX_SUPPRESS_MS,
 } from '@catalyst/routing/v2'
-import type { RouteTable, PeerRecord, PeerInfo } from '@catalyst/routing/v2'
+import type { RouteTable, PeerRecord, PeerInfo, Action } from '@catalyst/routing/v2'
 import { OrchestratorBus } from '../../src/v2/bus.js'
 import { MockPeerTransport, type TransportCall } from '../../src/v2/transport.js'
 import type { OrchestratorConfig } from '../../src/v1/types.js'
@@ -37,9 +37,9 @@ function connectedState(): RouteTable {
   return state
 }
 
-function addAction(route: typeof route1) {
+function addAction(route: typeof route1): Action {
   return {
-    action: Actions.InternalProtocolUpdate as const,
+    action: Actions.InternalProtocolUpdate,
     data: {
       peerInfo: peerB,
       update: {
@@ -49,9 +49,9 @@ function addAction(route: typeof route1) {
   }
 }
 
-function removeAction(route: typeof route1) {
+function removeAction(route: typeof route1): Action {
   return {
-    action: Actions.InternalProtocolUpdate as const,
+    action: Actions.InternalProtocolUpdate,
     data: {
       peerInfo: peerB,
       update: {
@@ -192,8 +192,8 @@ describe('route flap damping (RFC 7196 / RIPE-580)', () => {
 
     // Dispatch Tick far enough in the future: penalty is ~12000 after 6 flap cycles.
     // 5 half-lives => 12000 * 0.5^5 = 375 < 750 reuse threshold.
-    const tickAction = {
-      action: Actions.Tick as const,
+    const tickAction: Action = {
+      action: Actions.Tick,
       data: { now: Date.now() + FLAP_HALF_LIFE_MS * 5 },
     }
     const tickPlan = rib.plan(tickAction, currentState)
@@ -232,8 +232,8 @@ describe('route flap damping (RFC 7196 / RIPE-580)', () => {
     expect(rib.flapState.get(fk)?.suppressed).toBe(true)
 
     // Dispatch Tick just past the max suppress duration (30 min + 1 sec)
-    const tickAction = {
-      action: Actions.Tick as const,
+    const tickAction: Action = {
+      action: Actions.Tick,
       data: { now: Date.now() + FLAP_MAX_SUPPRESS_MS + 1000 },
     }
     const tickPlan = rib.plan(tickAction, currentState)

--- a/apps/orchestrator/tests/v2/flap-damping.test.ts
+++ b/apps/orchestrator/tests/v2/flap-damping.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   RoutingInformationBase,
   Actions,
@@ -10,6 +10,9 @@ import {
   FLAP_MAX_SUPPRESS_MS,
 } from '@catalyst/routing/v2'
 import type { RouteTable, PeerRecord, PeerInfo } from '@catalyst/routing/v2'
+import { OrchestratorBus } from '../../src/v2/bus.js'
+import { MockPeerTransport, type TransportCall } from '../../src/v2/transport.js'
+import type { OrchestratorConfig } from '../../src/v1/types.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -240,5 +243,343 @@ describe('route flap damping (RFC 7196 / RIPE-580)', () => {
     // Should be unsuppressed even though penalty may still be above reuse threshold
     expect(entry).toBeDefined()
     expect(entry!.suppressed).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Topology helpers (copied from orchestrator.topology.test.ts)
+// ---------------------------------------------------------------------------
+
+function topoMakeConfig(name: string): OrchestratorConfig {
+  return {
+    node: { name, endpoint: `ws://${name}:4000`, domains: ['topo.local'] },
+  }
+}
+
+function topoMakePeerInfo(name: string): PeerInfo {
+  return {
+    name,
+    endpoint: `ws://${name}:4000`,
+    domains: ['topo.local'],
+    peerToken: `token-${name}`,
+  }
+}
+
+function makeRoute(name: string) {
+  return { name, protocol: 'http' as const, endpoint: `http://${name}:8080` }
+}
+
+interface BusEntry {
+  name: string
+  bus: OrchestratorBus
+  transport: MockPeerTransport
+  peerInfo: PeerInfo
+}
+
+class TopologyHelper {
+  private nodes = new Map<string, BusEntry>()
+
+  addNode(name: string): BusEntry {
+    const transport = new MockPeerTransport()
+    const config = topoMakeConfig(name)
+    const bus = new OrchestratorBus({ config, transport })
+    const entry: BusEntry = { name, bus, transport, peerInfo: topoMakePeerInfo(name) }
+    this.nodes.set(name, entry)
+    return entry
+  }
+
+  get(name: string): BusEntry {
+    const entry = this.nodes.get(name)
+    if (entry === undefined) throw new Error(`Unknown node: ${name}`)
+    return entry
+  }
+
+  async peer(nameA: string, nameB: string): Promise<void> {
+    const a = this.get(nameA)
+    const b = this.get(nameB)
+
+    await a.bus.dispatch({ action: Actions.LocalPeerCreate, data: b.peerInfo })
+    await b.bus.dispatch({ action: Actions.LocalPeerCreate, data: a.peerInfo })
+
+    await a.bus.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: b.peerInfo },
+    })
+    await b.bus.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: a.peerInfo },
+    })
+  }
+
+  async propagate(fromName: string, toName: string): Promise<void> {
+    const from = this.get(fromName)
+    const to = this.get(toName)
+
+    const consumed: TransportCall[] = []
+    const remaining: TransportCall[] = []
+    for (const call of from.transport.calls) {
+      if (call.method === 'sendUpdate' && call.peer.name === toName) {
+        consumed.push(call)
+      } else {
+        remaining.push(call)
+      }
+    }
+
+    from.transport.calls.length = 0
+    for (const c of remaining) {
+      from.transport.calls.push(c)
+    }
+
+    for (const call of consumed) {
+      if (call.method !== 'sendUpdate') continue
+      await to.bus.dispatch({
+        action: Actions.InternalProtocolUpdate,
+        data: { peerInfo: from.peerInfo, update: call.message },
+      })
+    }
+  }
+
+  resetAll(): void {
+    for (const entry of this.nodes.values()) {
+      entry.transport.reset()
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Topology: flap damping multi-node tests
+// ---------------------------------------------------------------------------
+
+describe('Flap damping topology', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  /**
+   * Helper: flap a route N times at a source node, propagating through the
+   * chain after each add and remove. Each cycle is:
+   *   1. source dispatches LocalRouteCreate
+   *   2. propagate through the chain
+   *   3. resetAll
+   *   4. source dispatches LocalRouteDelete
+   *   5. propagate through the chain
+   *   6. resetAll
+   */
+  async function flapRoute(
+    topo: TopologyHelper,
+    sourceName: string,
+    chain: string[],
+    routeName: string,
+    cycles: number
+  ): Promise<void> {
+    const route = makeRoute(routeName)
+    for (let i = 0; i < cycles; i++) {
+      await topo.get(sourceName).bus.dispatch({ action: Actions.LocalRouteCreate, data: route })
+      for (const [idx, from] of chain.entries()) {
+        const to = chain[idx + 1]
+        if (to !== undefined) await topo.propagate(from, to)
+      }
+      topo.resetAll()
+
+      await topo.get(sourceName).bus.dispatch({ action: Actions.LocalRouteDelete, data: route })
+      for (const [idx, from] of chain.entries()) {
+        const to = chain[idx + 1]
+        if (to !== undefined) await topo.propagate(from, to)
+      }
+      topo.resetAll()
+    }
+  }
+
+  it('A flaps route 6 times — B suppresses propagation to C', async () => {
+    const topo = new TopologyHelper()
+    topo.addNode('node-a')
+    topo.addNode('node-b')
+    topo.addNode('node-c')
+
+    await topo.peer('node-a', 'node-b')
+    await topo.peer('node-b', 'node-c')
+    topo.resetAll()
+
+    // Flap 'flappy' 6 times through A→B→C
+    await flapRoute(topo, 'node-a', ['node-a', 'node-b', 'node-c'], 'flappy', 6)
+
+    // Final add: A creates the route one last time
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: makeRoute('flappy'),
+    })
+    await topo.propagate('node-a', 'node-b')
+
+    // B should have 'flappy' in its internal routes (the route was accepted)
+    const bRoutes = topo.get('node-b').bus.state.internal.routes
+    expect(bRoutes.some((r) => r.name === 'flappy')).toBe(true)
+
+    // B's transport should have NO sendUpdate calls to C containing 'flappy' as an 'add'
+    // because B suppresses propagation of the flapping route
+    const callsToC = topo
+      .get('node-b')
+      .transport.calls.filter((c) => c.method === 'sendUpdate' && c.peer.name === 'node-c')
+
+    const addUpdatesForFlappy = callsToC.flatMap((c) =>
+      c.method === 'sendUpdate'
+        ? c.message.updates.filter(
+            (u: { action: string; route: { name: string } }) =>
+              u.action === 'add' && u.route.name === 'flappy'
+          )
+        : []
+    )
+    expect(addUpdatesForFlappy).toHaveLength(0)
+  })
+
+  it('after decay, B resumes propagating to C', async () => {
+    const topo = new TopologyHelper()
+    topo.addNode('node-a')
+    topo.addNode('node-b')
+    topo.addNode('node-c')
+
+    await topo.peer('node-a', 'node-b')
+    await topo.peer('node-b', 'node-c')
+    topo.resetAll()
+
+    // Flap 'flappy' 6 times, then final add — route is suppressed at B
+    await flapRoute(topo, 'node-a', ['node-a', 'node-b', 'node-c'], 'flappy', 6)
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: makeRoute('flappy'),
+    })
+    await topo.propagate('node-a', 'node-b')
+
+    // Verify suppressed at B
+    const fk = 'flappy:node-a'
+    expect(topo.get('node-b').bus.rib.flapState.get(fk)?.suppressed).toBe(true)
+    topo.resetAll()
+
+    // Advance time by 5 half-lives (25 minutes) — penalty decays well below reuse threshold.
+    // After 6 flap cycles + final add, penalty ~13000. 13000 * 0.5^5 = 406.25 < 750 reuse.
+    vi.setSystemTime(Date.now() + FLAP_HALF_LIFE_MS * 5)
+
+    // Keep peers alive: dispatch keepalives so hold timers don't expire
+    await topo.get('node-b').bus.dispatch({
+      action: Actions.InternalProtocolKeepalive,
+      data: { peerInfo: topo.get('node-a').peerInfo },
+    })
+    await topo.get('node-b').bus.dispatch({
+      action: Actions.InternalProtocolKeepalive,
+      data: { peerInfo: topo.get('node-c').peerInfo },
+    })
+    topo.resetAll()
+
+    // Dispatch Tick on B to trigger flap decay
+    await topo.get('node-b').bus.dispatch({
+      action: Actions.Tick,
+      data: { now: Date.now() },
+    })
+
+    // Verify unsuppressed
+    expect(topo.get('node-b').bus.rib.flapState.get(fk)?.suppressed ?? false).toBe(false)
+    topo.resetAll()
+
+    // Trigger a route change at B so it can propagate to C.
+    // Remove and re-add the route from A. The penalty from this single cycle
+    // is small relative to the decayed value, so it stays unsuppressed.
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteDelete,
+      data: makeRoute('flappy'),
+    })
+    await topo.propagate('node-a', 'node-b')
+    topo.resetAll()
+
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: makeRoute('flappy'),
+    })
+    await topo.propagate('node-a', 'node-b')
+    await topo.propagate('node-b', 'node-c')
+
+    // C should now have 'flappy' in its internal routes
+    const cRoutes = topo.get('node-c').bus.state.internal.routes
+    expect(cRoutes.some((r) => r.name === 'flappy')).toBe(true)
+  })
+
+  it('suppressed route loses best-path to fresh route from another peer', async () => {
+    const topo = new TopologyHelper()
+    topo.addNode('node-a')
+    topo.addNode('node-c')
+    topo.addNode('node-d')
+
+    // Wire A↔C and D↔C
+    await topo.peer('node-a', 'node-c')
+    await topo.peer('node-d', 'node-c')
+    topo.resetAll()
+
+    // Flap route 'contested' from A at C 6 times
+    await flapRoute(topo, 'node-a', ['node-a', 'node-c'], 'contested', 6)
+
+    // Final add from A, propagate A→C — route is suppressed at C
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: makeRoute('contested'),
+    })
+    await topo.propagate('node-a', 'node-c')
+
+    const fk = 'contested:node-a'
+    expect(topo.get('node-c').bus.rib.flapState.get(fk)?.suppressed).toBe(true)
+    topo.resetAll()
+
+    // D creates route 'contested' normally (no flap), propagate D→C
+    await topo.get('node-d').bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: makeRoute('contested'),
+    })
+    await topo.propagate('node-d', 'node-c')
+
+    // C should have 'contested' from D (originNode='node-d')
+    const cRoutes = topo.get('node-c').bus.state.internal.routes
+    const contestedRoute = cRoutes.find((r) => r.name === 'contested' && r.originNode === 'node-d')
+    expect(contestedRoute).toBeDefined()
+  })
+
+  it('independent damping — flappy suppressed, stable propagates', async () => {
+    const topo = new TopologyHelper()
+    topo.addNode('node-a')
+    topo.addNode('node-b')
+
+    await topo.peer('node-a', 'node-b')
+    topo.resetAll()
+
+    // Flap route 'flappy' from A at B 6 times, then final add
+    await flapRoute(topo, 'node-a', ['node-a', 'node-b'], 'flappy', 6)
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: makeRoute('flappy'),
+    })
+    await topo.propagate('node-a', 'node-b')
+    topo.resetAll()
+
+    // Also add route 'stable' from A normally
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: makeRoute('stable'),
+    })
+    await topo.propagate('node-a', 'node-b')
+
+    // B should have both routes in internal routes
+    const bRoutes = topo.get('node-b').bus.state.internal.routes
+    expect(bRoutes.some((r) => r.name === 'flappy')).toBe(true)
+    expect(bRoutes.some((r) => r.name === 'stable')).toBe(true)
+
+    // Check B's RIB flapState
+    const rib = topo.get('node-b').bus.rib
+    const flappyEntry = rib.flapState.get('flappy:node-a')
+    expect(flappyEntry).toBeDefined()
+    expect(flappyEntry!.suppressed).toBe(true)
+
+    // 'stable' was never withdrawn, so it has no flapState entry
+    const stableEntry = rib.flapState.get('stable:node-a')
+    expect(stableEntry).toBeUndefined()
   })
 })

--- a/packages/routing/src/v2/port-operation.ts
+++ b/packages/routing/src/v2/port-operation.ts
@@ -10,9 +10,20 @@ export type RouteChange =
   | { type: 'removed'; route: DataChannelDefinition | InternalRoute }
   | { type: 'updated'; route: DataChannelDefinition | InternalRoute }
 
+export type FlapStateChange = {
+  key: string
+  entry: {
+    penalty: number
+    suppressed: boolean
+    suppressedAt: number | null
+    lastUpdated: number
+  } | null // null means delete
+}
+
 export type PlanResult = {
   prevState: RouteTable
   newState: RouteTable
   portOps: PortOperation[]
   routeChanges: RouteChange[]
+  flapStateChanges: FlapStateChange[]
 }

--- a/packages/routing/src/v2/rib/index.ts
+++ b/packages/routing/src/v2/rib/index.ts
@@ -1,6 +1,7 @@
 export { ActionQueue } from './action-queue.js'
 export { RoutingInformationBase } from './rib.js'
 export {
+  flapKey,
   FLAP_PENALTY_INCREMENT,
   FLAP_SUPPRESS_THRESHOLD,
   FLAP_REUSE_THRESHOLD,

--- a/packages/routing/src/v2/rib/index.ts
+++ b/packages/routing/src/v2/rib/index.ts
@@ -1,2 +1,10 @@
 export { ActionQueue } from './action-queue.js'
 export { RoutingInformationBase } from './rib.js'
+export {
+  FLAP_PENALTY_INCREMENT,
+  FLAP_SUPPRESS_THRESHOLD,
+  FLAP_REUSE_THRESHOLD,
+  FLAP_HALF_LIFE_MS,
+  FLAP_MAX_SUPPRESS_MS,
+} from './rib.js'
+export type { FlapEntry } from './rib.js'

--- a/packages/routing/src/v2/rib/rib.ts
+++ b/packages/routing/src/v2/rib/rib.ts
@@ -665,7 +665,7 @@ export class RoutingInformationBase {
 
       if (decayed < 1) {
         // Penalty negligible — clean up
-        if (entry.suppressed) flapStateChanged = true
+        flapStateChanged = true
         flapChanges.push({ key, entry: null })
         continue
       }

--- a/packages/routing/src/v2/rib/rib.ts
+++ b/packages/routing/src/v2/rib/rib.ts
@@ -10,7 +10,7 @@ import {
   type InternalRoute,
   type PeerInfo,
 } from '../state.js'
-import type { PlanResult, PortOperation, RouteChange } from '../port-operation.js'
+import type { FlapStateChange, PlanResult, PortOperation, RouteChange } from '../port-operation.js'
 
 // ---------------------------------------------------------------------------
 // Derived action data types — extracted from schema discriminated union members
@@ -67,9 +67,21 @@ export type FlapEntry = {
 
 const NO_ROUTE_CHANGES: RouteChange[] = []
 const NO_PORT_OPS: PortOperation[] = []
+const NO_FLAP_CHANGES: FlapStateChange[] = []
+
+/** Canonical key for flap-damping state entries: `routeKey:originNode`. */
+export function flapKey(rKey: string, originNode: string): string {
+  return `${rKey}:${originNode}`
+}
 
 function noChange(state: RouteTable): PlanResult {
-  return { prevState: state, newState: state, portOps: NO_PORT_OPS, routeChanges: NO_ROUTE_CHANGES }
+  return {
+    prevState: state,
+    newState: state,
+    portOps: NO_PORT_OPS,
+    routeChanges: NO_ROUTE_CHANGES,
+    flapStateChanges: NO_FLAP_CHANGES,
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -113,10 +125,6 @@ export class RoutingInformationBase {
     return this._flapState
   }
 
-  private flapKey(rKey: string, originNode: string): string {
-    return `${rKey}:${originNode}`
-  }
-
   private decayPenalty(entry: FlapEntry, now: number): number {
     const elapsed = now - entry.lastUpdated
     if (elapsed <= 0) return entry.penalty
@@ -130,7 +138,8 @@ export class RoutingInformationBase {
    * never mutated. If the action is a no-op (peer not found, duplicate, etc.)
    * `prevState === newState` (same object reference).
    */
-  plan(action: Action, state: RouteTable): PlanResult {
+  plan(action: Action, state: RouteTable, now?: number): PlanResult {
+    const timestamp = now ?? Date.now()
     switch (action.action) {
       case Actions.LocalPeerCreate:
         return this.planLocalPeerCreate(action.data, state)
@@ -145,15 +154,15 @@ export class RoutingInformationBase {
       case Actions.LocalRouteHealthUpdate:
         return this.planLocalRouteHealthUpdate(action.data, state)
       case Actions.InternalProtocolOpen:
-        return this.planInternalProtocolOpen(action.data, state)
+        return this.planInternalProtocolOpen(action.data, state, timestamp)
       case Actions.InternalProtocolConnected:
-        return this.planInternalProtocolConnected(action.data, state)
+        return this.planInternalProtocolConnected(action.data, state, timestamp)
       case Actions.InternalProtocolClose:
         return this.planInternalProtocolClose(action.data, state)
       case Actions.InternalProtocolUpdate:
-        return this.planInternalProtocolUpdate(action.data, state)
+        return this.planInternalProtocolUpdate(action.data, state, timestamp)
       case Actions.InternalProtocolKeepalive:
-        return this.planInternalProtocolKeepalive(action.data, state)
+        return this.planInternalProtocolKeepalive(action.data, state, timestamp)
       case Actions.Tick:
         return this.planTick(action.data, state)
       default:
@@ -170,6 +179,14 @@ export class RoutingInformationBase {
    */
   commit(plan: PlanResult, action: Action): RouteTable {
     this._state = plan.newState
+    // Apply deferred flap state mutations (collected during plan, applied here)
+    for (const change of plan.flapStateChanges) {
+      if (change.entry === null) {
+        this._flapState.delete(change.key)
+      } else {
+        this._flapState.set(change.key, change.entry)
+      }
+    }
     if (this.stateChanged(plan) && this._journal !== undefined) {
       this._journal.append(action, this._nodeId)
     }
@@ -210,7 +227,13 @@ export class RoutingInformationBase {
         peers: [...state.internal.peers, newPeer],
       },
     }
-    return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges: NO_ROUTE_CHANGES }
+    return {
+      prevState: state,
+      newState,
+      portOps: NO_PORT_OPS,
+      routeChanges: NO_ROUTE_CHANGES,
+      flapStateChanges: NO_FLAP_CHANGES,
+    }
   }
 
   private planLocalPeerUpdate(data: PeerInfo, state: RouteTable): PlanResult {
@@ -234,7 +257,13 @@ export class RoutingInformationBase {
       ...state,
       internal: { ...state.internal, peers },
     }
-    return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges: NO_ROUTE_CHANGES }
+    return {
+      prevState: state,
+      newState,
+      portOps: NO_PORT_OPS,
+      routeChanges: NO_ROUTE_CHANGES,
+      flapStateChanges: NO_FLAP_CHANGES,
+    }
   }
 
   private planLocalPeerDelete(data: LocalPeerDeleteData, state: RouteTable): PlanResult {
@@ -257,7 +286,7 @@ export class RoutingInformationBase {
       ...state,
       internal: { peers, routes },
     }
-    return { prevState: state, newState, portOps, routeChanges }
+    return { prevState: state, newState, portOps, routeChanges, flapStateChanges: NO_FLAP_CHANGES }
   }
 
   // -------------------------------------------------------------------------
@@ -277,6 +306,7 @@ export class RoutingInformationBase {
       newState,
       portOps: NO_PORT_OPS,
       routeChanges: [{ type: 'added', route: data }],
+      flapStateChanges: NO_FLAP_CHANGES,
     }
   }
 
@@ -299,6 +329,7 @@ export class RoutingInformationBase {
       newState,
       portOps,
       routeChanges: [{ type: 'removed', route }],
+      flapStateChanges: NO_FLAP_CHANGES,
     }
   }
 
@@ -336,6 +367,7 @@ export class RoutingInformationBase {
       newState,
       portOps: NO_PORT_OPS,
       routeChanges: [{ type: 'updated', route: updated }],
+      flapStateChanges: NO_FLAP_CHANGES,
     }
   }
 
@@ -343,7 +375,11 @@ export class RoutingInformationBase {
   // Internal protocol handlers
   // -------------------------------------------------------------------------
 
-  private planInternalProtocolOpen(data: InternalProtocolOpenData, state: RouteTable): PlanResult {
+  private planInternalProtocolOpen(
+    data: InternalProtocolOpenData,
+    state: RouteTable,
+    timestamp: number
+  ): PlanResult {
     const idx = state.internal.peers.findIndex((p) => p.name === data.peerInfo.name)
     // Unknown peer — we only accept opens for pre-configured peers
     if (idx === -1) return noChange(state)
@@ -356,19 +392,26 @@ export class RoutingInformationBase {
       ...existing,
       connectionStatus: 'connected',
       holdTime: negotiatedHoldTime,
-      lastReceived: Date.now(),
+      lastReceived: timestamp,
     }
     const peers = state.internal.peers.map((p, i) => (i === idx ? updated : p))
     const newState: RouteTable = {
       ...state,
       internal: { ...state.internal, peers },
     }
-    return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges: NO_ROUTE_CHANGES }
+    return {
+      prevState: state,
+      newState,
+      portOps: NO_PORT_OPS,
+      routeChanges: NO_ROUTE_CHANGES,
+      flapStateChanges: NO_FLAP_CHANGES,
+    }
   }
 
   private planInternalProtocolConnected(
     data: InternalProtocolConnectedData,
-    state: RouteTable
+    state: RouteTable,
+    timestamp: number
   ): PlanResult {
     const idx = state.internal.peers.findIndex((p) => p.name === data.peerInfo.name)
     if (idx === -1) return noChange(state)
@@ -376,12 +419,11 @@ export class RoutingInformationBase {
     const existing = state.internal.peers[idx]
     // Reset holdTime to default on reconnect so it can be re-negotiated
     // via the subsequent InternalProtocolOpen exchange.
-    const now = Date.now()
     const updated: PeerRecord = {
       ...existing,
       connectionStatus: 'connected',
-      lastConnected: now,
-      lastReceived: now,
+      lastConnected: timestamp,
+      lastReceived: timestamp,
       holdTime: 90_000,
       lastSent: 0,
     }
@@ -390,7 +432,13 @@ export class RoutingInformationBase {
       ...state,
       internal: { ...state.internal, peers },
     }
-    return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges: NO_ROUTE_CHANGES }
+    return {
+      prevState: state,
+      newState,
+      portOps: NO_PORT_OPS,
+      routeChanges: NO_ROUTE_CHANGES,
+      flapStateChanges: NO_FLAP_CHANGES,
+    }
   }
 
   private planInternalProtocolClose(
@@ -436,16 +484,27 @@ export class RoutingInformationBase {
       ...state,
       internal: { peers, routes },
     }
-    return { prevState: state, newState, portOps, routeChanges }
+    return { prevState: state, newState, portOps, routeChanges, flapStateChanges: NO_FLAP_CHANGES }
   }
 
   private planInternalProtocolUpdate(
     data: InternalProtocolUpdateData,
-    state: RouteTable
+    state: RouteTable,
+    timestamp: number
   ): PlanResult {
     let routes = [...state.internal.routes]
     const portOps: PortOperation[] = []
     const routeChanges: RouteChange[] = []
+    const flapChanges: FlapStateChange[] = []
+
+    // Build a transient view of flap state that includes pending changes from
+    // this plan, so that multiple updates in the same action see each other's
+    // mutations without touching the real _flapState.
+    const pendingFlapState = new Map<string, FlapEntry>()
+
+    const getFlapEntry = (key: string): FlapEntry | undefined => {
+      return pendingFlapState.get(key) ?? this._flapState.get(key)
+    }
 
     // --- Max prefix limit setup ---
     const limitPeer = state.internal.peers.find((p) => p.name === data.peerInfo.name)
@@ -495,19 +554,21 @@ export class RoutingInformationBase {
         }
 
         // --- Flap damping: track add-after-remove ---
-        const fk = this.flapKey(routeKey(item.route), item.originNode)
-        const flapEntry = this._flapState.get(fk)
+        const fk = flapKey(routeKey(item.route), item.originNode)
+        const flapEntry = getFlapEntry(fk)
         if (flapEntry && flapEntry.penalty > 0) {
-          const now = Date.now()
-          const decayed = this.decayPenalty(flapEntry, now)
+          const decayed = this.decayPenalty(flapEntry, timestamp)
           const newPenalty = decayed + FLAP_PENALTY_INCREMENT
           const shouldSuppress = newPenalty >= FLAP_SUPPRESS_THRESHOLD
-          this._flapState.set(fk, {
+          const newEntry: FlapEntry = {
             penalty: newPenalty,
             suppressed: shouldSuppress,
-            suppressedAt: shouldSuppress && !flapEntry.suppressed ? now : flapEntry.suppressedAt,
-            lastUpdated: now,
-          })
+            suppressedAt:
+              shouldSuppress && !flapEntry.suppressed ? timestamp : flapEntry.suppressedAt,
+            lastUpdated: timestamp,
+          }
+          pendingFlapState.set(fk, newEntry)
+          flapChanges.push({ key: fk, entry: newEntry })
         }
       } else {
         // action === 'remove'
@@ -522,24 +583,26 @@ export class RoutingInformationBase {
           }
 
           // --- Flap damping: mark as recently withdrawn ---
-          const fk = this.flapKey(routeKey(item.route), item.originNode)
-          const flapExisting = this._flapState.get(fk)
-          const now = Date.now()
+          const fk = flapKey(routeKey(item.route), item.originNode)
+          const flapExisting = getFlapEntry(fk)
+          let newEntry: FlapEntry
           if (!flapExisting) {
-            this._flapState.set(fk, {
+            newEntry = {
               penalty: FLAP_PENALTY_INCREMENT,
               suppressed: false,
               suppressedAt: null,
-              lastUpdated: now,
-            })
+              lastUpdated: timestamp,
+            }
           } else {
-            const decayed = this.decayPenalty(flapExisting, now)
-            this._flapState.set(fk, {
+            const decayed = this.decayPenalty(flapExisting, timestamp)
+            newEntry = {
               ...flapExisting,
               penalty: decayed + FLAP_PENALTY_INCREMENT,
-              lastUpdated: now,
-            })
+              lastUpdated: timestamp,
+            }
           }
+          pendingFlapState.set(fk, newEntry)
+          flapChanges.push({ key: fk, entry: newEntry })
         }
       }
     }
@@ -549,7 +612,7 @@ export class RoutingInformationBase {
     const peers =
       peerIdx !== -1
         ? state.internal.peers.map((p, i) =>
-            i === peerIdx ? { ...p, lastReceived: Date.now() } : p
+            i === peerIdx ? { ...p, lastReceived: timestamp } : p
           )
         : state.internal.peers
 
@@ -562,24 +625,31 @@ export class RoutingInformationBase {
       ...state,
       internal: { peers, routes },
     }
-    return { prevState: state, newState, portOps, routeChanges }
+    return { prevState: state, newState, portOps, routeChanges, flapStateChanges: flapChanges }
   }
 
   private planInternalProtocolKeepalive(
     data: InternalProtocolKeepaliveData,
-    state: RouteTable
+    state: RouteTable,
+    timestamp: number
   ): PlanResult {
     const idx = state.internal.peers.findIndex((p) => p.name === data.peerInfo.name)
     if (idx === -1) return noChange(state)
 
     const peers = state.internal.peers.map((p, i) =>
-      i === idx ? { ...p, lastReceived: Date.now() } : p
+      i === idx ? { ...p, lastReceived: timestamp } : p
     )
     const newState: RouteTable = {
       ...state,
       internal: { ...state.internal, peers },
     }
-    return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges: NO_ROUTE_CHANGES }
+    return {
+      prevState: state,
+      newState,
+      portOps: NO_PORT_OPS,
+      routeChanges: NO_ROUTE_CHANGES,
+      flapStateChanges: NO_FLAP_CHANGES,
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -589,13 +659,14 @@ export class RoutingInformationBase {
   private planTick(data: TickData, state: RouteTable): PlanResult {
     // --- Flap damping decay ---
     let flapStateChanged = false
+    const flapChanges: FlapStateChange[] = []
     for (const [key, entry] of this._flapState) {
       const decayed = this.decayPenalty(entry, data.now)
 
       if (decayed < 1) {
         // Penalty negligible — clean up
         if (entry.suppressed) flapStateChanged = true
-        this._flapState.delete(key)
+        flapChanges.push({ key, entry: null })
         continue
       }
 
@@ -605,15 +676,16 @@ export class RoutingInformationBase {
           (entry.suppressedAt != null && data.now - entry.suppressedAt > FLAP_MAX_SUPPRESS_MS))
 
       if (shouldUnsuppress) {
-        this._flapState.set(key, {
+        const newEntry: FlapEntry = {
           penalty: decayed,
           suppressed: false,
           suppressedAt: null,
           lastUpdated: data.now,
-        })
+        }
+        flapChanges.push({ key, entry: newEntry })
         flapStateChanged = true
       } else if (Math.abs(decayed - entry.penalty) > 0.1) {
-        this._flapState.set(key, { ...entry, penalty: decayed, lastUpdated: data.now })
+        flapChanges.push({ key, entry: { ...entry, penalty: decayed, lastUpdated: data.now } })
       }
     }
 
@@ -651,7 +723,13 @@ export class RoutingInformationBase {
 
     if (purgedPeerNames.size === 0 && flapStateChanged) {
       const newState: RouteTable = { ...state }
-      return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges: NO_ROUTE_CHANGES }
+      return {
+        prevState: state,
+        newState,
+        portOps: NO_PORT_OPS,
+        routeChanges: NO_ROUTE_CHANGES,
+        flapStateChanges: flapChanges,
+      }
     }
 
     const removedRoutes = state.internal.routes.filter((r) => purgedPeerNames.has(r.peer.name))
@@ -670,6 +748,6 @@ export class RoutingInformationBase {
       ...state,
       internal: { peers, routes },
     }
-    return { prevState: state, newState, portOps, routeChanges }
+    return { prevState: state, newState, portOps, routeChanges, flapStateChanges: flapChanges }
   }
 }

--- a/packages/routing/src/v2/rib/rib.ts
+++ b/packages/routing/src/v2/rib/rib.ts
@@ -46,6 +46,22 @@ type InternalProtocolKeepaliveData = Extract<
 type TickData = Extract<Action, { action: typeof Actions.Tick }>['data']
 
 // ---------------------------------------------------------------------------
+// Flap damping constants (RFC 2439 / RFC 7196 / RIPE-580)
+// ---------------------------------------------------------------------------
+export const FLAP_PENALTY_INCREMENT = 1000
+export const FLAP_SUPPRESS_THRESHOLD = 6000
+export const FLAP_REUSE_THRESHOLD = 750
+export const FLAP_HALF_LIFE_MS = 300_000 // 5 minutes
+export const FLAP_MAX_SUPPRESS_MS = 1_800_000 // 30 minutes
+
+export type FlapEntry = {
+  penalty: number
+  suppressed: boolean
+  suppressedAt: number | null
+  lastUpdated: number
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -88,6 +104,23 @@ export class RoutingInformationBase {
 
   get nodeId(): string {
     return this._nodeId
+  }
+
+  /** Ephemeral flap damping state — does not survive restart. */
+  private _flapState = new Map<string, FlapEntry>()
+
+  get flapState(): ReadonlyMap<string, FlapEntry> {
+    return this._flapState
+  }
+
+  private flapKey(rKey: string, originNode: string): string {
+    return `${rKey}:${originNode}`
+  }
+
+  private decayPenalty(entry: FlapEntry, now: number): number {
+    const elapsed = now - entry.lastUpdated
+    if (elapsed <= 0) return entry.penalty
+    return entry.penalty * Math.pow(0.5, elapsed / FLAP_HALF_LIFE_MS)
   }
 
   /**
@@ -460,6 +493,22 @@ export class RoutingInformationBase {
           routeChanges.push({ type: 'added', route: newRoute })
           if (hasLimit) currentPeerRouteCount++
         }
+
+        // --- Flap damping: track add-after-remove ---
+        const fk = this.flapKey(routeKey(item.route), item.originNode)
+        const flapEntry = this._flapState.get(fk)
+        if (flapEntry && flapEntry.penalty > 0) {
+          const now = Date.now()
+          const decayed = this.decayPenalty(flapEntry, now)
+          const newPenalty = decayed + FLAP_PENALTY_INCREMENT
+          const shouldSuppress = newPenalty >= FLAP_SUPPRESS_THRESHOLD
+          this._flapState.set(fk, {
+            penalty: newPenalty,
+            suppressed: shouldSuppress,
+            suppressedAt: shouldSuppress && !flapEntry.suppressed ? now : flapEntry.suppressedAt,
+            lastUpdated: now,
+          })
+        }
       } else {
         // action === 'remove'
         const key = routeKey(item.route)
@@ -470,6 +519,26 @@ export class RoutingInformationBase {
           if (hasLimit) currentPeerRouteCount--
           if (removed.envoyPort != null) {
             portOps.push({ type: 'release', routeKey: key, port: removed.envoyPort })
+          }
+
+          // --- Flap damping: mark as recently withdrawn ---
+          const fk = this.flapKey(routeKey(item.route), item.originNode)
+          const flapExisting = this._flapState.get(fk)
+          const now = Date.now()
+          if (!flapExisting) {
+            this._flapState.set(fk, {
+              penalty: FLAP_PENALTY_INCREMENT,
+              suppressed: false,
+              suppressedAt: null,
+              lastUpdated: now,
+            })
+          } else {
+            const decayed = this.decayPenalty(flapExisting, now)
+            this._flapState.set(fk, {
+              ...flapExisting,
+              penalty: decayed + FLAP_PENALTY_INCREMENT,
+              lastUpdated: now,
+            })
           }
         }
       }

--- a/packages/routing/src/v2/rib/rib.ts
+++ b/packages/routing/src/v2/rib/rib.ts
@@ -587,6 +587,36 @@ export class RoutingInformationBase {
   // -------------------------------------------------------------------------
 
   private planTick(data: TickData, state: RouteTable): PlanResult {
+    // --- Flap damping decay ---
+    let flapStateChanged = false
+    for (const [key, entry] of this._flapState) {
+      const decayed = this.decayPenalty(entry, data.now)
+
+      if (decayed < 1) {
+        // Penalty negligible — clean up
+        if (entry.suppressed) flapStateChanged = true
+        this._flapState.delete(key)
+        continue
+      }
+
+      const shouldUnsuppress =
+        entry.suppressed &&
+        (decayed < FLAP_REUSE_THRESHOLD ||
+          (entry.suppressedAt != null && data.now - entry.suppressedAt > FLAP_MAX_SUPPRESS_MS))
+
+      if (shouldUnsuppress) {
+        this._flapState.set(key, {
+          penalty: decayed,
+          suppressed: false,
+          suppressedAt: null,
+          lastUpdated: data.now,
+        })
+        flapStateChanged = true
+      } else if (Math.abs(decayed - entry.penalty) > 0.1) {
+        this._flapState.set(key, { ...entry, penalty: decayed, lastUpdated: data.now })
+      }
+    }
+
     // Find connected peers whose hold timer has expired
     const expiredPeerNames = new Set<string>()
     const peers = state.internal.peers.map((p) => {
@@ -617,7 +647,12 @@ export class RoutingInformationBase {
     }
 
     const purgedPeerNames = new Set([...expiredPeerNames, ...stalePeerNames])
-    if (purgedPeerNames.size === 0) return noChange(state)
+    if (purgedPeerNames.size === 0 && !flapStateChanged) return noChange(state)
+
+    if (purgedPeerNames.size === 0 && flapStateChanged) {
+      const newState: RouteTable = { ...state }
+      return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges: NO_ROUTE_CHANGES }
+    }
 
     const removedRoutes = state.internal.routes.filter((r) => purgedPeerNames.has(r.peer.name))
     const routes = state.internal.routes.filter((r) => !purgedPeerNames.has(r.peer.name))


### PR DESCRIPTION
## From [#401](https://github.com/orbisoperations/catalyst-router/issues/401): add route flap damping

> A penalty-based system where each withdrawal/re-announcement of the same route increments a counter. Once the penalty exceeds a suppress threshold, the route is suppressed (not propagated, deprioritized in best-path). Penalty decays over time via `Tick`.
>
> **Why It Matters:** A service that crashes and restarts repeatedly causes route oscillation across all peers. Without damping, every flap cascades through the entire mesh.

Stacked on [#651](https://github.com/orbisoperations/catalyst-router/pull/651) (max prefix limits).

## Implementation

Parameters follow [RFC 7196](https://www.rfc-editor.org/rfc/rfc7196) / [RIPE-580](https://www.ripe.net/publications/docs/ripe-580/) (suppress threshold 6000, not the harmful vendor default of 2000). Adapted for small meshes: 5-minute half-life, 30-minute max suppress time.

## Changes

- Flap constants, `FlapEntry` type, ephemeral `flapState` Map on RIB
- Penalty tracking on withdraw-then-re-add cycles in `planInternalProtocolUpdate`
- Exponential decay in `planTick` with max-suppress-time cap
- Suppress check in `buildUpdatesForPeer` (bus.ts)
- 9 tests (5 unit + 4 multi-node topology with fake timers)

## Design decisions

- **Suppress threshold 6000** — a single legitimate failover generates 3-4 path exploration updates. At the vendor default of 2000 this suppresses legitimate routes. At 6000 it takes 6 real flap cycles.
- **Ephemeral flap state** — does not survive restart. On restart, penalties reset to zero.
- **Cisco penalty model** — penalty increments on withdraw-then-re-add cycle only, not each individual event.

## How it was tested

**Unit tests** (5) — test RIB `plan()` directly:
- Single withdraw/re-add: penalty stays below threshold, not suppressed
- Six rapid flaps: penalty exceeds 6000, route suppressed
- Independent damping: flappy route suppressed, stable route unaffected
- Tick decay: after 5 half-lives (~25 min), penalty drops below reuse threshold, route unsuppressed
- Max suppress cap: after 30 minutes, route unsuppressed regardless of penalty

**Multi-node topology tests** (4) — real OrchestratorBus instances via TopologyHelper with `vi.useFakeTimers()`:
- A flaps 6 times: B accepts route but suppresses propagation to C
- After decay: B resumes propagating to C (keepalives dispatched to prevent hold-timer expiry)
- Fresh route from D beats suppressed route from A at C (best-path deprioritization)
- Flappy route suppressed while stable route propagates normally

Run: `pnpm vitest run apps/orchestrator/tests/v2/flap-damping.test.ts`

## References

- [RFC 2439 — BGP Route Flap Damping](https://www.rfc-editor.org/rfc/rfc2439)
- [RFC 7196 — Making Route Flap Damping Usable](https://www.rfc-editor.org/rfc/rfc7196)
- [RIPE-580](https://www.ripe.net/publications/docs/ripe-580/)