### PR TITLE
feat(routing): add peer session flap detection with exponential backoff

### DIFF
--- a/apps/orchestrator/src/v2/bus.ts
+++ b/apps/orchestrator/src/v2/bus.ts
@@ -316,17 +316,26 @@ export class OrchestratorBus {
       const peerName = action.data.peerInfo.name
       const peer = connectedPeers.find((p) => p.name === peerName)
       if (peer !== undefined) {
-        await withWideEvent('orchestrator.peer_sync', logger, async (event) => {
-          event.set({
-            'catalyst.orchestrator.peer.name': peerName,
-            'catalyst.orchestrator.sync.type': 'full',
+        if (peer.syncDeferredUntil && peer.syncDeferredUntil > Date.now()) {
+          logger.warn('Deferring initial sync to flapping peer {peerName} until {deferUntil}', {
+            'event.name': 'peer.sync.deferred',
+            peerName,
+            deferUntil: new Date(peer.syncDeferredUntil).toISOString(),
+            consecutiveFailures: peer.consecutiveFailures,
           })
-          logger.info('Peer {peerName} connected, syncing full route table', {
-            'event.name': 'peer.sync.started',
-            'catalyst.orchestrator.peer.name': peerName,
+        } else {
+          await withWideEvent('orchestrator.peer_sync', logger, async (event) => {
+            event.set({
+              'catalyst.orchestrator.peer.name': peerName,
+              'catalyst.orchestrator.sync.type': 'full',
+            })
+            logger.info('Peer {peerName} connected, syncing full route table', {
+              'event.name': 'peer.sync.started',
+              'catalyst.orchestrator.peer.name': peerName,
+            })
+            await this.syncRoutesToPeer(peer, state)
           })
-          await this.syncRoutesToPeer(peer, state)
-        })
+        }
       }
       return
     }

--- a/apps/orchestrator/src/v2/bus.ts
+++ b/apps/orchestrator/src/v2/bus.ts
@@ -300,6 +300,18 @@ export class OrchestratorBus {
         'catalyst.orchestrator.keepalive.needed': ka.needed,
         'catalyst.orchestrator.keepalive.sent': ka.sent,
       })
+
+      // Deferred sync retry: when planTick clears syncDeferredUntil for a
+      // connected peer whose backoff window has expired, sync routes now.
+      const connectedPeers = committedState.internal.peers.filter(
+        (p) => p.connectionStatus === 'connected'
+      )
+      for (const peer of connectedPeers) {
+        const prevPeer = plan.prevState.internal.peers.find((p) => p.name === peer.name)
+        if (prevPeer && prevPeer.syncDeferredUntil > 0 && peer.syncDeferredUntil === 0) {
+          await this.syncRoutesToPeer(peer, committedState)
+        }
+      }
     }
   }
 

--- a/apps/orchestrator/tests/routes/api-state.test.ts
+++ b/apps/orchestrator/tests/routes/api-state.test.ts
@@ -24,6 +24,9 @@ function makeRouteTable(): RouteTable {
           holdTime: 90_000,
           lastSent: 100,
           lastReceived: 200,
+          consecutiveFailures: 0,
+          lastFailure: 0,
+          syncDeferredUntil: 0,
         },
       ],
       routes: [

--- a/apps/orchestrator/tests/v2/flap-damping.test.ts
+++ b/apps/orchestrator/tests/v2/flap-damping.test.ts
@@ -31,6 +31,9 @@ function connectedState(): RouteTable {
     holdTime: 90_000,
     lastSent: 0,
     lastReceived: 1000,
+    consecutiveFailures: 0,
+    lastFailure: 0,
+    syncDeferredUntil: 0,
   }
   state.internal.peers = [peer]
   return state

--- a/apps/orchestrator/tests/v2/graceful-shutdown.test.ts
+++ b/apps/orchestrator/tests/v2/graceful-shutdown.test.ts
@@ -23,6 +23,9 @@ function connectedState(): RouteTable {
     holdTime: 90_000,
     lastSent: 0,
     lastReceived: 1000,
+    consecutiveFailures: 0,
+    lastFailure: 0,
+    syncDeferredUntil: 0,
   }
   state.internal.peers = [peer]
   return state
@@ -191,6 +194,9 @@ describe('graceful shutdown — drain signal', () => {
       holdTime: 90_000,
       lastSent: 0,
       lastReceived: 1000,
+      consecutiveFailures: 0,
+      lastFailure: 0,
+      syncDeferredUntil: 0,
     }
     const peerCRecord: PeerRecord = {
       ...peerC,
@@ -199,6 +205,9 @@ describe('graceful shutdown — drain signal', () => {
       holdTime: 90_000,
       lastSent: 0,
       lastReceived: 1000,
+      consecutiveFailures: 0,
+      lastFailure: 0,
+      syncDeferredUntil: 0,
     }
     state.internal.peers = [peerBRecord, peerCRecord]
 

--- a/apps/orchestrator/tests/v2/max-prefix.test.ts
+++ b/apps/orchestrator/tests/v2/max-prefix.test.ts
@@ -24,6 +24,9 @@ function stateWithPeer(maxPrefixes?: number): RouteTable {
     lastSent: 0,
     lastReceived: 1000,
     maxPrefixes,
+    consecutiveFailures: 0,
+    lastFailure: 0,
+    syncDeferredUntil: 0,
   }
   state.internal.peers = [peer]
   return state
@@ -138,6 +141,9 @@ describe('max prefix limits (drop-excess model)', () => {
       lastSent: 0,
       lastReceived: 1000,
       maxPrefixes: 2,
+      consecutiveFailures: 0,
+      lastFailure: 0,
+      syncDeferredUntil: 0,
     }
     const peerCRecord: PeerRecord = {
       ...peerC,
@@ -147,6 +153,9 @@ describe('max prefix limits (drop-excess model)', () => {
       lastSent: 0,
       lastReceived: 1000,
       maxPrefixes: 2,
+      consecutiveFailures: 0,
+      lastFailure: 0,
+      syncDeferredUntil: 0,
     }
     state.internal.peers = [peerBRecord, peerCRecord]
 

--- a/apps/orchestrator/tests/v2/reconnect-sync.integration.test.ts
+++ b/apps/orchestrator/tests/v2/reconnect-sync.integration.test.ts
@@ -4,6 +4,10 @@
  * Verifies that when ReconnectManager successfully reconnects a peer, it dispatches
  * InternalProtocolConnected which triggers syncRoutesToPeer on the bus — delivering
  * the full route table to the reconnected peer.
+ *
+ * Note: Session flap detection defers sync for peers with consecutiveFailures > 0.
+ * Tests that need immediate sync after a transport-error close must advance time
+ * past the SESSION_FLAP_BASE_DELAY_MS window.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { OrchestratorServiceV2 } from '../../src/v2/service.js'
@@ -90,18 +94,19 @@ describe('ReconnectManager → Bus → initial sync chain', () => {
     const openCalls = transport.getCallsFor('openPeer')
     expect(openCalls).toHaveLength(1)
 
-    // Then dispatched InternalProtocolConnected → which triggers initial sync
-    // Check that sendUpdate was called with our local route
-    const updateCalls = transport
+    // After a transport-error close, the peer has consecutiveFailures=1.
+    // Session flap detection defers the initial sync for SESSION_FLAP_BASE_DELAY_MS,
+    // so sendUpdate should NOT have been called yet.
+    const deferredUpdateCalls = transport
       .getCallsFor('sendUpdate')
       .filter((c) => c.method === 'sendUpdate' && c.peer.name === 'node-b')
+    expect(deferredUpdateCalls).toHaveLength(0)
 
-    expect(updateCalls.length).toBeGreaterThanOrEqual(1)
-    const firstUpdate = updateCalls[0]
-    if (firstUpdate.method !== 'sendUpdate') return
-
-    const routeNames = firstUpdate.message.updates.map((u) => u.route.name)
-    expect(routeNames).toContain('alpha')
+    // Verify the peer is reconnected but sync was deferred
+    const reconnectedPeer = svc.bus.state.internal.peers.find((p) => p.name === 'node-b')!
+    expect(reconnectedPeer.connectionStatus).toBe('connected')
+    expect(reconnectedPeer.consecutiveFailures).toBe(1)
+    expect(reconnectedPeer.syncDeferredUntil).toBeGreaterThan(0)
   })
 
   it('reconnect resets attempt counter on success', async () => {

--- a/apps/orchestrator/tests/v2/reconnect.test.ts
+++ b/apps/orchestrator/tests/v2/reconnect.test.ts
@@ -18,6 +18,9 @@ const peerRecord: PeerRecord = {
   holdTime: 90_000,
   lastSent: 0,
   lastReceived: 0,
+  consecutiveFailures: 0,
+  lastFailure: 0,
+  syncDeferredUntil: 0,
 }
 
 const peerRecordNoToken: PeerRecord = {
@@ -29,6 +32,9 @@ const peerRecordNoToken: PeerRecord = {
   holdTime: 90_000,
   lastSent: 0,
   lastReceived: 0,
+  consecutiveFailures: 0,
+  lastFailure: 0,
+  syncDeferredUntil: 0,
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/orchestrator/tests/v2/service.test.ts
+++ b/apps/orchestrator/tests/v2/service.test.ts
@@ -102,6 +102,9 @@ describe('OrchestratorServiceV2', () => {
       holdTime: 90_000,
       lastSent: 0,
       lastReceived: 0,
+      consecutiveFailures: 0,
+      lastFailure: 0,
+      syncDeferredUntil: 0,
     }
 
     svc.reconnectManager.scheduleReconnect(peerRecord)
@@ -147,6 +150,9 @@ describe('OrchestratorServiceV2', () => {
       holdTime: 90_000,
       lastSent: 0,
       lastReceived: 0,
+      consecutiveFailures: 0,
+      lastFailure: 0,
+      syncDeferredUntil: 0,
     }
     svc.reconnectManager.scheduleReconnect(peerRecord)
     expect(svc.reconnectManager.pendingCount).toBe(1)

--- a/apps/orchestrator/tests/v2/session-flap.test.ts
+++ b/apps/orchestrator/tests/v2/session-flap.test.ts
@@ -16,40 +16,43 @@ import type { PeerInfo, Action } from '@catalyst/routing/v2'
 const nodeId = 'node-a'
 const peerB: PeerInfo = { name: 'node-b', endpoint: 'ws://b:4000', domains: ['test.local'] }
 
+/** Deterministic base timestamp for all tests. */
+const T0 = 1_000_000
+
 /** Add peer via LocalPeerCreate, then connect via InternalProtocolConnected */
-function createAndConnectPeer(rib: RoutingInformationBase): void {
+function createAndConnectPeer(rib: RoutingInformationBase, now: number): void {
   const create: Action = {
     action: Actions.LocalPeerCreate,
     data: peerB,
   }
-  const p1 = rib.plan(create, rib.state)
+  const p1 = rib.plan(create, rib.state, now)
   rib.commit(p1, create)
 
   const connect: Action = {
     action: Actions.InternalProtocolConnected,
     data: { peerInfo: peerB },
   }
-  const p2 = rib.plan(connect, rib.state)
+  const p2 = rib.plan(connect, rib.state, now)
   rib.commit(p2, connect)
 }
 
 /** Disconnect peer via InternalProtocolClose with transport error */
-function disconnectPeer(rib: RoutingInformationBase): void {
+function disconnectPeer(rib: RoutingInformationBase, now: number): void {
   const close: Action = {
     action: Actions.InternalProtocolClose,
     data: { peerInfo: peerB, code: CloseCodes.TRANSPORT_ERROR, reason: 'disconnect' },
   }
-  const plan = rib.plan(close, rib.state)
+  const plan = rib.plan(close, rib.state, now)
   rib.commit(plan, close)
 }
 
 /** Reconnect peer via InternalProtocolConnected */
-function reconnectPeer(rib: RoutingInformationBase): void {
+function reconnectPeer(rib: RoutingInformationBase, now: number): void {
   const connect: Action = {
     action: Actions.InternalProtocolConnected,
     data: { peerInfo: peerB },
   }
-  const plan = rib.plan(connect, rib.state)
+  const plan = rib.plan(connect, rib.state, now)
   rib.commit(plan, connect)
 }
 
@@ -60,7 +63,7 @@ function reconnectPeer(rib: RoutingInformationBase): void {
 describe('session flap detection (RFC 4271 §8 / BIRD error-wait)', () => {
   it('first disconnect sets consecutiveFailures to 1', () => {
     const rib = new RoutingInformationBase({ nodeId })
-    createAndConnectPeer(rib)
+    createAndConnectPeer(rib, T0)
 
     // Verify connected and zero failures
     const peerBefore = rib.state.internal.peers.find((p) => p.name === peerB.name)!
@@ -68,22 +71,25 @@ describe('session flap detection (RFC 4271 §8 / BIRD error-wait)', () => {
     expect(peerBefore.consecutiveFailures).toBe(0)
 
     // Disconnect
-    disconnectPeer(rib)
+    disconnectPeer(rib, T0 + 1000)
 
     const peerAfter = rib.state.internal.peers.find((p) => p.name === peerB.name)!
     expect(peerAfter.connectionStatus).toBe('closed')
     expect(peerAfter.consecutiveFailures).toBe(1)
-    expect(peerAfter.lastFailure).toBeGreaterThan(0)
+    expect(peerAfter.lastFailure).toBe(T0 + 1000)
   })
 
   it('third consecutive reconnect has sync deferred with expected delay', () => {
     const rib = new RoutingInformationBase({ nodeId })
-    createAndConnectPeer(rib)
+    let now = T0
+    createAndConnectPeer(rib, now)
 
     // 3 close/connect cycles
     for (let i = 0; i < 3; i++) {
-      disconnectPeer(rib)
-      reconnectPeer(rib)
+      now += 1000
+      disconnectPeer(rib, now)
+      now += 1000
+      reconnectPeer(rib, now)
     }
 
     const peer = rib.state.internal.peers.find((p) => p.name === peerB.name)!
@@ -91,51 +97,54 @@ describe('session flap detection (RFC 4271 §8 / BIRD error-wait)', () => {
     expect(peer.syncDeferredUntil).toBeGreaterThan(0)
 
     // After 3 failures, delay = 5000 * 2^(3-1) = 5000 * 4 = 20000
-    // syncDeferredUntil = Date.now() + 20000, so the delta should be ~20000
-    const now = Date.now()
-    const delta = peer.syncDeferredUntil - now
-    // Allow some slack for test execution time (within 1 second)
-    expect(delta).toBeGreaterThan(SESSION_FLAP_BASE_DELAY_MS * Math.pow(2, 2) - 1000)
-    expect(delta).toBeLessThanOrEqual(SESSION_FLAP_BASE_DELAY_MS * Math.pow(2, 2) + 1000)
+    // syncDeferredUntil = reconnectTimestamp + 20000
+    const expectedDelay = SESSION_FLAP_BASE_DELAY_MS * Math.pow(2, 2)
+    expect(peer.syncDeferredUntil).toBe(now + expectedDelay)
   })
 
   it('delay is capped at SESSION_FLAP_MAX_DELAY_MS', () => {
     const rib = new RoutingInformationBase({ nodeId })
-    createAndConnectPeer(rib)
+    let now = T0
+    createAndConnectPeer(rib, now)
 
     // 20 close/connect cycles to push past the cap
     for (let i = 0; i < 20; i++) {
-      disconnectPeer(rib)
-      reconnectPeer(rib)
+      now += 1000
+      disconnectPeer(rib, now)
+      now += 1000
+      reconnectPeer(rib, now)
     }
 
     const peer = rib.state.internal.peers.find((p) => p.name === peerB.name)!
     expect(peer.consecutiveFailures).toBe(20)
     expect(peer.syncDeferredUntil).toBeGreaterThan(0)
 
-    const now = Date.now()
-    const delta = peer.syncDeferredUntil - now
-    expect(delta).toBeLessThanOrEqual(SESSION_FLAP_MAX_DELAY_MS + 1000)
+    // The delay should be exactly the cap
+    expect(peer.syncDeferredUntil).toBe(now + SESSION_FLAP_MAX_DELAY_MS)
   })
 
-  it('stable peer for 5 minutes via Tick resets consecutiveFailures', () => {
+  it('stable peer for 5 minutes via Tick resets consecutiveFailures (uses lastConnected)', () => {
     const rib = new RoutingInformationBase({ nodeId })
-    createAndConnectPeer(rib)
+    let now = T0
+    createAndConnectPeer(rib, now)
 
     // Simulate some failures
-    disconnectPeer(rib)
-    reconnectPeer(rib)
-    disconnectPeer(rib)
-    reconnectPeer(rib)
+    now += 1000
+    disconnectPeer(rib, now)
+    now += 1000
+    reconnectPeer(rib, now)
+    now += 1000
+    disconnectPeer(rib, now)
+    now += 1000
+    reconnectPeer(rib, now)
 
     const peerBefore = rib.state.internal.peers.find((p) => p.name === peerB.name)!
     expect(peerBefore.consecutiveFailures).toBe(2)
     expect(peerBefore.connectionStatus).toBe('connected')
 
-    // Dispatch Tick well past the stability window.
-    // The stability check uses lastReceived, so we need it to be older than
-    // SESSION_FLAP_STABILITY_MS from tick's `now`.
-    const tickNow = peerBefore.lastReceived + SESSION_FLAP_STABILITY_MS + 1
+    // Stability check uses lastConnected, NOT lastReceived.
+    // Tick past the stability window from lastConnected.
+    const tickNow = peerBefore.lastConnected + SESSION_FLAP_STABILITY_MS + 1
     const tickAction: Action = {
       action: Actions.Tick,
       data: { now: tickNow },
@@ -151,11 +160,52 @@ describe('session flap detection (RFC 4271 §8 / BIRD error-wait)', () => {
 
   it('non-flapping peer gets immediate sync (syncDeferredUntil === 0)', () => {
     const rib = new RoutingInformationBase({ nodeId })
-    createAndConnectPeer(rib)
+    createAndConnectPeer(rib, T0)
 
     const peer = rib.state.internal.peers.find((p) => p.name === peerB.name)!
     expect(peer.connectionStatus).toBe('connected')
     expect(peer.consecutiveFailures).toBe(0)
     expect(peer.syncDeferredUntil).toBe(0)
+  })
+
+  it('Tick clears syncDeferredUntil when backoff window expires', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    let now = T0
+    createAndConnectPeer(rib, now)
+
+    // Create a flapping peer: disconnect + reconnect so sync is deferred
+    now += 1000
+    disconnectPeer(rib, now)
+    now += 1000
+    reconnectPeer(rib, now)
+
+    const peerBefore = rib.state.internal.peers.find((p) => p.name === peerB.name)!
+    expect(peerBefore.consecutiveFailures).toBe(1)
+    expect(peerBefore.syncDeferredUntil).toBeGreaterThan(0)
+    const deferUntil = peerBefore.syncDeferredUntil
+
+    // Tick before deferral expires -- should NOT clear
+    const earlyTick: Action = { action: Actions.Tick, data: { now: deferUntil - 1 } }
+    const earlyPlan = rib.plan(earlyTick, rib.state)
+    rib.commit(earlyPlan, earlyTick)
+    const peerStillDeferred = rib.state.internal.peers.find((p) => p.name === peerB.name)!
+    expect(peerStillDeferred.syncDeferredUntil).toBe(deferUntil)
+
+    // Tick at exactly deferral time -- should clear
+    const lateTick: Action = { action: Actions.Tick, data: { now: deferUntil } }
+    const latePlan = rib.plan(lateTick, rib.state)
+    expect(rib.stateChanged(latePlan)).toBe(true)
+    rib.commit(latePlan, lateTick)
+
+    const peerAfter = rib.state.internal.peers.find((p) => p.name === peerB.name)!
+    expect(peerAfter.syncDeferredUntil).toBe(0)
+    // consecutiveFailures should still be set (only stability reset clears it)
+    expect(peerAfter.consecutiveFailures).toBe(1)
+
+    // Confirm prevState vs newState shows the transition
+    const prevPeer = latePlan.prevState.internal.peers.find((p) => p.name === peerB.name)!
+    expect(prevPeer.syncDeferredUntil).toBe(deferUntil)
+    const newPeer = latePlan.newState.internal.peers.find((p) => p.name === peerB.name)!
+    expect(newPeer.syncDeferredUntil).toBe(0)
   })
 })

--- a/apps/orchestrator/tests/v2/session-flap.test.ts
+++ b/apps/orchestrator/tests/v2/session-flap.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest'
+import {
+  RoutingInformationBase,
+  Actions,
+  CloseCodes,
+  SESSION_FLAP_BASE_DELAY_MS,
+  SESSION_FLAP_MAX_DELAY_MS,
+  SESSION_FLAP_STABILITY_MS,
+} from '@catalyst/routing/v2'
+import type { PeerInfo, Action } from '@catalyst/routing/v2'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const nodeId = 'node-a'
+const peerB: PeerInfo = { name: 'node-b', endpoint: 'ws://b:4000', domains: ['test.local'] }
+
+/** Add peer via LocalPeerCreate, then connect via InternalProtocolConnected */
+function createAndConnectPeer(rib: RoutingInformationBase): void {
+  const create: Action = {
+    action: Actions.LocalPeerCreate,
+    data: peerB,
+  }
+  const p1 = rib.plan(create, rib.state)
+  rib.commit(p1, create)
+
+  const connect: Action = {
+    action: Actions.InternalProtocolConnected,
+    data: { peerInfo: peerB },
+  }
+  const p2 = rib.plan(connect, rib.state)
+  rib.commit(p2, connect)
+}
+
+/** Disconnect peer via InternalProtocolClose with transport error */
+function disconnectPeer(rib: RoutingInformationBase): void {
+  const close: Action = {
+    action: Actions.InternalProtocolClose,
+    data: { peerInfo: peerB, code: CloseCodes.TRANSPORT_ERROR, reason: 'disconnect' },
+  }
+  const plan = rib.plan(close, rib.state)
+  rib.commit(plan, close)
+}
+
+/** Reconnect peer via InternalProtocolConnected */
+function reconnectPeer(rib: RoutingInformationBase): void {
+  const connect: Action = {
+    action: Actions.InternalProtocolConnected,
+    data: { peerInfo: peerB },
+  }
+  const plan = rib.plan(connect, rib.state)
+  rib.commit(plan, connect)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('session flap detection (RFC 4271 §8 / BIRD error-wait)', () => {
+  it('first disconnect sets consecutiveFailures to 1', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    createAndConnectPeer(rib)
+
+    // Verify connected and zero failures
+    const peerBefore = rib.state.internal.peers.find((p) => p.name === peerB.name)!
+    expect(peerBefore.connectionStatus).toBe('connected')
+    expect(peerBefore.consecutiveFailures).toBe(0)
+
+    // Disconnect
+    disconnectPeer(rib)
+
+    const peerAfter = rib.state.internal.peers.find((p) => p.name === peerB.name)!
+    expect(peerAfter.connectionStatus).toBe('closed')
+    expect(peerAfter.consecutiveFailures).toBe(1)
+    expect(peerAfter.lastFailure).toBeGreaterThan(0)
+  })
+
+  it('third consecutive reconnect has sync deferred with expected delay', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    createAndConnectPeer(rib)
+
+    // 3 close/connect cycles
+    for (let i = 0; i < 3; i++) {
+      disconnectPeer(rib)
+      reconnectPeer(rib)
+    }
+
+    const peer = rib.state.internal.peers.find((p) => p.name === peerB.name)!
+    expect(peer.consecutiveFailures).toBe(3)
+    expect(peer.syncDeferredUntil).toBeGreaterThan(0)
+
+    // After 3 failures, delay = 5000 * 2^(3-1) = 5000 * 4 = 20000
+    // syncDeferredUntil = Date.now() + 20000, so the delta should be ~20000
+    const now = Date.now()
+    const delta = peer.syncDeferredUntil - now
+    // Allow some slack for test execution time (within 1 second)
+    expect(delta).toBeGreaterThan(SESSION_FLAP_BASE_DELAY_MS * Math.pow(2, 2) - 1000)
+    expect(delta).toBeLessThanOrEqual(SESSION_FLAP_BASE_DELAY_MS * Math.pow(2, 2) + 1000)
+  })
+
+  it('delay is capped at SESSION_FLAP_MAX_DELAY_MS', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    createAndConnectPeer(rib)
+
+    // 20 close/connect cycles to push past the cap
+    for (let i = 0; i < 20; i++) {
+      disconnectPeer(rib)
+      reconnectPeer(rib)
+    }
+
+    const peer = rib.state.internal.peers.find((p) => p.name === peerB.name)!
+    expect(peer.consecutiveFailures).toBe(20)
+    expect(peer.syncDeferredUntil).toBeGreaterThan(0)
+
+    const now = Date.now()
+    const delta = peer.syncDeferredUntil - now
+    expect(delta).toBeLessThanOrEqual(SESSION_FLAP_MAX_DELAY_MS + 1000)
+  })
+
+  it('stable peer for 5 minutes via Tick resets consecutiveFailures', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    createAndConnectPeer(rib)
+
+    // Simulate some failures
+    disconnectPeer(rib)
+    reconnectPeer(rib)
+    disconnectPeer(rib)
+    reconnectPeer(rib)
+
+    const peerBefore = rib.state.internal.peers.find((p) => p.name === peerB.name)!
+    expect(peerBefore.consecutiveFailures).toBe(2)
+    expect(peerBefore.connectionStatus).toBe('connected')
+
+    // Dispatch Tick well past the stability window.
+    // The stability check uses lastReceived, so we need it to be older than
+    // SESSION_FLAP_STABILITY_MS from tick's `now`.
+    const tickNow = peerBefore.lastReceived + SESSION_FLAP_STABILITY_MS + 1
+    const tickAction: Action = {
+      action: Actions.Tick,
+      data: { now: tickNow },
+    }
+    const plan = rib.plan(tickAction, rib.state)
+    rib.commit(plan, tickAction)
+
+    const peerAfter = rib.state.internal.peers.find((p) => p.name === peerB.name)!
+    expect(peerAfter.consecutiveFailures).toBe(0)
+    expect(peerAfter.lastFailure).toBe(0)
+    expect(peerAfter.syncDeferredUntil).toBe(0)
+  })
+
+  it('non-flapping peer gets immediate sync (syncDeferredUntil === 0)', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    createAndConnectPeer(rib)
+
+    const peer = rib.state.internal.peers.find((p) => p.name === peerB.name)!
+    expect(peer.connectionStatus).toBe('connected')
+    expect(peer.consecutiveFailures).toBe(0)
+    expect(peer.syncDeferredUntil).toBe(0)
+  })
+})

--- a/apps/orchestrator/tests/v2/ws-peering.integration.test.ts
+++ b/apps/orchestrator/tests/v2/ws-peering.integration.test.ts
@@ -147,6 +147,9 @@ async function peerNodes(a: TestNode, b: TestNode): Promise<void> {
       holdTime: 90_000,
       lastSent: 0,
       lastReceived: 0,
+      consecutiveFailures: 0,
+      lastFailure: 0,
+      syncDeferredUntil: 0,
     },
     a.token
   )
@@ -172,6 +175,9 @@ async function peerNodes(a: TestNode, b: TestNode): Promise<void> {
       holdTime: 90_000,
       lastSent: 0,
       lastReceived: 0,
+      consecutiveFailures: 0,
+      lastFailure: 0,
+      syncDeferredUntil: 0,
     },
     b.token
   )
@@ -226,6 +232,9 @@ describe('WebSocketPeerTransport: connection lifecycle', () => {
       holdTime: 90_000,
       lastSent: 0,
       lastReceived: 0,
+      consecutiveFailures: 0,
+      lastFailure: 0,
+      syncDeferredUntil: 0,
     }
 
     await transportA.openPeer(peerRecord, tokenA)
@@ -253,6 +262,9 @@ describe('WebSocketPeerTransport: connection lifecycle', () => {
       holdTime: 90_000,
       lastSent: 0,
       lastReceived: 0,
+      consecutiveFailures: 0,
+      lastFailure: 0,
+      syncDeferredUntil: 0,
     }
 
     await expect(transport.openPeer(peerRecord, 'any-token')).rejects.toThrow()

--- a/packages/routing/src/v2/rib/index.ts
+++ b/packages/routing/src/v2/rib/index.ts
@@ -7,5 +7,8 @@ export {
   FLAP_REUSE_THRESHOLD,
   FLAP_HALF_LIFE_MS,
   FLAP_MAX_SUPPRESS_MS,
+  SESSION_FLAP_BASE_DELAY_MS,
+  SESSION_FLAP_MAX_DELAY_MS,
+  SESSION_FLAP_STABILITY_MS,
 } from './rib.js'
 export type { FlapEntry } from './rib.js'

--- a/packages/routing/src/v2/rib/rib.ts
+++ b/packages/routing/src/v2/rib/rib.ts
@@ -62,6 +62,13 @@ export const FLAP_REUSE_THRESHOLD = 750
 export const FLAP_HALF_LIFE_MS = 300_000 // 5 minutes
 export const FLAP_MAX_SUPPRESS_MS = 1_800_000 // 30 minutes
 
+// ---------------------------------------------------------------------------
+// Session flap detection constants (RFC 4271 §8 / BIRD error-wait model)
+// ---------------------------------------------------------------------------
+export const SESSION_FLAP_BASE_DELAY_MS = 5_000 // 5 seconds
+export const SESSION_FLAP_MAX_DELAY_MS = 300_000 // 5 minutes cap
+export const SESSION_FLAP_STABILITY_MS = 300_000 // 5 minutes stable = reset
+
 export type FlapEntry = {
   penalty: number
   suppressed: boolean
@@ -166,7 +173,7 @@ export class RoutingInformationBase {
       case Actions.InternalProtocolConnected:
         return this.planInternalProtocolConnected(action.data, state, timestamp)
       case Actions.InternalProtocolClose:
-        return this.planInternalProtocolClose(action.data, state)
+        return this.planInternalProtocolClose(action.data, state, timestamp)
       case Actions.InternalProtocolUpdate:
         return this.planInternalProtocolUpdate(action.data, state, timestamp)
       case Actions.InternalProtocolKeepalive:
@@ -231,6 +238,9 @@ export class RoutingInformationBase {
       holdTime: 90_000,
       lastSent: 0,
       lastReceived: 0,
+      consecutiveFailures: 0,
+      lastFailure: 0,
+      syncDeferredUntil: 0,
     }
     const newState: RouteTable = {
       ...state,
@@ -431,6 +441,14 @@ export class RoutingInformationBase {
     const existing = state.internal.peers[idx]
     // Reset holdTime to default on reconnect so it can be re-negotiated
     // via the subsequent InternalProtocolOpen exchange.
+    const failures = existing.consecutiveFailures ?? 0
+    const syncDelay =
+      failures > 0
+        ? Math.min(
+            SESSION_FLAP_BASE_DELAY_MS * Math.pow(2, failures - 1),
+            SESSION_FLAP_MAX_DELAY_MS
+          )
+        : 0
     const updated: PeerRecord = {
       ...existing,
       connectionStatus: 'connected',
@@ -438,6 +456,7 @@ export class RoutingInformationBase {
       lastReceived: timestamp,
       holdTime: 90_000,
       lastSent: 0,
+      syncDeferredUntil: syncDelay > 0 ? timestamp + syncDelay : 0,
     }
     const peers = state.internal.peers.map((p, i) => (i === idx ? updated : p))
     const newState: RouteTable = {
@@ -455,7 +474,8 @@ export class RoutingInformationBase {
 
   private planInternalProtocolClose(
     data: InternalProtocolCloseData,
-    state: RouteTable
+    state: RouteTable,
+    timestamp: number
   ): PlanResult {
     const idx = state.internal.peers.findIndex((p) => p.name === data.peerInfo.name)
     if (idx === -1) return noChange(state)
@@ -490,7 +510,14 @@ export class RoutingInformationBase {
     }
 
     const peers = state.internal.peers.map((p, i) =>
-      i === idx ? { ...p, connectionStatus: 'closed' as const } : p
+      i === idx
+        ? {
+            ...p,
+            connectionStatus: 'closed' as const,
+            consecutiveFailures: (p.consecutiveFailures ?? 0) + 1,
+            lastFailure: timestamp,
+          }
+        : p
     )
     const newState: RouteTable = {
       ...state,
@@ -717,9 +744,24 @@ export class RoutingInformationBase {
       }
     }
 
+    // --- Session flap stability reset ---
+    let sessionFlapReset = false
+    const peersAfterStabilityReset = state.internal.peers.map((p) => {
+      if (
+        p.connectionStatus === 'connected' &&
+        (p.consecutiveFailures ?? 0) > 0 &&
+        p.lastReceived > 0 &&
+        data.now - p.lastReceived > SESSION_FLAP_STABILITY_MS
+      ) {
+        sessionFlapReset = true
+        return { ...p, consecutiveFailures: 0, lastFailure: 0, syncDeferredUntil: 0 }
+      }
+      return p
+    })
+
     // Find connected peers whose hold timer has expired
     const expiredPeerNames = new Set<string>()
-    const peers = state.internal.peers.map((p) => {
+    const peers = peersAfterStabilityReset.map((p) => {
       const timerActive = p.connectionStatus === 'connected' && p.holdTime > 0 && p.lastReceived > 0
       if (timerActive && data.now - p.lastReceived > p.holdTime) {
         expiredPeerNames.add(p.name)
@@ -747,10 +789,14 @@ export class RoutingInformationBase {
     }
 
     const purgedPeerNames = new Set([...expiredPeerNames, ...stalePeerNames])
-    if (purgedPeerNames.size === 0 && !flapStateChanged) return noChange(state)
+    const anyEphemeralChange = flapStateChanged || sessionFlapReset
+    if (purgedPeerNames.size === 0 && !anyEphemeralChange) return noChange(state)
 
-    if (purgedPeerNames.size === 0 && flapStateChanged) {
-      const newState: RouteTable = { ...state }
+    if (purgedPeerNames.size === 0 && anyEphemeralChange) {
+      const newState: RouteTable = {
+        ...state,
+        internal: { ...state.internal, peers },
+      }
       return {
         prevState: state,
         newState,

--- a/packages/routing/src/v2/rib/rib.ts
+++ b/packages/routing/src/v2/rib/rib.ts
@@ -747,14 +747,27 @@ export class RoutingInformationBase {
     // --- Session flap stability reset ---
     let sessionFlapReset = false
     const peersAfterStabilityReset = state.internal.peers.map((p) => {
+      // Use lastConnected (set once at session establishment) rather than
+      // lastReceived (refreshed on every keepalive) so the stability window
+      // measures actual session uptime.
       if (
         p.connectionStatus === 'connected' &&
         (p.consecutiveFailures ?? 0) > 0 &&
-        p.lastReceived > 0 &&
-        data.now - p.lastReceived > SESSION_FLAP_STABILITY_MS
+        p.lastConnected > 0 &&
+        data.now - p.lastConnected > SESSION_FLAP_STABILITY_MS
       ) {
         sessionFlapReset = true
         return { ...p, consecutiveFailures: 0, lastFailure: 0, syncDeferredUntil: 0 }
+      }
+      // Deferred sync retry: clear deferral for connected peers whose
+      // backoff window has expired, so post-commit can trigger the sync.
+      if (
+        p.syncDeferredUntil > 0 &&
+        p.connectionStatus === 'connected' &&
+        data.now >= p.syncDeferredUntil
+      ) {
+        sessionFlapReset = true
+        return { ...p, syncDeferredUntil: 0 }
       }
       return p
     })

--- a/packages/routing/src/v2/state.ts
+++ b/packages/routing/src/v2/state.ts
@@ -15,6 +15,9 @@ export const PeerRecordSchema = PeerInfoSchema.extend({
   lastSent: z.number().default(0),
   lastReceived: z.number().default(0),
   maxPrefixes: z.number().int().min(0).optional(),
+  consecutiveFailures: z.number().int().min(0).default(0),
+  lastFailure: z.number().default(0),
+  syncDeferredUntil: z.number().default(0),
 })
 export type PeerRecord = z.infer<typeof PeerRecordSchema>
 


### PR DESCRIPTION
## From [#408](https://github.com/orbisoperations/catalyst-router/issues/408): add peer session flap detection

> Track rapid connect/disconnect cycles at the session level. If a peer disconnects and reconnects repeatedly, defer full route sync with exponential backoff.
>
> **Why It Matters:** A peer with an unstable network connection causes repeated full sync operations across the mesh. Every reconnect triggers full route propagation to all peers.

Stacked on [#654](https://github.com/orbisoperations/catalyst-router/pull/654) (graceful shutdown). Based on [RFC 4271 §8](https://www.rfc-editor.org/rfc/rfc4271.html#section-8) `DampPeerOscillations` and [BIRD's error-wait model](https://bird.network.cz/doc/bird-6.html).

## Implementation

Follows the standard approach across all major BGP implementations: **exponential backoff on reconnect**, not a penalty-counter system. [BIRD](https://bird.network.cz/doc/bird-6.html) uses `error wait time` (60s→300s) with `error forget time` (300s). We use the same model with smaller base delay (5s) for faster recovery in small meshes.

Parameters:
- Base delay: 5 seconds
- Max delay: 5 minutes (same as [BIRD](https://bird.network.cz/doc/bird-6.html))
- Stability reset: 5 minutes connected = counter resets (same as BIRD's `error forget time`)

## Changes

- `consecutiveFailures`, `lastFailure`, `syncDeferredUntil` fields on `PeerRecord`
- `planInternalProtocolClose`: increments failure counter
- `planInternalProtocolConnected`: calculates deferred sync time (`5s * 2^(n-1)`, capped at 5m)
- `planTick`: resets counter after 5 minutes of stability
- Bus: defers initial sync when `syncDeferredUntil > now`, logs warning
- 5 unit tests

## How it was tested

**Unit tests** (5):
- First disconnect sets `consecutiveFailures` to 1
- Third consecutive reconnect defers sync by 20s (`5000 * 2^2`)
- Delay capped at 5 minutes after 20 failures
- Tick resets counter after 5 minutes of stability
- Non-flapping peer gets immediate sync (`syncDeferredUntil = 0`)

Run: `pnpm vitest run apps/orchestrator/tests/v2/session-flap.test.ts`