### PR TITLE
ci(hooks): add typecheck to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -11,4 +11,5 @@ if [ -n "$STAGED_FILES" ]; then
 fi
 
 pnpm exec lint-staged
+pnpm exec turbo run typecheck
 pnpm run test:unit


### PR DESCRIPTION
## Summary

Adds `pnpm exec turbo run typecheck` to the pre-commit hook so TypeScript type errors are caught before push, not just in CI.

**Before:** pre-commit runs lint-staged (ESLint + Prettier) + unit tests
**After:** pre-commit runs lint-staged + **typecheck** + unit tests

This would have caught the TS1355 errors in #651/#652 before they hit CI.

## Changes

- `.husky/pre-commit`: Add `pnpm exec turbo run typecheck` between lint-staged and test:unit