### PR TITLE
fix(routing): enforce-first-as validation on nodePath and originNode

### DIFF
--- a/apps/orchestrator/tests/v2/origin-validation.test.ts
+++ b/apps/orchestrator/tests/v2/origin-validation.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest'
+import { RoutingInformationBase, Actions, newRouteTable } from '@catalyst/routing/v2'
+import type { RouteTable, PeerRecord, PeerInfo, Action } from '@catalyst/routing/v2'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const nodeId = 'node-a'
+const peerB: PeerInfo = { name: 'node-b', endpoint: 'ws://b:4000', domains: ['test.local'] }
+
+function makeRoute(name: string) {
+  return { name, protocol: 'http' as const, endpoint: `http://${name}:8080` }
+}
+
+function stateWithPeer(): RouteTable {
+  const state = newRouteTable()
+  const peer: PeerRecord = {
+    ...peerB,
+    connectionStatus: 'connected',
+    lastConnected: 1000,
+    holdTime: 90_000,
+    lastSent: 0,
+    lastReceived: 1000,
+    consecutiveFailures: 0,
+    lastFailure: 0,
+    syncDeferredUntil: 0,
+  }
+  state.internal.peers = [peer]
+  return state
+}
+
+const NOW = 5000
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('enforce-first-as origin validation (RFC 4271 §6.3)', () => {
+  it('accepts valid single-hop route where nodePath[0] and originNode match peer', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = stateWithPeer()
+
+    const action: Action = {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [
+            {
+              action: 'add' as const,
+              route: makeRoute('svc-1'),
+              nodePath: ['node-b'],
+              originNode: 'node-b',
+            },
+          ],
+        },
+      },
+    }
+
+    const plan = rib.plan(action, state, NOW)
+
+    expect(plan.routeChanges).toHaveLength(1)
+    expect(plan.routeChanges[0].type).toBe('added')
+    expect(plan.newState.internal.routes).toHaveLength(1)
+  })
+
+  it('discards route when nodePath[0] does not match peer', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = stateWithPeer()
+
+    const action: Action = {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [
+            {
+              action: 'add' as const,
+              route: makeRoute('svc-1'),
+              // nodePath[0] is "node-c", but peer is "node-b" — spoofed first hop
+              nodePath: ['node-c', 'node-b'],
+              originNode: 'node-c',
+            },
+          ],
+        },
+      },
+    }
+
+    const plan = rib.plan(action, state, NOW)
+
+    expect(plan.routeChanges).toHaveLength(0)
+    expect(plan.newState.internal.routes).toHaveLength(0)
+  })
+
+  it('discards single-hop route when originNode does not match peer', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = stateWithPeer()
+
+    const action: Action = {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [
+            {
+              action: 'add' as const,
+              route: makeRoute('svc-1'),
+              // nodePath[0] matches peer, but originNode claims to be someone else
+              nodePath: ['node-b'],
+              originNode: 'node-c',
+            },
+          ],
+        },
+      },
+    }
+
+    const plan = rib.plan(action, state, NOW)
+
+    expect(plan.routeChanges).toHaveLength(0)
+    expect(plan.newState.internal.routes).toHaveLength(0)
+  })
+
+  it('accepts valid multi-hop route where nodePath[0] matches peer and originNode differs', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = stateWithPeer()
+
+    const action: Action = {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [
+            {
+              action: 'add' as const,
+              route: makeRoute('svc-1'),
+              // node-b forwarding a route that originated at node-c
+              nodePath: ['node-b', 'node-c'],
+              originNode: 'node-c',
+            },
+          ],
+        },
+      },
+    }
+
+    const plan = rib.plan(action, state, NOW)
+
+    expect(plan.routeChanges).toHaveLength(1)
+    expect(plan.routeChanges[0].type).toBe('added')
+    expect(plan.newState.internal.routes).toHaveLength(1)
+    expect(plan.newState.internal.routes[0].originNode).toBe('node-c')
+  })
+
+  it('discards withdrawal when nodePath[0] does not match peer', () => {
+    const rib = new RoutingInformationBase({ nodeId })
+    const state = stateWithPeer()
+
+    // First, install a valid route from node-b
+    const addAction: Action = {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [
+            {
+              action: 'add' as const,
+              route: makeRoute('svc-1'),
+              nodePath: ['node-b'],
+              originNode: 'node-b',
+            },
+          ],
+        },
+      },
+    }
+    const addPlan = rib.plan(addAction, state, NOW)
+    rib.commit(addPlan, addAction)
+
+    expect(rib.state.internal.routes).toHaveLength(1)
+
+    // Now attempt a spoofed withdrawal where nodePath[0] != peer
+    const removeAction: Action = {
+      action: Actions.InternalProtocolUpdate,
+      data: {
+        peerInfo: peerB,
+        update: {
+          updates: [
+            {
+              action: 'remove' as const,
+              route: makeRoute('svc-1'),
+              // Spoofed: nodePath[0] claims to be node-c, but sender is node-b
+              nodePath: ['node-c'],
+              originNode: 'node-c',
+            },
+          ],
+        },
+      },
+    }
+
+    const removePlan = rib.plan(removeAction, rib.state, NOW)
+
+    // Route should still be present — spoofed withdrawal was discarded
+    expect(removePlan.routeChanges).toHaveLength(0)
+    expect(removePlan.newState.internal.routes).toHaveLength(1)
+  })
+})

--- a/packages/routing/src/v2/rib/rib.ts
+++ b/packages/routing/src/v2/rib/rib.ts
@@ -563,6 +563,11 @@ export class RoutingInformationBase {
       : 0
 
     for (const item of data.update.updates) {
+      // --- enforce-first-as: nodePath[0] must match authenticated peer (RFC 4271 §6.3) ---
+      if (item.nodePath[0] !== data.peerInfo.name) continue
+      // For single-hop routes, originNode must also match the direct sender
+      if (item.nodePath.length === 1 && item.originNode !== data.peerInfo.name) continue
+
       if (item.action === 'add') {
         // Loop detection — discard advertisements that already include this node
         if (item.nodePath.includes(this._nodeId)) continue

--- a/packages/routing/tests/v2/rib/rib.test.ts
+++ b/packages/routing/tests/v2/rib/rib.test.ts
@@ -330,7 +330,7 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
     const plan = apply(
       rib,
       makeProtocolUpdate(peer, [
-        { action: 'add', route, nodePath: ['node-a', 'peer-b'], originNode: 'peer-b' },
+        { action: 'add', route, nodePath: ['peer-b', 'node-a'], originNode: 'peer-b' },
       ])
     )
 
@@ -409,26 +409,26 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
     const { rib, peer } = ribWithConnectedPeer('node-a', 'peer-b')
     const route = makeRoute('svc-1')
 
-    // First: longer path (2 hops)
+    // First: longer path (3 hops)
     apply(
       rib,
       makeProtocolUpdate(peer, [
-        { action: 'add', route, nodePath: ['peer-c', 'peer-b'], originNode: 'peer-c' },
+        { action: 'add', route, nodePath: ['peer-b', 'peer-c', 'peer-d'], originNode: 'peer-b' },
       ])
     )
     const first = rib.state.internal.routes.find((r) => r.name === 'svc-1')
-    expect(first!.nodePath).toHaveLength(2)
+    expect(first!.nodePath).toHaveLength(3)
 
-    // Second: shorter path (1 hop) — should replace
+    // Second: shorter path (2 hops) — should replace
     const plan = apply(
       rib,
       makeProtocolUpdate(peer, [
-        { action: 'add', route, nodePath: ['peer-b'], originNode: 'peer-c' },
+        { action: 'add', route, nodePath: ['peer-b', 'peer-c'], originNode: 'peer-b' },
       ])
     )
 
     const updated = rib.state.internal.routes.find((r) => r.name === 'svc-1')
-    expect(updated!.nodePath).toHaveLength(1)
+    expect(updated!.nodePath).toHaveLength(2)
     expect(plan.routeChanges.some((c) => c.type === 'updated')).toBe(true)
   })
 
@@ -448,7 +448,7 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
     const plan = apply(
       rib,
       makeProtocolUpdate(peer, [
-        { action: 'add', route, nodePath: ['peer-c', 'peer-b'], originNode: 'peer-b' },
+        { action: 'add', route, nodePath: ['peer-b', 'peer-c'], originNode: 'peer-b' },
       ])
     )
 
@@ -532,7 +532,7 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
       {
         action: 'add' as const,
         route: makeRoute('looped'),
-        nodePath: ['node-a', 'peer-b'],
+        nodePath: ['peer-b', 'node-a'],
         originNode: 'peer-b',
       },
       {
@@ -569,7 +569,7 @@ describe('BGP propagation via InternalProtocolUpdate', () => {
     const plan = apply(
       rib,
       makeProtocolUpdate(peer, [
-        { action: 'add', route, nodePath: ['peer-c', 'peer-b'], originNode: 'peer-b' },
+        { action: 'add', route, nodePath: ['peer-b', 'peer-c'], originNode: 'peer-b' },
       ])
     )
 


### PR DESCRIPTION
## From [#486](https://github.com/orbisoperations/catalyst-router/issues/486): originNode not bound to authenticated peer identity

> In the v2 routing system, `originNode` and `nodePath` fields in `InternalProtocolUpdate` messages are fully attacker-controlled. A compromised or malicious peer can set `originNode` to an arbitrary node ID and advertise routes it does not own.
>
> **Severity:** HIGH — blocks production deployment of v2 routing over untrusted networks.

Stacked on [#657](https://github.com/orbisoperations/catalyst-router/pull/657) (End-of-RIB).

## Implementation

Adds the BGP `enforce-first-as` equivalent, which is the industry-standard first line of defense against route origin spoofing. Enabled by default in [Cisco IOS](https://www.cisco.com/c/en/us/td/docs/routers/ios/config/17-x/ip-routing/b-ip-routing/m_irg-bgp-neighbor.html) and [FRR](https://docs.frrouting.org/en/latest/bgp.html) (since Oct 2023). Explicitly permitted by [RFC 4271 §6.3](https://www.rfc-editor.org/rfc/rfc4271.html#section-6.3).

Two checks on every update item (both add and remove), before any other processing:

1. **`nodePath[0]` must match `peerInfo.name`** — the authenticated sender must be the first hop
2. **For single-hop routes, `originNode` must also match `peerInfo.name`** — if claiming to originate, must be the direct sender

Invalid items are silently discarded (session stays alive). Same behavior as Cisco/FRR.

## How it was tested

**Unit tests** (5):
- Valid single-hop: accepted
- Invalid `nodePath[0]` mismatch: silently discarded
- Invalid single-hop with `originNode != peer`: silently discarded
- Valid multi-hop with different `originNode`: accepted (peer forwarding route from another node)
- Spoofed withdrawal with mismatched `nodePath[0]`: silently discarded

Also fixed 4 pre-existing test fixtures that had technically invalid `nodePath[0]` values (the new validation correctly rejects them).

Run: `pnpm vitest run apps/orchestrator/tests/v2/origin-validation.test.ts`

## References

- [RFC 4271 §6.3](https://www.rfc-editor.org/rfc/rfc4271.html#section-6.3) — `MAY check whether the leftmost AS in AS_PATH equals the neighbor's AS`
- [RFC 4271 §5.1.2](https://www.rfc-editor.org/rfc/rfc4271.html#section-5.1.2) — `SHALL prepend its own AS to AS_PATH` (mandatory for senders)
- [FRR enforce-first-as default change](https://github.com/FRRouting/frr/issues/14617)
- [NSA Guide to BGP Best Practices](https://www.nsa.gov/portals/75/documents/what-we-do/cybersecurity/professional-resources/ctr-guide-to-border-gateway-protocol-best-practices.pdf)