### PR TITLE
feat(routing): add End-of-RIB marker to purge stale routes after reconnect

### DIFF
--- a/apps/orchestrator/src/v2/bus.ts
+++ b/apps/orchestrator/src/v2/bus.ts
@@ -347,6 +347,16 @@ export class OrchestratorBus {
             })
             await this.syncRoutesToPeer(peer, state)
           })
+
+          // After the initial sync completes, dispatch End-of-RIB to purge any
+          // remaining stale routes from this peer that were not refreshed.
+          // Scheduled (not awaited) because the ActionQueue would deadlock if we
+          // awaited a nested dispatch from within an in-flight dispatch.
+          const eorAction: Action = {
+            action: Actions.InternalProtocolEndOfRib,
+            data: { peerInfo: action.data.peerInfo },
+          }
+          void this.dispatch(eorAction)
         }
       }
       return

--- a/apps/orchestrator/tests/v2/graceful-restart.topology.test.ts
+++ b/apps/orchestrator/tests/v2/graceful-restart.topology.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { OrchestratorBus } from '../../src/v2/bus.js'
 import { MockPeerTransport } from '../../src/v2/transport.js'
 import { Actions, CloseCodes } from '@catalyst/routing/v2'
+import type { Action } from '@catalyst/routing/v2'
 import type { OrchestratorConfig } from '../../src/v1/types.js'
 import type { PeerInfo } from '@catalyst/routing/v2'
 
@@ -460,5 +461,271 @@ describe('Graceful restart: partial refresh — only re-advertised routes surviv
     // Both stale routes from the closed peer are purged
     expect(bus.state.internal.routes.find((r) => r.name === 'service-y')).toBeUndefined()
     expect(bus.state.internal.routes.find((r) => r.name === 'service-x')).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: End-of-RIB purges remaining stale routes
+// ---------------------------------------------------------------------------
+
+describe('Graceful restart: End-of-RIB purges remaining stale routes', () => {
+  const routeY = { name: 'service-y', protocol: 'http' as const, endpoint: 'http://svc-y:8080' }
+  let transport: MockPeerTransport
+  let bus: OrchestratorBus
+
+  beforeEach(async () => {
+    transport = new MockPeerTransport()
+    bus = new OrchestratorBus({ config: makeConfig('node-a'), transport })
+  })
+
+  it('EoR purges remaining stale routes from reconnected peer', async () => {
+    const peerB = makePeer('node-b')
+    await connectPeer(bus, peerB)
+
+    // B advertises route-x and route-y
+    await bus.dispatch({
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [
+            { action: 'add', route: routeX, nodePath: ['node-b'], originNode: 'node-b' },
+            { action: 'add', route: routeY, nodePath: ['node-b'], originNode: 'node-b' },
+          ],
+        },
+      },
+    })
+
+    expect(bus.state.internal.routes).toHaveLength(2)
+
+    // Transport error — both routes go stale
+    await bus.dispatch({
+      action: Actions.InternalProtocolClose,
+      data: { peerInfo: peerB, code: CloseCodes.TRANSPORT_ERROR },
+    })
+
+    expect(bus.state.internal.routes.every((r) => r.isStale === true)).toBe(true)
+
+    // B reconnects
+    await bus.dispatch({ action: Actions.LocalPeerCreate, data: peerB })
+    await bus.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: peerB },
+    })
+
+    // B re-advertises ONLY route-x (route-y is gone from B)
+    await bus.dispatch({
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [{ action: 'add', route: routeX, nodePath: ['node-b'], originNode: 'node-b' }],
+        },
+      },
+    })
+
+    // route-x refreshed, route-y still stale
+    expect(bus.state.internal.routes.find((r) => r.name === 'service-x')?.isStale).toBe(false)
+    expect(bus.state.internal.routes.find((r) => r.name === 'service-y')?.isStale).toBe(true)
+
+    // Dispatch End-of-RIB for B
+    const eorAction: Action = {
+      action: Actions.InternalProtocolEndOfRib,
+      data: { peerInfo: peerB },
+    }
+    await bus.dispatch(eorAction)
+
+    // route-x exists (fresh), route-y is purged
+    expect(bus.state.internal.routes.find((r) => r.name === 'service-x')).toBeDefined()
+    expect(bus.state.internal.routes.find((r) => r.name === 'service-x')?.isStale).toBe(false)
+    expect(bus.state.internal.routes.find((r) => r.name === 'service-y')).toBeUndefined()
+  })
+
+  it('EoR with no stale routes is a no-op', async () => {
+    const peerB = makePeer('node-b')
+    await connectPeer(bus, peerB)
+
+    // B advertises route-x (fresh, no stale routes)
+    await bus.dispatch({
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [{ action: 'add', route: routeX, nodePath: ['node-b'], originNode: 'node-b' }],
+        },
+      },
+    })
+
+    const routeBefore = bus.state.internal.routes.find((r) => r.name === 'service-x')
+    expect(routeBefore?.isStale).toBe(false)
+
+    // Dispatch End-of-RIB — nothing stale, should be no-op
+    const eorAction: Action = {
+      action: Actions.InternalProtocolEndOfRib,
+      data: { peerInfo: peerB },
+    }
+    const result = await bus.dispatch(eorAction)
+
+    // No state change
+    expect(result.success).toBe(false)
+    // Route still exists unchanged
+    expect(bus.state.internal.routes.find((r) => r.name === 'service-x')).toBeDefined()
+  })
+
+  it('EoR withdrawal is propagated to other connected peers', async () => {
+    const peerB = makePeer('node-b')
+    const peerC = makePeer('node-c')
+    await connectPeer(bus, peerB)
+    await connectPeer(bus, peerC)
+
+    // B advertises route-x and route-y
+    await bus.dispatch({
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [
+            { action: 'add', route: routeX, nodePath: ['node-b'], originNode: 'node-b' },
+            { action: 'add', route: routeY, nodePath: ['node-b'], originNode: 'node-b' },
+          ],
+        },
+      },
+    })
+
+    // Transport error on B
+    await bus.dispatch({
+      action: Actions.InternalProtocolClose,
+      data: { peerInfo: peerB, code: CloseCodes.TRANSPORT_ERROR },
+    })
+
+    // B reconnects, re-advertises only route-x
+    await bus.dispatch({ action: Actions.LocalPeerCreate, data: peerB })
+    await bus.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: peerB },
+    })
+    await bus.dispatch({
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [{ action: 'add', route: routeX, nodePath: ['node-b'], originNode: 'node-b' }],
+        },
+      },
+    })
+
+    transport.reset()
+
+    // Dispatch End-of-RIB for B — route-y should be purged and withdrawal sent to C
+    const eorAction: Action = {
+      action: Actions.InternalProtocolEndOfRib,
+      data: { peerInfo: peerB },
+    }
+    await bus.dispatch(eorAction)
+
+    // Withdrawal of route-y must have been sent to node-c
+    const updateCalls = transport
+      .getCallsFor('sendUpdate')
+      .filter((c) => c.method === 'sendUpdate' && c.peer.name === 'node-c')
+    const removals = updateCalls.flatMap((c) =>
+      c.method === 'sendUpdate'
+        ? c.message.updates.filter((u) => u.action === 'remove' && u.route.name === 'service-y')
+        : []
+    )
+    expect(removals.length).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: InternalProtocolConnected auto-dispatches EoR after sync
+// ---------------------------------------------------------------------------
+
+describe('Graceful restart: InternalProtocolConnected auto-dispatches EoR', () => {
+  const routeY = { name: 'service-y', protocol: 'http' as const, endpoint: 'http://svc-y:8080' }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reconnect auto-purges stale routes that were not re-advertised during sync', async () => {
+    const BASE_NOW = 1_700_000_000_000
+    vi.spyOn(Date, 'now').mockReturnValue(BASE_NOW)
+
+    const transport = new MockPeerTransport()
+    const busA = new OrchestratorBus({ config: makeConfig('node-a'), transport })
+    const peerB = makePeer('node-b')
+
+    // Connect B, B advertises route-x and route-y
+    await connectPeer(busA, peerB)
+    await busA.dispatch({
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [
+            { action: 'add', route: routeX, nodePath: ['node-b'], originNode: 'node-b' },
+            { action: 'add', route: routeY, nodePath: ['node-b'], originNode: 'node-b' },
+          ],
+        },
+      },
+    })
+
+    expect(busA.state.internal.routes).toHaveLength(2)
+
+    // B disconnects with transport error (consecutiveFailures becomes 1)
+    await busA.dispatch({
+      action: Actions.InternalProtocolClose,
+      data: { peerInfo: peerB, code: CloseCodes.TRANSPORT_ERROR },
+    })
+    expect(busA.state.internal.routes.every((r) => r.isStale === true)).toBe(true)
+
+    // B reconnects — advance time far enough for B's refresh before
+    // InternalProtocolConnected, then use an incrementing clock so that
+    // by the time handleBGPNotify checks syncDeferredUntil, Date.now()
+    // has advanced past it. planInternalProtocolConnected computes
+    // syncDeferredUntil = now + 5000 (base delay for 1 failure), so we
+    // need Date.now() to return > T+5000 during the post-commit phase.
+    const reconnectTime = BASE_NOW + 10_000
+    vi.spyOn(Date, 'now').mockReturnValue(reconnectTime)
+
+    await busA.dispatch({ action: Actions.LocalPeerCreate, data: peerB })
+
+    // B sends its refreshed route before InternalProtocolConnected
+    await busA.dispatch({
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [{ action: 'add', route: routeX, nodePath: ['node-b'], originNode: 'node-b' }],
+        },
+      },
+    })
+
+    // Use an incrementing clock: the plan phase of InternalProtocolConnected
+    // uses Date.now() once to set syncDeferredUntil = T + 5000. The post-commit
+    // handleBGPNotify also calls Date.now() once to check the deferral. By
+    // returning a later time on the second call, the sync proceeds and EoR fires.
+    let callCount = 0
+    vi.spyOn(Date, 'now').mockImplementation(() => {
+      callCount++
+      // Call 1 (plan phase): sets syncDeferredUntil = reconnectTime + 5000
+      // Call 2+ (post-commit): returns past syncDeferredUntil so sync fires
+      return callCount <= 1 ? reconnectTime : reconnectTime + 10_000
+    })
+
+    // InternalProtocolConnected triggers auto-EoR dispatch (queued, not awaited).
+    await busA.dispatch({
+      action: Actions.InternalProtocolConnected,
+      data: { peerInfo: peerB },
+    })
+
+    // Allow the queued EoR dispatch to execute (it runs on the next microtask
+    // after the ActionQueue drains the InternalProtocolConnected dispatch)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // route-x should be fresh, route-y should be purged by auto-EoR
+    expect(busA.state.internal.routes.find((r) => r.name === 'service-x')).toBeDefined()
+    expect(busA.state.internal.routes.find((r) => r.name === 'service-x')?.isStale).toBe(false)
+    expect(busA.state.internal.routes.find((r) => r.name === 'service-y')).toBeUndefined()
   })
 })

--- a/packages/routing/src/v2/action-types.ts
+++ b/packages/routing/src/v2/action-types.ts
@@ -19,6 +19,7 @@ export const Actions = {
   InternalProtocolConnected: 'internal:protocol:connected',
   InternalProtocolUpdate: 'internal:protocol:update',
   InternalProtocolKeepalive: 'internal:protocol:keepalive',
+  InternalProtocolEndOfRib: 'internal:protocol:end-of-rib',
 
   // System
   Tick: 'system:tick',

--- a/packages/routing/src/v2/internal/actions.ts
+++ b/packages/routing/src/v2/internal/actions.ts
@@ -78,3 +78,10 @@ export const InternalProtocolKeepaliveMessageSchema = z.object({
     peerInfo: PeerInfoSchema,
   }),
 })
+
+export const InternalProtocolEndOfRibMessageSchema = z.object({
+  action: z.literal(Actions.InternalProtocolEndOfRib),
+  data: z.object({
+    peerInfo: PeerInfoSchema,
+  }),
+})

--- a/packages/routing/src/v2/rib/rib.ts
+++ b/packages/routing/src/v2/rib/rib.ts
@@ -43,6 +43,10 @@ type InternalProtocolKeepaliveData = Extract<
   Action,
   { action: typeof Actions.InternalProtocolKeepalive }
 >['data']
+type InternalProtocolEndOfRibData = Extract<
+  Action,
+  { action: typeof Actions.InternalProtocolEndOfRib }
+>['data']
 type TickData = Extract<Action, { action: typeof Actions.Tick }>['data']
 type AdminGracefulShutdownData = Extract<
   Action,
@@ -178,6 +182,8 @@ export class RoutingInformationBase {
         return this.planInternalProtocolUpdate(action.data, state, timestamp)
       case Actions.InternalProtocolKeepalive:
         return this.planInternalProtocolKeepalive(action.data, state, timestamp)
+      case Actions.InternalProtocolEndOfRib:
+        return this.planInternalProtocolEndOfRib(action.data, state)
       case Actions.Tick:
         return this.planTick(action.data, state)
       case Actions.AdminGracefulShutdown:
@@ -705,6 +711,40 @@ export class RoutingInformationBase {
       routeChanges: NO_ROUTE_CHANGES,
       flapStateChanges: NO_FLAP_CHANGES,
     }
+  }
+
+  private planInternalProtocolEndOfRib(
+    data: InternalProtocolEndOfRibData,
+    state: RouteTable
+  ): PlanResult {
+    // Purge any remaining stale routes from this peer.
+    // After the peer finishes its initial sync, routes still marked stale
+    // were not re-advertised and should be withdrawn immediately rather than
+    // waiting for the full holdTime grace period.
+    const peerName = data.peerInfo.name
+    const staleRoutes = state.internal.routes.filter(
+      (r) => r.peer.name === peerName && r.isStale === true
+    )
+    if (staleRoutes.length === 0) return noChange(state)
+
+    const routes = state.internal.routes.filter(
+      (r) => !(r.peer.name === peerName && r.isStale === true)
+    )
+
+    const portOps: PortOperation[] = staleRoutes
+      .filter((r) => r.envoyPort != null)
+      .map((r) => ({ type: 'release' as const, routeKey: routeKey(r), port: r.envoyPort! }))
+
+    const routeChanges: RouteChange[] = staleRoutes.map((r) => ({
+      type: 'removed' as const,
+      route: r,
+    }))
+
+    const newState: RouteTable = {
+      ...state,
+      internal: { ...state.internal, routes },
+    }
+    return { prevState: state, newState, portOps, routeChanges, flapStateChanges: NO_FLAP_CHANGES }
   }
 
   // -------------------------------------------------------------------------

--- a/packages/routing/src/v2/rib/rib.ts
+++ b/packages/routing/src/v2/rib/rib.ts
@@ -103,6 +103,20 @@ function noChange(state: RouteTable): PlanResult {
   }
 }
 
+function buildRemovalOps(routes: InternalRoute[]): {
+  portOps: PortOperation[]
+  routeChanges: RouteChange[]
+} {
+  const portOps: PortOperation[] = routes
+    .filter((r) => r.envoyPort != null)
+    .map((r) => ({ type: 'release' as const, routeKey: routeKey(r), port: r.envoyPort! }))
+  const routeChanges: RouteChange[] = routes.map((r) => ({
+    type: 'removed' as const,
+    route: r,
+  }))
+  return { portOps, routeChanges }
+}
+
 // ---------------------------------------------------------------------------
 // RoutingInformationBase
 // ---------------------------------------------------------------------------
@@ -300,15 +314,7 @@ export class RoutingInformationBase {
 
     const removedRoutes = state.internal.routes.filter((r) => r.peer.name === data.name)
     const routes = state.internal.routes.filter((r) => r.peer.name !== data.name)
-
-    const portOps: PortOperation[] = removedRoutes
-      .filter((r) => r.envoyPort != null)
-      .map((r) => ({ type: 'release' as const, routeKey: routeKey(r), port: r.envoyPort! }))
-
-    const routeChanges: RouteChange[] = removedRoutes.map((r) => ({
-      type: 'removed' as const,
-      route: r,
-    }))
+    const { portOps, routeChanges } = buildRemovalOps(removedRoutes)
 
     const newState: RouteTable = {
       ...state,
@@ -509,10 +515,7 @@ export class RoutingInformationBase {
       // Hard close (normal, hold-expired, admin-shutdown, protocol-error):
       // withdraw routes and release any allocated envoy ports.
       routes = state.internal.routes.filter((r) => r.peer.name !== data.peerInfo.name)
-      routeChanges = peerRoutes.map((r) => ({ type: 'removed' as const, route: r }))
-      portOps = peerRoutes
-        .filter((r) => r.envoyPort != null)
-        .map((r) => ({ type: 'release' as const, routeKey: routeKey(r), port: r.envoyPort! }))
+      ;({ portOps, routeChanges } = buildRemovalOps(peerRoutes))
     }
 
     const peers = state.internal.peers.map((p, i) =>
@@ -731,14 +734,7 @@ export class RoutingInformationBase {
       (r) => !(r.peer.name === peerName && r.isStale === true)
     )
 
-    const portOps: PortOperation[] = staleRoutes
-      .filter((r) => r.envoyPort != null)
-      .map((r) => ({ type: 'release' as const, routeKey: routeKey(r), port: r.envoyPort! }))
-
-    const routeChanges: RouteChange[] = staleRoutes.map((r) => ({
-      type: 'removed' as const,
-      route: r,
-    }))
+    const { portOps, routeChanges } = buildRemovalOps(staleRoutes)
 
     const newState: RouteTable = {
       ...state,
@@ -861,15 +857,7 @@ export class RoutingInformationBase {
 
     const removedRoutes = state.internal.routes.filter((r) => purgedPeerNames.has(r.peer.name))
     const routes = state.internal.routes.filter((r) => !purgedPeerNames.has(r.peer.name))
-
-    const portOps: PortOperation[] = removedRoutes
-      .filter((r) => r.envoyPort != null)
-      .map((r) => ({ type: 'release' as const, routeKey: routeKey(r), port: r.envoyPort! }))
-
-    const routeChanges: RouteChange[] = removedRoutes.map((r) => ({
-      type: 'removed' as const,
-      route: r,
-    }))
+    const { portOps, routeChanges } = buildRemovalOps(removedRoutes)
 
     const newState: RouteTable = {
       ...state,

--- a/packages/routing/src/v2/schema.ts
+++ b/packages/routing/src/v2/schema.ts
@@ -13,6 +13,7 @@ import {
   InternalProtocolCloseMessageSchema,
   InternalProtocolConnectedMessageSchema,
   InternalProtocolKeepaliveMessageSchema,
+  InternalProtocolEndOfRibMessageSchema,
 } from './internal/actions.js'
 import {
   TickMessageSchema,
@@ -36,6 +37,7 @@ export const ActionSchema = z.discriminatedUnion('action', [
   InternalProtocolCloseMessageSchema,
   InternalProtocolConnectedMessageSchema,
   InternalProtocolKeepaliveMessageSchema,
+  InternalProtocolEndOfRibMessageSchema,
   TickMessageSchema,
   AdminGracefulShutdownMessageSchema,
   AdminCancelShutdownMessageSchema,


### PR DESCRIPTION
## From [#406](https://github.com/orbisoperations/catalyst-router/issues/406): add end-of-RIB marker and convergence delay

> When a peer connects, it sends its routing table followed by an End-of-RIB marker. This signals that initial sync is complete.

This PR implements the **stale route purge** part of EoR: after a peer reconnects and re-advertises its routes, any remaining stale routes from that peer are immediately purged instead of waiting for the full holdTime grace period (90s → near-instant).

The **defer propagation during loading** part (batching initial sync, per [FRR's `update-delay`](https://docs.frrouting.org/en/latest/bgp.html) and [BIRD's `BFS_LOADING` state](https://bird.network.cz/doc/bird-6.html)) is a separate optimization deferred for a future PR.

Stacked on [#656](https://github.com/orbisoperations/catalyst-router/pull/656) (graceful restart gap tests).

## References

- [RFC 4724 §2](https://www.rfc-editor.org/rfc/rfc4724#section-2) — defines End-of-RIB as an empty UPDATE message; receiver uses it to know peer has finished re-advertising routes after restart, so unrefreshed stale routes can be purged
- [BIRD graceful restart](https://bird.network.cz/doc/bird-6.html) — defers propagation until EoR (deferred to future PR)
- [FRR `bgp_update_delay`](https://docs.frrouting.org/en/latest/bgp.html) — batches updates until EoR (deferred to future PR)

## Changes

- `InternalProtocolEndOfRib` action type + schema
- RIB handler: purges remaining stale routes from the peer, releases ports, emits withdrawals
- Bus: auto-dispatches EoR after `syncRoutesToPeer` completes on `InternalProtocolConnected`
- 4 new tests

## How it was tested

**Unit tests** (3):
- EoR purges remaining stale routes, keeps refreshed ones
- EoR with no stale routes is a no-op
- EoR withdrawal propagated to other connected peers

**Integration test** (1):
- Full reconnect lifecycle: B disconnects (TRANSPORT_ERROR) → routes go stale at A → B reconnects → B re-syncs routes → auto-EoR fires → A purges routes B didn't re-advertise

Run: `pnpm vitest run apps/orchestrator/tests/v2/graceful-restart.topology.test.ts`