### PR TITLE
feat(routing): add graceful shutdown with drain signal

### DIFF
--- a/apps/orchestrator/src/v2/bus.ts
+++ b/apps/orchestrator/src/v2/bus.ts
@@ -752,6 +752,7 @@ export const BusTransforms = {
       healthStatus: route.healthStatus,
       responseTimeMs: route.responseTimeMs,
       lastChecked: route.lastChecked,
+      draining: route.draining,
     }
   },
 }

--- a/apps/orchestrator/tests/v2/graceful-shutdown.test.ts
+++ b/apps/orchestrator/tests/v2/graceful-shutdown.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import { RoutingInformationBase, Actions, newRouteTable } from '@catalyst/routing/v2'
 import type { RouteTable, PeerRecord, PeerInfo, Action } from '@catalyst/routing/v2'
+import { OrchestratorBus } from '../../src/v2/bus.js'
+import { MockPeerTransport, type TransportCall } from '../../src/v2/transport.js'
+import type { OrchestratorConfig } from '../../src/v1/types.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -120,7 +123,7 @@ describe('graceful shutdown — drain signal', () => {
     expect(rib.state.internal.routes[0].draining).toBeUndefined()
   })
 
-  it('drained route does NOT replace a healthy route', () => {
+  it('same-peer drain update is accepted (authoritative)', () => {
     const rib = new RoutingInformationBase({ nodeId })
     const state = connectedState()
 
@@ -147,7 +150,7 @@ describe('graceful shutdown — drain signal', () => {
     expect(rib.state.internal.routes).toHaveLength(1)
     expect(rib.state.internal.routes[0].draining).toBeUndefined()
 
-    // Now receive the same route but with draining — should NOT replace
+    // Same peer sends a drain update — should be accepted (same peer is authoritative)
     const addDrained: Action = {
       action: Actions.InternalProtocolUpdate,
       data: {
@@ -166,7 +169,84 @@ describe('graceful shutdown — drain signal', () => {
     }
     const p2 = rib.plan(addDrained, rib.state)
 
-    // No route changes — the healthy route is kept
+    // The route should be updated (same peer announcing drain)
+    const updated = p2.routeChanges.filter((c) => c.type === 'updated')
+    expect(updated).toHaveLength(1)
+    expect(updated[0].route.draining).toBe(true)
+
+    // After commit, the route should be draining
+    rib.commit(p2, addDrained)
+    expect(rib.state.internal.routes).toHaveLength(1)
+    expect(rib.state.internal.routes[0].draining).toBe(true)
+  })
+
+  it('drained route via different peer does NOT replace healthy route', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+
+    // Set up state with two peers
+    const peerC: PeerInfo = { name: 'node-c', endpoint: 'ws://c:4000', domains: ['test.local'] }
+    const state = newRouteTable()
+    const peerBRecord: PeerRecord = {
+      ...peerB,
+      connectionStatus: 'connected',
+      lastConnected: 1000,
+      holdTime: 90_000,
+      lastSent: 0,
+      lastReceived: 1000,
+    }
+    const peerCRecord: PeerRecord = {
+      ...peerC,
+      connectionStatus: 'connected',
+      lastConnected: 1000,
+      holdTime: 90_000,
+      lastSent: 0,
+      lastReceived: 1000,
+    }
+    state.internal.peers = [peerBRecord, peerCRecord]
+
+    // Receive healthy route from peer-B (origin: node-x)
+    const addHealthy: Action = {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [
+            {
+              action: 'add' as const,
+              route: makeRoute('svc-1'),
+              nodePath: ['node-b', 'node-x'],
+              originNode: 'node-x',
+            },
+          ],
+        },
+      },
+    }
+    const p1 = rib.plan(addHealthy, state)
+    rib.commit(p1, addHealthy)
+
+    expect(rib.state.internal.routes).toHaveLength(1)
+    expect(rib.state.internal.routes[0].draining).toBeUndefined()
+
+    // Receive drained version of same route from different peer-C (same origin: node-x)
+    const addDrained: Action = {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerC,
+        update: {
+          updates: [
+            {
+              action: 'add' as const,
+              route: { ...makeRoute('svc-1'), draining: true },
+              nodePath: ['node-c', 'node-x'],
+              originNode: 'node-x',
+            },
+          ],
+        },
+      },
+    }
+    const p2 = rib.plan(addDrained, rib.state)
+
+    // No route changes — the healthy route from the other peer path is kept
     const updated = p2.routeChanges.filter((c) => c.type === 'updated')
     expect(updated).toHaveLength(0)
 
@@ -214,5 +294,200 @@ describe('graceful shutdown — drain signal', () => {
       expect(route.draining).toBeUndefined()
     }
     expect(rib.state.local.routes).toHaveLength(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Topology helpers (copied from max-prefix.test.ts / orchestrator.topology.test.ts)
+// ---------------------------------------------------------------------------
+
+function topoMakeConfig(name: string): OrchestratorConfig {
+  return {
+    node: { name, endpoint: `ws://${name}:4000`, domains: ['topo.local'] },
+  }
+}
+
+function topoMakePeerInfo(name: string): PeerInfo {
+  return {
+    name,
+    endpoint: `ws://${name}:4000`,
+    domains: ['topo.local'],
+    peerToken: `token-${name}`,
+  }
+}
+
+interface BusEntry {
+  name: string
+  bus: OrchestratorBus
+  transport: MockPeerTransport
+  peerInfo: PeerInfo
+}
+
+class TopologyHelper {
+  private nodes = new Map<string, BusEntry>()
+
+  addNode(name: string): BusEntry {
+    const transport = new MockPeerTransport()
+    const config = topoMakeConfig(name)
+    const bus = new OrchestratorBus({ config, transport })
+    const entry: BusEntry = { name, bus, transport, peerInfo: topoMakePeerInfo(name) }
+    this.nodes.set(name, entry)
+    return entry
+  }
+
+  get(name: string): BusEntry {
+    const entry = this.nodes.get(name)
+    if (entry === undefined) throw new Error(`Unknown node: ${name}`)
+    return entry
+  }
+
+  async peer(nameA: string, nameB: string): Promise<void> {
+    const a = this.get(nameA)
+    const b = this.get(nameB)
+
+    await a.bus.dispatch({ action: Actions.LocalPeerCreate, data: b.peerInfo })
+    await b.bus.dispatch({ action: Actions.LocalPeerCreate, data: a.peerInfo })
+
+    await a.bus.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: b.peerInfo },
+    })
+    await b.bus.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: a.peerInfo },
+    })
+  }
+
+  async propagate(fromName: string, toName: string): Promise<void> {
+    const from = this.get(fromName)
+    const to = this.get(toName)
+
+    const consumed: TransportCall[] = []
+    const remaining: TransportCall[] = []
+    for (const call of from.transport.calls) {
+      if (call.method === 'sendUpdate' && call.peer.name === toName) {
+        consumed.push(call)
+      } else {
+        remaining.push(call)
+      }
+    }
+
+    from.transport.calls.length = 0
+    for (const c of remaining) {
+      from.transport.calls.push(c)
+    }
+
+    for (const call of consumed) {
+      if (call.method !== 'sendUpdate') continue
+      await to.bus.dispatch({
+        action: Actions.InternalProtocolUpdate,
+        data: { peerInfo: from.peerInfo, update: call.message },
+      })
+    }
+  }
+
+  resetAll(): void {
+    for (const entry of this.nodes.values()) {
+      entry.transport.reset()
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Topology tests for graceful shutdown
+// ---------------------------------------------------------------------------
+
+describe('Graceful shutdown topology', () => {
+  it('A drains -> C prefers B; A cancels -> C accepts A again', async () => {
+    const topo = new TopologyHelper()
+    topo.addNode('node-a')
+    topo.addNode('node-b')
+    topo.addNode('node-c')
+
+    // Setup: A<->C and B<->C (no direct A<->B link)
+    await topo.peer('node-a', 'node-c')
+    await topo.peer('node-b', 'node-c')
+    topo.resetAll()
+
+    // Both A and B create the same local route 'shared-svc'
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: makeRoute('shared-svc'),
+    })
+    await topo.get('node-b').bus.dispatch({
+      action: Actions.LocalRouteCreate,
+      data: makeRoute('shared-svc'),
+    })
+
+    // Propagate A->C and B->C. C should have the route from both peers.
+    await topo.propagate('node-a', 'node-c')
+    await topo.propagate('node-b', 'node-c')
+
+    const cRoutes = topo.get('node-c').bus.state.internal.routes
+    expect(cRoutes).toHaveLength(2)
+
+    const fromA = cRoutes.find((r) => r.originNode === 'node-a')
+    const fromB = cRoutes.find((r) => r.originNode === 'node-b')
+    expect(fromA).toBeDefined()
+    expect(fromB).toBeDefined()
+    expect(fromA!.draining).toBeUndefined()
+    expect(fromB!.draining).toBeUndefined()
+    topo.resetAll()
+
+    // ---------------------------------------------------------------
+    // Phase 1: A dispatches AdminGracefulShutdown
+    // ---------------------------------------------------------------
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.AdminGracefulShutdown,
+      data: {},
+    })
+
+    // A's local routes should be draining
+    expect(topo.get('node-a').bus.state.local.routes[0].draining).toBe(true)
+
+    // Propagate the drained update A->C
+    await topo.propagate('node-a', 'node-c')
+
+    const cRoutesAfterDrain = topo.get('node-c').bus.state.internal.routes
+    expect(cRoutesAfterDrain).toHaveLength(2)
+
+    const fromADrained = cRoutesAfterDrain.find((r) => r.originNode === 'node-a')
+    const fromBHealthy = cRoutesAfterDrain.find((r) => r.originNode === 'node-b')
+    expect(fromADrained).toBeDefined()
+    expect(fromBHealthy).toBeDefined()
+
+    // A's route on C should now be draining
+    expect(fromADrained!.draining).toBe(true)
+    // B's route on C should remain healthy
+    expect(fromBHealthy!.draining).toBeUndefined()
+
+    topo.resetAll()
+
+    // ---------------------------------------------------------------
+    // Phase 2: A dispatches AdminCancelShutdown
+    // ---------------------------------------------------------------
+    await topo.get('node-a').bus.dispatch({
+      action: Actions.AdminCancelShutdown,
+      data: {},
+    })
+
+    // A's local routes should no longer be draining
+    expect(topo.get('node-a').bus.state.local.routes[0].draining).toBeUndefined()
+
+    // Propagate the undrained update A->C
+    await topo.propagate('node-a', 'node-c')
+
+    const cRoutesAfterCancel = topo.get('node-c').bus.state.internal.routes
+    expect(cRoutesAfterCancel).toHaveLength(2)
+
+    const fromARestored = cRoutesAfterCancel.find((r) => r.originNode === 'node-a')
+    const fromBStillHealthy = cRoutesAfterCancel.find((r) => r.originNode === 'node-b')
+    expect(fromARestored).toBeDefined()
+    expect(fromBStillHealthy).toBeDefined()
+
+    // A's route on C should no longer be draining
+    expect(fromARestored!.draining).toBeUndefined()
+    // B's route on C should still be healthy
+    expect(fromBStillHealthy!.draining).toBeUndefined()
   })
 })

--- a/apps/orchestrator/tests/v2/graceful-shutdown.test.ts
+++ b/apps/orchestrator/tests/v2/graceful-shutdown.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from 'vitest'
+import { RoutingInformationBase, Actions, newRouteTable } from '@catalyst/routing/v2'
+import type { RouteTable, PeerRecord, PeerInfo, Action } from '@catalyst/routing/v2'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const nodeId = 'node-a'
+const peerB: PeerInfo = { name: 'node-b', endpoint: 'ws://b:4000', domains: ['test.local'] }
+
+function makeRoute(name: string) {
+  return { name, protocol: 'http' as const, endpoint: `http://${name}:8080` }
+}
+
+function connectedState(): RouteTable {
+  const state = newRouteTable()
+  const peer: PeerRecord = {
+    ...peerB,
+    connectionStatus: 'connected',
+    lastConnected: 1000,
+    holdTime: 90_000,
+    lastSent: 0,
+    lastReceived: 1000,
+  }
+  state.internal.peers = [peer]
+  return state
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('graceful shutdown — drain signal', () => {
+  it('marks all local routes as draining', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+
+    // Create two local routes
+    const create1: Action = { action: Actions.LocalRouteCreate, data: makeRoute('svc-1') }
+    const p1 = rib.plan(create1, rib.state)
+    rib.commit(p1, create1)
+
+    const create2: Action = { action: Actions.LocalRouteCreate, data: makeRoute('svc-2') }
+    const p2 = rib.plan(create2, rib.state)
+    rib.commit(p2, create2)
+
+    expect(rib.state.local.routes).toHaveLength(2)
+
+    // Dispatch graceful shutdown
+    const shutdown: Action = { action: Actions.AdminGracefulShutdown, data: {} }
+    const plan = rib.plan(shutdown, rib.state)
+
+    // All local routes should be marked draining
+    expect(plan.newState.local.routes).toHaveLength(2)
+    for (const route of plan.newState.local.routes) {
+      expect(route.draining).toBe(true)
+    }
+
+    // Route changes should report 2 updated entries
+    expect(plan.routeChanges).toHaveLength(2)
+    for (const change of plan.routeChanges) {
+      expect(change.type).toBe('updated')
+    }
+  })
+
+  it('peers deprioritize drained routes — non-drained wins', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = connectedState()
+
+    // Add a drained internal route from peer-B
+    const addDrained: Action = {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [
+            {
+              action: 'add' as const,
+              route: { ...makeRoute('svc-1'), draining: true },
+              nodePath: ['node-b'],
+              originNode: 'node-b',
+            },
+          ],
+        },
+      },
+    }
+    const p1 = rib.plan(addDrained, state)
+    rib.commit(p1, addDrained)
+
+    expect(rib.state.internal.routes).toHaveLength(1)
+    expect(rib.state.internal.routes[0].draining).toBe(true)
+
+    // Now receive the same route without draining — should replace the drained version
+    const addHealthy: Action = {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [
+            {
+              action: 'add' as const,
+              route: makeRoute('svc-1'),
+              nodePath: ['node-b'],
+              originNode: 'node-b',
+            },
+          ],
+        },
+      },
+    }
+    const p2 = rib.plan(addHealthy, rib.state)
+
+    // The route should be updated (non-drained replaces drained)
+    const updated = p2.routeChanges.filter((c) => c.type === 'updated')
+    expect(updated).toHaveLength(1)
+    expect(updated[0].route.draining).toBeUndefined()
+
+    // After commit, the route should not be draining
+    rib.commit(p2, addHealthy)
+    expect(rib.state.internal.routes).toHaveLength(1)
+    expect(rib.state.internal.routes[0].draining).toBeUndefined()
+  })
+
+  it('drained route does NOT replace a healthy route', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = connectedState()
+
+    // Add a healthy (non-drained) internal route from peer-B
+    const addHealthy: Action = {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [
+            {
+              action: 'add' as const,
+              route: makeRoute('svc-1'),
+              nodePath: ['node-b'],
+              originNode: 'node-b',
+            },
+          ],
+        },
+      },
+    }
+    const p1 = rib.plan(addHealthy, state)
+    rib.commit(p1, addHealthy)
+
+    expect(rib.state.internal.routes).toHaveLength(1)
+    expect(rib.state.internal.routes[0].draining).toBeUndefined()
+
+    // Now receive the same route but with draining — should NOT replace
+    const addDrained: Action = {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [
+            {
+              action: 'add' as const,
+              route: { ...makeRoute('svc-1'), draining: true },
+              nodePath: ['node-b'],
+              originNode: 'node-b',
+            },
+          ],
+        },
+      },
+    }
+    const p2 = rib.plan(addDrained, rib.state)
+
+    // No route changes — the healthy route is kept
+    const updated = p2.routeChanges.filter((c) => c.type === 'updated')
+    expect(updated).toHaveLength(0)
+
+    // After commit, the route should still not be draining
+    rib.commit(p2, addDrained)
+    expect(rib.state.internal.routes).toHaveLength(1)
+    expect(rib.state.internal.routes[0].draining).toBeUndefined()
+  })
+
+  it('cancel removes drain marker', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+
+    // Create two local routes
+    const create1: Action = { action: Actions.LocalRouteCreate, data: makeRoute('svc-1') }
+    const p1 = rib.plan(create1, rib.state)
+    rib.commit(p1, create1)
+
+    const create2: Action = { action: Actions.LocalRouteCreate, data: makeRoute('svc-2') }
+    const p2 = rib.plan(create2, rib.state)
+    rib.commit(p2, create2)
+
+    // Dispatch graceful shutdown
+    const shutdown: Action = { action: Actions.AdminGracefulShutdown, data: {} }
+    const shutdownPlan = rib.plan(shutdown, rib.state)
+    rib.commit(shutdownPlan, shutdown)
+
+    // Verify routes are draining
+    for (const route of rib.state.local.routes) {
+      expect(route.draining).toBe(true)
+    }
+
+    // Dispatch cancel shutdown
+    const cancel: Action = { action: Actions.AdminCancelShutdown, data: {} }
+    const cancelPlan = rib.plan(cancel, rib.state)
+
+    // Route changes should report 2 updated entries
+    expect(cancelPlan.routeChanges).toHaveLength(2)
+    for (const change of cancelPlan.routeChanges) {
+      expect(change.type).toBe('updated')
+    }
+
+    // After commit, routes should no longer have draining
+    rib.commit(cancelPlan, cancel)
+    for (const route of rib.state.local.routes) {
+      expect(route.draining).toBeUndefined()
+    }
+    expect(rib.state.local.routes).toHaveLength(2)
+  })
+})

--- a/apps/orchestrator/tests/v2/graceful-shutdown.test.ts
+++ b/apps/orchestrator/tests/v2/graceful-shutdown.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { RoutingInformationBase, Actions, newRouteTable } from '@catalyst/routing/v2'
 import type { RouteTable, PeerRecord, PeerInfo, Action } from '@catalyst/routing/v2'
-import { OrchestratorBus } from '../../src/v2/bus.js'
-import { MockPeerTransport, type TransportCall } from '../../src/v2/transport.js'
-import type { OrchestratorConfig } from '../../src/v1/types.js'
+import { TopologyHelper } from './helpers/topology-helper.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -295,103 +293,41 @@ describe('graceful shutdown — drain signal', () => {
     }
     expect(rib.state.local.routes).toHaveLength(2)
   })
+
+  it('shutdown is idempotent — second dispatch is a no-op', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+
+    // Create a local route
+    const create: Action = { action: Actions.LocalRouteCreate, data: makeRoute('svc-1') }
+    const p1 = rib.plan(create, rib.state)
+    rib.commit(p1, create)
+
+    // First shutdown — should produce route changes
+    const shutdown: Action = { action: Actions.AdminGracefulShutdown, data: {} }
+    const plan1 = rib.plan(shutdown, rib.state)
+    expect(rib.stateChanged(plan1)).toBe(true)
+    expect(plan1.routeChanges).toHaveLength(1)
+    rib.commit(plan1, shutdown)
+
+    // Second shutdown — already draining, should be a no-op
+    const plan2 = rib.plan(shutdown, rib.state)
+    expect(rib.stateChanged(plan2)).toBe(false)
+    expect(plan2.routeChanges).toHaveLength(0)
+  })
+
+  it('shutdown with zero local routes is a no-op', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+
+    // No local routes — shutdown should be a no-op
+    expect(rib.state.local.routes).toHaveLength(0)
+
+    const shutdown: Action = { action: Actions.AdminGracefulShutdown, data: {} }
+    const plan = rib.plan(shutdown, rib.state)
+    expect(rib.stateChanged(plan)).toBe(false)
+    expect(plan.routeChanges).toHaveLength(0)
+    expect(plan.portOps).toHaveLength(0)
+  })
 })
-
-// ---------------------------------------------------------------------------
-// Topology helpers (copied from max-prefix.test.ts / orchestrator.topology.test.ts)
-// ---------------------------------------------------------------------------
-
-function topoMakeConfig(name: string): OrchestratorConfig {
-  return {
-    node: { name, endpoint: `ws://${name}:4000`, domains: ['topo.local'] },
-  }
-}
-
-function topoMakePeerInfo(name: string): PeerInfo {
-  return {
-    name,
-    endpoint: `ws://${name}:4000`,
-    domains: ['topo.local'],
-    peerToken: `token-${name}`,
-  }
-}
-
-interface BusEntry {
-  name: string
-  bus: OrchestratorBus
-  transport: MockPeerTransport
-  peerInfo: PeerInfo
-}
-
-class TopologyHelper {
-  private nodes = new Map<string, BusEntry>()
-
-  addNode(name: string): BusEntry {
-    const transport = new MockPeerTransport()
-    const config = topoMakeConfig(name)
-    const bus = new OrchestratorBus({ config, transport })
-    const entry: BusEntry = { name, bus, transport, peerInfo: topoMakePeerInfo(name) }
-    this.nodes.set(name, entry)
-    return entry
-  }
-
-  get(name: string): BusEntry {
-    const entry = this.nodes.get(name)
-    if (entry === undefined) throw new Error(`Unknown node: ${name}`)
-    return entry
-  }
-
-  async peer(nameA: string, nameB: string): Promise<void> {
-    const a = this.get(nameA)
-    const b = this.get(nameB)
-
-    await a.bus.dispatch({ action: Actions.LocalPeerCreate, data: b.peerInfo })
-    await b.bus.dispatch({ action: Actions.LocalPeerCreate, data: a.peerInfo })
-
-    await a.bus.dispatch({
-      action: Actions.InternalProtocolConnected,
-      data: { peerInfo: b.peerInfo },
-    })
-    await b.bus.dispatch({
-      action: Actions.InternalProtocolConnected,
-      data: { peerInfo: a.peerInfo },
-    })
-  }
-
-  async propagate(fromName: string, toName: string): Promise<void> {
-    const from = this.get(fromName)
-    const to = this.get(toName)
-
-    const consumed: TransportCall[] = []
-    const remaining: TransportCall[] = []
-    for (const call of from.transport.calls) {
-      if (call.method === 'sendUpdate' && call.peer.name === toName) {
-        consumed.push(call)
-      } else {
-        remaining.push(call)
-      }
-    }
-
-    from.transport.calls.length = 0
-    for (const c of remaining) {
-      from.transport.calls.push(c)
-    }
-
-    for (const call of consumed) {
-      if (call.method !== 'sendUpdate') continue
-      await to.bus.dispatch({
-        action: Actions.InternalProtocolUpdate,
-        data: { peerInfo: from.peerInfo, update: call.message },
-      })
-    }
-  }
-
-  resetAll(): void {
-    for (const entry of this.nodes.values()) {
-      entry.transport.reset()
-    }
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Topology tests for graceful shutdown

--- a/packages/routing/src/v2/action-types.ts
+++ b/packages/routing/src/v2/action-types.ts
@@ -22,6 +22,8 @@ export const Actions = {
 
   // System
   Tick: 'system:tick',
+  AdminGracefulShutdown: 'admin:graceful-shutdown',
+  AdminCancelShutdown: 'admin:cancel-shutdown',
 } as const
 
 export type ActionType = (typeof Actions)[keyof typeof Actions]

--- a/packages/routing/src/v2/datachannel.ts
+++ b/packages/routing/src/v2/datachannel.ts
@@ -27,6 +27,7 @@ export const DataChannelDefinitionSchema = z.object({
   healthStatus: z.enum(['up', 'down']).optional(),
   responseTimeMs: z.number().nullable().optional(),
   lastChecked: z.string().optional(),
+  draining: z.boolean().optional(),
 })
 export type DataChannelDefinition = z.infer<typeof DataChannelDefinitionSchema>
 

--- a/packages/routing/src/v2/rib/rib.ts
+++ b/packages/routing/src/v2/rib/rib.ts
@@ -553,14 +553,24 @@ export class RoutingInformationBase {
           const existing = routes[existingIdx]
           // Best-path selection: prefer shorter path, or replace a stale route
           const betterPath = item.nodePath.length < existing.nodePath.length
+          const equalPath = item.nodePath.length === existing.nodePath.length
           const replacingStale = existing.isStale === true
           const existingDrained = existing.draining === true
           const newDrained = newRoute.draining === true
           // Non-drained always beats drained, regardless of path length
           const drainingAdvantage = existingDrained && !newDrained
-          // Don't replace healthy route with a draining one
-          const drainingDisadvantage = !existingDrained && newDrained
-          if (!drainingDisadvantage && (betterPath || replacingStale || drainingAdvantage)) {
+          // Don't replace healthy route with a draining one — but only when received
+          // from a different peer (multi-path). Same-peer updates are authoritative
+          // (e.g. the origin announcing its own drain).
+          const samePeer = existing.peer.name === data.peerInfo.name
+          const drainingDisadvantage = !samePeer && !existingDrained && newDrained
+          // Same-peer equal-path: accept metadata changes (drain/undrain) from
+          // the authoritative source without requiring a strictly better path.
+          const samePeerRefresh = samePeer && equalPath
+          if (
+            !drainingDisadvantage &&
+            (betterPath || replacingStale || drainingAdvantage || samePeerRefresh)
+          ) {
             routes = routes.map((r, i) => (i === existingIdx ? newRoute : r))
             routeChanges.push({ type: 'updated', route: newRoute })
           }

--- a/packages/routing/src/v2/rib/rib.ts
+++ b/packages/routing/src/v2/rib/rib.ts
@@ -44,6 +44,14 @@ type InternalProtocolKeepaliveData = Extract<
   { action: typeof Actions.InternalProtocolKeepalive }
 >['data']
 type TickData = Extract<Action, { action: typeof Actions.Tick }>['data']
+type AdminGracefulShutdownData = Extract<
+  Action,
+  { action: typeof Actions.AdminGracefulShutdown }
+>['data']
+type AdminCancelShutdownData = Extract<
+  Action,
+  { action: typeof Actions.AdminCancelShutdown }
+>['data']
 
 // ---------------------------------------------------------------------------
 // Flap damping constants (RFC 2439 / RFC 7196 / RIPE-580)
@@ -165,6 +173,10 @@ export class RoutingInformationBase {
         return this.planInternalProtocolKeepalive(action.data, state, timestamp)
       case Actions.Tick:
         return this.planTick(action.data, state)
+      case Actions.AdminGracefulShutdown:
+        return this.planAdminGracefulShutdown(action.data, state)
+      case Actions.AdminCancelShutdown:
+        return this.planAdminCancelShutdown(action.data, state)
       default:
         return noChange(state)
     }
@@ -542,7 +554,13 @@ export class RoutingInformationBase {
           // Best-path selection: prefer shorter path, or replace a stale route
           const betterPath = item.nodePath.length < existing.nodePath.length
           const replacingStale = existing.isStale === true
-          if (betterPath || replacingStale) {
+          const existingDrained = existing.draining === true
+          const newDrained = newRoute.draining === true
+          // Non-drained always beats drained, regardless of path length
+          const drainingAdvantage = existingDrained && !newDrained
+          // Don't replace healthy route with a draining one
+          const drainingDisadvantage = !existingDrained && newDrained
+          if (!drainingDisadvantage && (betterPath || replacingStale || drainingAdvantage)) {
             routes = routes.map((r, i) => (i === existingIdx ? newRoute : r))
             routeChanges.push({ type: 'updated', route: newRoute })
           }
@@ -749,5 +767,35 @@ export class RoutingInformationBase {
       internal: { peers, routes },
     }
     return { prevState: state, newState, portOps, routeChanges, flapStateChanges: flapChanges }
+  }
+
+  private planAdminGracefulShutdown(
+    _data: AdminGracefulShutdownData,
+    state: RouteTable
+  ): PlanResult {
+    if (state.local.routes.length === 0) return noChange(state)
+
+    const routes = state.local.routes.map((r) => ({ ...r, draining: true }))
+    const routeChanges: RouteChange[] = routes.map((r) => ({ type: 'updated' as const, route: r }))
+
+    const newState: RouteTable = {
+      ...state,
+      local: { ...state.local, routes },
+    }
+    return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges }
+  }
+
+  private planAdminCancelShutdown(_data: AdminCancelShutdownData, state: RouteTable): PlanResult {
+    const hasDraining = state.local.routes.some((r) => r.draining === true)
+    if (!hasDraining) return noChange(state)
+
+    const routes = state.local.routes.map(({ draining: _draining, ...rest }) => rest)
+    const routeChanges: RouteChange[] = routes.map((r) => ({ type: 'updated' as const, route: r }))
+
+    const newState: RouteTable = {
+      ...state,
+      local: { ...state.local, routes },
+    }
+    return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges }
   }
 }

--- a/packages/routing/src/v2/rib/rib.ts
+++ b/packages/routing/src/v2/rib/rib.ts
@@ -785,6 +785,9 @@ export class RoutingInformationBase {
   ): PlanResult {
     if (state.local.routes.length === 0) return noChange(state)
 
+    const allAlreadyDraining = state.local.routes.every((r) => r.draining === true)
+    if (allAlreadyDraining) return noChange(state)
+
     const routes = state.local.routes.map((r) => ({ ...r, draining: true }))
     const routeChanges: RouteChange[] = routes.map((r) => ({ type: 'updated' as const, route: r }))
 
@@ -792,7 +795,13 @@ export class RoutingInformationBase {
       ...state,
       local: { ...state.local, routes },
     }
-    return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges }
+    return {
+      prevState: state,
+      newState,
+      portOps: NO_PORT_OPS,
+      routeChanges,
+      flapStateChanges: NO_FLAP_CHANGES,
+    }
   }
 
   private planAdminCancelShutdown(_data: AdminCancelShutdownData, state: RouteTable): PlanResult {
@@ -806,6 +815,12 @@ export class RoutingInformationBase {
       ...state,
       local: { ...state.local, routes },
     }
-    return { prevState: state, newState, portOps: NO_PORT_OPS, routeChanges }
+    return {
+      prevState: state,
+      newState,
+      portOps: NO_PORT_OPS,
+      routeChanges,
+      flapStateChanges: NO_FLAP_CHANGES,
+    }
   }
 }

--- a/packages/routing/src/v2/schema.ts
+++ b/packages/routing/src/v2/schema.ts
@@ -14,7 +14,11 @@ import {
   InternalProtocolConnectedMessageSchema,
   InternalProtocolKeepaliveMessageSchema,
 } from './internal/actions.js'
-import { TickMessageSchema } from './system/actions.js'
+import {
+  TickMessageSchema,
+  AdminGracefulShutdownMessageSchema,
+  AdminCancelShutdownMessageSchema,
+} from './system/actions.js'
 
 /**
  * Unified Action Schema — V2.
@@ -33,6 +37,8 @@ export const ActionSchema = z.discriminatedUnion('action', [
   InternalProtocolConnectedMessageSchema,
   InternalProtocolKeepaliveMessageSchema,
   TickMessageSchema,
+  AdminGracefulShutdownMessageSchema,
+  AdminCancelShutdownMessageSchema,
 ])
 
 export type Action = z.infer<typeof ActionSchema>

--- a/packages/routing/src/v2/system/actions.ts
+++ b/packages/routing/src/v2/system/actions.ts
@@ -7,3 +7,13 @@ export const TickMessageSchema = z.object({
     now: z.number(),
   }),
 })
+
+export const AdminGracefulShutdownMessageSchema = z.object({
+  action: z.literal(Actions.AdminGracefulShutdown),
+  data: z.object({}),
+})
+
+export const AdminCancelShutdownMessageSchema = z.object({
+  action: z.literal(Actions.AdminCancelShutdown),
+  data: z.object({}),
+})


### PR DESCRIPTION
## From [#404](https://github.com/orbisoperations/catalyst-router/issues/404): add graceful shutdown with drain signal

> Before a planned shutdown, a node re-advertises all routes with a "draining" marker. Peers deprioritize drained routes, preferring alternative paths. After traffic drains, the node can shut down safely.
>
> **Why It Matters:** Enables zero-downtime rolling deploys of catalyst nodes. Without this, shutting down a node causes immediate route withdrawal and potential traffic disruption.

Stacked on [#652](https://github.com/orbisoperations/catalyst-router/pull/652) (flap damping). Based on [RFC 8326](https://www.rfc-editor.org/rfc/rfc8326.html) (BGP Graceful Shutdown).

## Implementation

Adapts the [RFC 8326](https://www.rfc-editor.org/rfc/rfc8326.html) community-based approach (used by [FRR](https://docs.frrouting.org/en/latest/bgp.html#graceful-shutdown), [BIRD](https://bgpfilterguide.nlnog.net/guides/graceful_shutdown/#bird), [Juniper](https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/graceful-shutdown-edit-protocols-bgp.html), [OpenBGPD](https://bgpfilterguide.nlnog.net/guides/graceful_shutdown/#openbgpd)) to our protocol: a `draining` flag on routes that causes receivers to deprioritize them. Routes stay in the RIB as backup -- they're just deprioritized so traffic shifts to alternatives before shutdown.

## Changes

- `draining?: boolean` on `DataChannelDefinition`
- `AdminGracefulShutdown` / `AdminCancelShutdown` action types
- Plan handlers mark/clear drain on all local routes
- Best-path: non-drained always beats drained, drained never replaces healthy
- `BusTransforms.toDataChannel` propagates drain flag to peers
- 6 tests (5 unit + 1 topology)

## How it was tested

**Unit tests** (5):
- Marks all local routes as draining
- Peers deprioritize drained routes (non-drained wins regardless of path length)
- Same-peer drain update accepted (authoritative)
- Drained route via different peer does not replace healthy route
- Cancel removes drain marker

**Topology test** (1) -- A↔C↔B triangle:
- A drains → C's route from A gets draining flag, B's stays healthy
- A cancels → C's route from A cleared

Run: `pnpm vitest run apps/orchestrator/tests/v2/graceful-shutdown.test.ts`